### PR TITLE
fix: hide internal ADK tool calls from web UI chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hide internal ADK tool calls from web UI chat** — `transfer_to_agent` (and any future ADK-internal tools) are no longer streamed to the WebSocket client. Previously, agent routing events appeared as unhelpful `🔧 transfer_to_agent: {'result': None}` messages that exposed internal sub-agent names. `ADK_INTERNAL_TOOLS` is now a public constant in `callbacks/risk_gate.py` shared by both the risk gate and the chat router.
+
 ### Added
 
 - **Clear all sessions** — bulk-delete all chat sessions at once instead of removing them one by one.

--- a/src/squire/api/routers/chat.py
+++ b/src/squire/api/routers/chat.py
@@ -14,7 +14,7 @@ from google.adk.runners import InMemoryRunner
 from google.genai import types
 
 from ...agents import create_squire_agent
-from ...callbacks.risk_gate import create_risk_gate
+from ...callbacks.risk_gate import ADK_INTERNAL_TOOLS, create_risk_gate
 from ...config import GuardrailsConfig
 from ...tools import TOOL_RISK_LEVELS
 from ..dependencies import get_app_config, get_db, get_llm_config, get_registry
@@ -330,6 +330,8 @@ async def _stream_response(
                     # concatenating prior sub-agent text into
                     # message_complete).
                     response_parts = []
+                    if fc.name in ADK_INTERNAL_TOOLS:
+                        continue
                     request_id = str(uuid.uuid4())
                     await websocket.send_json(
                         {
@@ -351,6 +353,8 @@ async def _stream_response(
                 elif part.function_response:
                     fr = part.function_response
                     response_parts = []
+                    if fr.name in ADK_INTERNAL_TOOLS:
+                        continue
                     await websocket.send_json(
                         {
                             "type": "tool_result",

--- a/src/squire/callbacks/risk_gate.py
+++ b/src/squire/callbacks/risk_gate.py
@@ -18,13 +18,16 @@ from ..types import BeforeToolCallback
 
 logger = logging.getLogger(__name__)
 
-# ADK framework tools that should bypass the risk gate.
+# ADK framework tools that should bypass the risk gate and be hidden from users.
 # These are auto-injected by ADK and are not user-facing tools.
-_ADK_INTERNAL_TOOLS = frozenset(
+ADK_INTERNAL_TOOLS = frozenset(
     {
         "transfer_to_agent",
     }
 )
+
+# Keep the private alias for backwards compatibility within this module.
+_ADK_INTERNAL_TOOLS = ADK_INTERNAL_TOOLS
 
 
 def create_risk_gate(


### PR DESCRIPTION
Filter `transfer_to_agent` (and any future `ADK_INTERNAL_TOOLS`) from the WebSocket stream in `_stream_response`. Previously these routing events appeared as unhelpful tool call/result messages in the chat, exposing internal sub-agent names and meaningless `None` results.

Closes #12

Generated with [Claude Code](https://claude.ai/code)