### PR TITLE
feat: add clear all sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Clear all sessions** — bulk-delete all chat sessions at once instead of removing them one by one.
+  - `DELETE /api/sessions` — new API endpoint; returns `{"deleted": <count>}`.
+  - **Web UI** — "Clear All" button (with browser confirmation dialog) on the Sessions page; only shown when sessions exist.
+  - **CLI** — `squire sessions clear` command with a `--yes/-y` flag to skip the confirmation prompt. The existing `squire sessions` command is now a sub-command group (`squire sessions list` / `squire sessions clear`).
+  - **TUI** — `Ctrl+X` binding opens a confirmation modal and deletes all sessions from the database.
+- `DatabaseService.delete_all_sessions()` — deletes all rows from `sessions` and `conversations`, returns the session count.
+
 ## [0.5.0] — 2026-03-18
 
 ### Added

--- a/src/squire/api/routers/sessions.py
+++ b/src/squire/api/routers/sessions.py
@@ -31,6 +31,13 @@ async def get_messages(
     return [MessageInfo(**r) for r in rows]
 
 
+@router.delete("")
+async def delete_all_sessions(db=Depends(get_db)):
+    """Delete all sessions and their messages."""
+    count = await db.delete_all_sessions()
+    return {"deleted": count}
+
+
 @router.delete("/{session_id}")
 async def delete_session(session_id: str, db=Depends(get_db)):
     """Delete a session and its messages."""

--- a/src/squire/cli.py
+++ b/src/squire/cli.py
@@ -27,8 +27,12 @@ def chat(
     run_chat(resume_session_id=resume)
 
 
-@app.command()
-def sessions() -> None:
+sessions_app = typer.Typer(name="sessions", help="Manage chat sessions.")
+app.add_typer(sessions_app)
+
+
+@sessions_app.command("list")
+def sessions_list() -> None:
     """List recent chat sessions."""
     from .main import list_sessions
 
@@ -55,6 +59,29 @@ def sessions() -> None:
         )
 
     console.print(table)
+
+
+@sessions_app.command("clear")
+def sessions_clear(
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+) -> None:
+    """Delete all chat sessions and their messages."""
+    from .config import DatabaseConfig
+    from .database.service import DatabaseService
+
+    if not yes and not typer.confirm("Delete ALL sessions and their messages? This cannot be undone."):
+        raise typer.Abort()
+
+    async def _run() -> int:
+        db_config = DatabaseConfig()
+        db = DatabaseService(db_config.path)
+        try:
+            return await db.delete_all_sessions()
+        finally:
+            await db.close()
+
+    count = asyncio.run(_run())
+    typer.echo(f"Deleted {count} session(s).")
 
 
 watch_app = typer.Typer(name="watch", help="Autonomous watch mode.", invoke_without_command=True)

--- a/src/squire/database/service.py
+++ b/src/squire/database/service.py
@@ -290,6 +290,17 @@ class DatabaseService:
         await conn.commit()
         return cursor.rowcount > 0
 
+    async def delete_all_sessions(self) -> int:
+        """Delete all sessions and their messages. Returns the number of sessions deleted."""
+        conn = await self._get_conn()
+        cursor = await conn.execute("SELECT COUNT(*) FROM sessions")
+        row = await cursor.fetchone()
+        count = row[0] if row else 0
+        await conn.execute("DELETE FROM conversations")
+        await conn.execute("DELETE FROM sessions")
+        await conn.commit()
+        return count
+
     # --- Watch State ---
 
     async def set_watch_state(self, key: str, value: str) -> None:

--- a/src/squire/tui/app.py
+++ b/src/squire/tui/app.py
@@ -9,7 +9,7 @@ from textual.widgets import Footer, Header
 
 from ..instructions.profiles import get_profile
 from .approval_bridge import ApprovalBridge, ApprovalRequest
-from .approval_modal import ApprovalModal
+from .approval_modal import ApprovalModal, ConfirmModal
 from .chat_pane import ChatPane
 from .log_viewer import LogViewer
 from .status_panel import StatusPanel
@@ -62,6 +62,7 @@ class SquireApp(App):
         Binding("ctrl+l", "clear_chat", "Clear", show=True),
         Binding("ctrl+g", "toggle_log", "Log", show=True),
         Binding("ctrl+s", "toggle_status", "Status", show=True),
+        Binding("ctrl+x", "clear_all_sessions", "Del Sessions", show=True),
     ]
 
     def __init__(
@@ -162,3 +163,15 @@ class SquireApp(App):
     def action_clear_chat(self) -> None:
         chat_pane = self.query_one(ChatPane)
         chat_pane.clear_messages()
+
+    async def action_clear_all_sessions(self) -> None:
+        """Prompt the user to confirm deleting all sessions, then delete them."""
+        confirmed = await self.push_screen_wait(
+            ConfirmModal(
+                message="Delete ALL sessions and their messages?\nThis cannot be undone.",
+                title="Clear All Sessions",
+            )
+        )
+        if confirmed and self._db is not None:
+            count = await self._db.delete_all_sessions()
+            self.notify(f"Deleted {count} session(s).", severity="information")

--- a/src/squire/tui/approval_modal.py
+++ b/src/squire/tui/approval_modal.py
@@ -6,6 +6,65 @@ from textual.screen import ModalScreen
 from textual.widgets import Button, Label, Static
 
 
+class ConfirmModal(ModalScreen[bool]):
+    """Simple yes/no confirmation dialog.
+
+    Returns True if confirmed, False if cancelled.
+    """
+
+    DEFAULT_CSS = """
+    ConfirmModal {
+        align: center middle;
+    }
+
+    #confirm-dialog {
+        width: 50;
+        max-width: 80%;
+        height: auto;
+        border: thick $error;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #confirm-title {
+        text-style: bold;
+        color: $error;
+        margin-bottom: 1;
+    }
+
+    #confirm-message {
+        color: $text;
+        margin-bottom: 1;
+    }
+
+    #confirm-buttons {
+        margin-top: 1;
+        align: center middle;
+        height: auto;
+    }
+
+    #confirm-buttons Button {
+        margin: 0 2;
+    }
+    """
+
+    def __init__(self, message: str, title: str = "Confirm", **kwargs):
+        super().__init__(**kwargs)
+        self._message = message
+        self._title = title
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-dialog"):
+            yield Label(self._title, id="confirm-title")
+            yield Static(self._message, id="confirm-message")
+            with Horizontal(id="confirm-buttons"):
+                yield Button("Yes", variant="error", id="btn-yes")
+                yield Button("Cancel", variant="default", id="btn-cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "btn-yes")
+
+
 class ApprovalModal(ModalScreen[bool]):
     """Modal dialog that asks the user to approve or deny a tool execution.
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -59,3 +59,43 @@ async def test_empty_queries(db):
     assert await db.get_snapshots(since="2020-01-01") == []
     assert await db.get_messages("nonexistent") == []
     assert await db.list_sessions() == []
+
+
+@pytest.mark.asyncio
+async def test_delete_session(db):
+    await db.create_session("sess-del", preview="to be deleted")
+    await db.save_message(session_id="sess-del", role="user", content="hello")
+
+    deleted = await db.delete_session("sess-del")
+    assert deleted is True
+
+    sessions = await db.list_sessions()
+    assert not any(s["session_id"] == "sess-del" for s in sessions)
+    assert await db.get_messages("sess-del") == []
+
+
+@pytest.mark.asyncio
+async def test_delete_session_not_found(db):
+    deleted = await db.delete_session("nonexistent-session")
+    assert deleted is False
+
+
+@pytest.mark.asyncio
+async def test_delete_all_sessions(db):
+    await db.create_session("sess-a", preview="first")
+    await db.create_session("sess-b", preview="second")
+    await db.save_message(session_id="sess-a", role="user", content="hello")
+    await db.save_message(session_id="sess-b", role="user", content="world")
+
+    count = await db.delete_all_sessions()
+    assert count == 2
+
+    assert await db.list_sessions() == []
+    assert await db.get_messages("sess-a") == []
+    assert await db.get_messages("sess-b") == []
+
+
+@pytest.mark.asyncio
+async def test_delete_all_sessions_empty(db):
+    count = await db.delete_all_sessions()
+    assert count == 0

--- a/web/src/app/sessions/page.tsx
+++ b/web/src/app/sessions/page.tsx
@@ -12,7 +12,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { Trash2, MessageSquare, History } from "lucide-react";
+import { Trash2, MessageSquare, History, Eraser } from "lucide-react";
 import type { SessionInfo } from "@/lib/types";
 
 function relativeTime(dateStr: string): string {
@@ -40,9 +40,23 @@ export default function SessionsPage() {
     mutate();
   };
 
+  const handleClearAll = async () => {
+    if (!confirm("Delete ALL sessions and their messages? This cannot be undone.")) return;
+    await apiDelete("/api/sessions");
+    mutate();
+  };
+
   return (
     <div className="space-y-6 animate-fade-in">
-      <h1 className="text-2xl">Session History</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl">Session History</h1>
+        {sessions && sessions.length > 0 && (
+          <Button variant="outline" size="sm" onClick={handleClearAll}>
+            <Eraser className="h-4 w-4 mr-2" />
+            Clear All
+          </Button>
+        )}
+      </div>
 
       {!sessions || sessions.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-12 text-muted-foreground gap-2">


### PR DESCRIPTION
Implements #-10: bulk delete all chat sessions at once across all interfaces (API, Web UI, CLI, TUI).

Generated with [Claude Code](https://claude.ai/code)