### PR TITLE
feat!: replace runbooks with file-based skills (Open Agent Skills spec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **Hide internal ADK tool calls from web UI chat** — `transfer_to_agent` (and any future ADK-internal tools) are no longer streamed to the WebSocket client. Previously, agent routing events appeared as unhelpful `🔧 transfer_to_agent: {'result': None}` messages that exposed internal sub-agent names. `ADK_INTERNAL_TOOLS` is now a public constant in `callbacks/risk_gate.py` shared by both the risk gate and the chat router.
-
 ### Added
 
+- **Skills** (replaces Runbooks) — file-based skill definitions aligned with the [Open Agent Skills spec](https://agentskills.io/specification). Each skill is a `SKILL.md` file with YAML frontmatter + freeform Markdown instructions, stored in a configurable directory (default `~/.local/share/squire/skills`). No database required — skills are version-controllable and editable with any text editor.
+  - **SkillService** (`src/squire/skills/`) — file-based CRUD: `list_skills`, `get_skill`, `save_skill`, `delete_skill`. Parses YAML frontmatter with `yaml.safe_load()` and renders back to spec-compliant SKILL.md format (`name`/`description` at top level, Squire-specific fields under `metadata`). Names are validated per the spec (lowercase alphanumeric + hyphens, max 64 chars).
+  - **SkillsConfig** (`src/squire/config/skills.py`) — configurable via `[skills]` in `squire.toml` or `SQUIRE_SKILLS_` env vars. Default path: `~/.local/share/squire/skills`.
+  - **API** — `GET/POST /api/skills`, `GET/PUT/DELETE /api/skills/{name}`, `POST /api/skills/{name}/toggle`, `POST /api/skills/{name}/execute`. Execute returns skill metadata for the frontend to start a chat session.
+  - **CLI** — `squire skills list|show|add|remove|enable|disable`. Create from Markdown file with `--instructions-file`.
+  - **Agent integration** — `build_skill_section()` reads `active_skill` from session state and injects freeform instructions into the system prompt. Single `[SKILL COMPLETE]` marker replaces per-step tracking.
+  - **Watch mode** — skills with `trigger=watch` are appended to the check-in prompt each cycle.
+  - **Web UI** — Skills page (`/skills`) with table listing, create/edit dialog (Markdown textarea for instructions), toggle, delete, and execute (opens in chat). Sidebar updated with Skills link.
 - **Clear all sessions** — bulk-delete all chat sessions at once instead of removing them one by one.
   - `DELETE /api/sessions` — new API endpoint; returns `{"deleted": <count>}`.
   - **Web UI** — "Clear All" button (with browser confirmation dialog) on the Sessions page; only shown when sessions exist.
   - **CLI** — `squire sessions clear` command with a `--yes/-y` flag to skip the confirmation prompt. The existing `squire sessions` command is now a sub-command group (`squire sessions list` / `squire sessions clear`).
   - **TUI** — `Ctrl+X` binding opens a confirmation modal and deletes all sessions from the database.
 - `DatabaseService.delete_all_sessions()` — deletes all rows from `sessions` and `conversations`, returns the session count.
+
+### Changed
+
+- **Runbooks replaced by Skills** — the database-backed runbook system (ordered steps in `runbooks` + `runbook_steps` tables) has been replaced by file-based skills. This simplifies the data model (no numbered steps, no per-step tracking), makes skills version-controllable, and aligns with the Open Agent Skills spec. The `[STEP N COMPLETE]` / `[RUNBOOK COMPLETE]` markers are replaced by a single `[SKILL COMPLETE]` marker. Existing runbook tables in the database are left in place but no longer queried. The WebSocket `?runbook=` query param is now `?skill=`. CLI commands changed from `squire runbooks` to `squire skills`. Added `pyyaml>=6.0` as an explicit dependency (was already a transitive dep).
+
+### Fixed
+
+- **Hide internal ADK tool calls from web UI chat** — `transfer_to_agent` (and any future ADK-internal tools) are no longer streamed to the WebSocket client. Previously, agent routing events appeared as unhelpful `🔧 transfer_to_agent: {'result': None}` messages that exposed internal sub-agent names. `ADK_INTERNAL_TOOLS` is now a public constant in `callbacks/risk_gate.py` shared by both the risk gate and the chat router.
 
 ## [0.5.0] — 2026-03-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,12 @@ Squire is an AI-powered homelab monitoring and management agent. It uses Google 
 ```
 src/squire/              Main application
   agents/                ADK agent definitions
-  api/                   FastAPI routers (chat, system, sessions, alerts, etc.)
+  api/                   FastAPI routers (chat, system, sessions, alerts, skills, etc.)
   callbacks/             Risk gate implementation
-  config/                Config loaders (app, llm, database, hosts)
+  config/                Config loaders (app, llm, database, hosts, skills)
   database/              SQLite service
   instructions/          Dynamic system prompts for agents
+  skills/                File-based skill service (Open Agent Skills spec)
   notifications/         Webhook dispatcher & alert evaluator
   schemas/               Pydantic models
   system/                Backend registry (local/SSH execution)
@@ -57,7 +58,7 @@ packages/
   agent-risk-engine/     Standalone risk evaluation library
 
 web/                     Next.js frontend
-  src/app/               Pages (chat, sessions, hosts, notifications, config, activity)
+  src/app/               Pages (chat, skills, sessions, hosts, notifications, config, activity)
   src/components/        UI components
   src/hooks/             Custom React hooks
   src/lib/               API client, types, utilities

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - [Autonomous Watch Mode](#autonomous-watch-mode)
     - [Running watch mode](#running-watch-mode)
   - [Alert Rules](#alert-rules)
+  - [Skills](#skills)
 - [CLI](#cli)
 - [Development](#development)
 - [License](#license)
@@ -25,6 +26,7 @@
 ## Features
 
 - **Multi-agent architecture** — Squire decomposes into specialized sub-agents (Monitor, Container, Admin, Notifier) that collaborate via [Google ADK](https://google.github.io/adk-docs/)'s transfer pattern — while maintaining a single unified persona
+- **Skills** — file-based instructions ([Open Agent Skills spec](https://agentskills.io/specification)) that give Squire guided, repeatable behavior. Each skill is a `SKILL.md` file with YAML frontmatter + Markdown instructions — version-controllable, editable with any text editor, no database required. Execute manually or attach to watch mode for automated checks
 - **Autonomous watch mode** — `squire watch` runs a headless monitoring loop that checks your systems on a schedule, takes corrective action within risk limits, and sends notifications
 - **Alert rules** — Define conditions like `cpu_percent > 90` and get notified when they trigger. Manage via conversation, CLI, or TUI
 - **Multi-machine management** — Connect to remote hosts over SSH and manage your entire homelab from one Squire instance
@@ -185,6 +187,62 @@ squire alerts remove high-cpu
 Or manage them conversationally. Ask Squire to "alert me if disk usage exceeds 90%".
 
 Conditions use a safe DSL: `<field> <op> <value>` where field is a snapshot metric (`cpu_percent`, `memory_used_mb`, etc.) and op is `>`, `<`, `>=`, `<=`, `==`, `!=`.
+
+### Skills
+
+Define reusable instructions for Squire to follow. Each skill is a directory with a `SKILL.md` file:
+
+```
+skills/
+  restart-on-error/
+    SKILL.md
+```
+
+A `SKILL.md` uses YAML frontmatter for metadata and freeform Markdown for instructions:
+
+```yaml
+---
+name: restart-on-error
+description: Check container health and restart errored containers.
+metadata:
+  host: prod-apps-01
+  trigger: manual
+---
+
+Check the status of all Docker containers on the target host.
+If any containers are in an errored state, check their logs for
+the root cause and restart them.
+Verify the containers come back healthy after restart.
+```
+
+The `name` and `description` fields are required by the [Open Agent Skills spec](https://agentskills.io/specification). Names must be lowercase letters, numbers, and hyphens (max 64 chars). Squire-specific fields (`host`, `trigger`, `enabled`) go under `metadata`.
+
+Manage skills via CLI:
+
+```bash
+squire skills list
+squire skills show restart-on-error
+squire skills add --name my-skill --description "What this skill does" --instructions-file instructions.md
+squire skills remove my-skill
+squire skills enable my-skill
+squire skills disable my-skill
+```
+
+#### Web UI
+
+The Skills page (`/skills`) in the web interface provides full management:
+
+- **Browse** all skills in a table with name, description, host, trigger, and enabled status
+- **Create/edit** skills with a form dialog — metadata fields plus a Markdown textarea for instructions
+- **Toggle** enabled/disabled state and **delete** skills inline
+- **Execute** a skill by clicking the play button, which opens a new chat session with the skill pre-loaded. Squire automatically begins following the instructions using its tools — no manual prompting needed. The chat stops when the agent emits `[SKILL COMPLETE]` (stripped from the display)
+
+#### Triggers
+
+- **`manual`** — execute on demand from the web UI, CLI, or API
+- **`watch`** — automatically appended to the check-in prompt during each watch mode cycle
+
+The skills directory is configurable via `[skills]` in `squire.toml` (default `~/.local/share/squire/skills`).
 
 ## CLI
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -149,15 +149,91 @@ squire alerts disable disk-full
 
 ---
 
+### `squire skills`
+
+Manage file-based skills (Open Agent Skills spec). Skills are stored as `SKILL.md` files in the configured skills directory (default `~/.local/share/squire/skills`).
+
+#### `squire skills list`
+
+List all configured skills.
+
+```bash
+squire skills list
+```
+
+#### `squire skills show`
+
+Display a skill's metadata and instructions.
+
+```bash
+squire skills show restart-on-error
+```
+
+#### `squire skills add`
+
+Create a new skill from a Markdown instructions file.
+
+```bash
+squire skills add --name restart-on-error --description "Restart errored containers" --instructions-file instructions.md
+squire skills add -n my-check -d "Health check" -f check.md --host prod-01 --trigger watch
+```
+
+| Option | Short | Required | Default | Description |
+|---|---|---|---|---|
+| `--name` | `-n` | Yes | | Skill name — lowercase letters, numbers, hyphens (max 64 chars) |
+| `--description` | `-d` | Yes | | What the skill does and when to use it |
+| `--instructions-file` | `-f` | Yes | | Path to Markdown file with instructions |
+| `--host` | | No | `all` | Target host (`all` or a specific host name) |
+| `--trigger` | `-t` | No | `manual` | `manual` or `watch` |
+
+#### `squire skills remove`
+
+Delete a skill and its directory.
+
+```bash
+squire skills remove restart-on-error
+```
+
+#### `squire skills enable`
+
+Enable a previously disabled skill.
+
+```bash
+squire skills enable restart-on-error
+```
+
+#### `squire skills disable`
+
+Disable a skill without deleting it.
+
+```bash
+squire skills disable restart-on-error
+```
+
+---
+
 ### `squire sessions`
+
+Manage chat sessions.
+
+#### `squire sessions list`
 
 List recent chat sessions.
 
 ```bash
-squire sessions
+squire sessions list
 ```
 
 Displays a table with session ID, creation time, last activity, and a preview of the conversation.
+
+#### `squire sessions clear`
+
+Delete all chat sessions and their messages.
+
+```bash
+squire sessions clear         # prompts for confirmation
+squire sessions clear --yes   # skip confirmation
+```
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,6 +259,52 @@ model = "gemini/gemini-2.0-flash"
 
 ---
 
+## Skills -- `[skills]`
+
+Skills are file-based instruction sets aligned with the [Open Agent Skills spec](https://agentskills.io/specification). Each skill lives in a `NAME/SKILL.md` subdirectory under the configured skills path.
+
+| Key | Default | Env Var | Description |
+|---|---|---|---|
+| `path` | `~/.local/share/squire/skills` | `SQUIRE_SKILLS_PATH` | Directory containing skill definitions |
+
+```toml
+[skills]
+path = "~/.local/share/squire/skills"
+```
+
+### SKILL.md Format
+
+Each skill is a directory containing a `SKILL.md` file with YAML frontmatter and Markdown instructions:
+
+```yaml
+---
+name: restart-on-error
+description: Check container health and restart errored containers.
+metadata:
+  host: prod-apps-01
+  trigger: manual
+---
+
+Check the status of all Docker containers on the target host.
+If any containers are in an errored state, check their logs and restart them.
+```
+
+The format follows the [Open Agent Skills spec](https://agentskills.io/specification). `name` and `description` are spec-required top-level fields. Squire-specific fields live under `metadata`:
+
+| Key | Required | Default | Description |
+|---|---|---|---|
+| `name` | Yes | | Skill name — lowercase letters, numbers, hyphens, max 64 chars. Must match directory name. |
+| `description` | Yes | | What the skill does and when to use it (max 1024 chars). |
+| `metadata.host` | No | `all` | Target host (`all` or a specific host name) |
+| `metadata.trigger` | No | `manual` | `manual` (on-demand) or `watch` (each watch cycle) |
+| `metadata.enabled` | No | `true` | Whether the skill is active |
+
+The `metadata` key is omitted entirely when all Squire-specific fields are at their defaults.
+
+Skills with `trigger: watch` are appended to the watch mode check-in prompt each cycle. Manual skills can be executed from the web UI or CLI.
+
+---
+
 ## Database -- `[db]`
 
 Squire persists chat history, system snapshots, events, and alert rules to SQLite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "aiosqlite>=0.19.0",
     "httpx>=0.27.0",
     "asyncssh>=2.17.0",
+    "pyyaml>=6.0",
     "agent-risk-engine",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",

--- a/squire.example.toml
+++ b/squire.example.toml
@@ -65,6 +65,10 @@
 # tools_allow = []                   # additional tools to auto-allow in watch
 # tools_deny = []                    # additional tools to deny in watch
 
+# --- Skills (file-based, Open Agent Skills spec) ---
+[skills]
+# path = "~/.local/share/squire/skills"  # Directory containing NAME/SKILL.md subdirectories
+
 # --- Watch mode (operational settings only — risk policy is in [guardrails.watch]) ---
 [watch]
 # interval_minutes = 5

--- a/src/squire/api/app.py
+++ b/src/squire/api/app.py
@@ -12,18 +12,27 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
-from ..config import AppConfig, DatabaseConfig, GuardrailsConfig, LLMConfig, NotificationsConfig, WatchConfig
+from ..config import (
+    AppConfig,
+    DatabaseConfig,
+    GuardrailsConfig,
+    LLMConfig,
+    NotificationsConfig,
+    SkillsConfig,
+    WatchConfig,
+)
 from ..config.hosts import HostConfig
 from ..config.loader import get_list_section
 from ..database.service import DatabaseService
 from ..main import _collect_all_snapshots
 from ..notifications.webhook import WebhookDispatcher
+from ..skills import SkillService
 from ..system.registry import BackendRegistry
 from ..tools import set_db as tools_set_db
 from ..tools import set_notifier as tools_set_notifier
 from ..tools import set_registry as tools_set_registry
 from . import dependencies as deps
-from .routers import alerts, chat, config, events, hosts, sessions, system, watch
+from .routers import alerts, chat, config, events, hosts, sessions, skills, system, watch
 
 load_dotenv()
 logger = logging.getLogger(__name__)
@@ -67,6 +76,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     deps.notif_config = NotificationsConfig()
     deps.watch_config = WatchConfig()
     deps.guardrails = GuardrailsConfig()
+    skills_config = SkillsConfig()
 
     # Load host configs
     host_dicts = get_list_section("hosts")
@@ -76,6 +86,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     deps.registry = BackendRegistry(deps.host_configs)
     deps.db = DatabaseService(deps.db_config.path)
     deps.notifier = WebhookDispatcher(deps.notif_config)
+    deps.skills_service = SkillService(skills_config.path)
 
     # Wire up tool registry
     tools_set_registry(deps.registry)
@@ -150,6 +161,7 @@ def create_app() -> FastAPI:
     app.include_router(chat.router, prefix="/api/chat", tags=["chat"])
     app.include_router(sessions.router, prefix="/api/sessions", tags=["sessions"])
     app.include_router(alerts.router, prefix="/api/alerts", tags=["alerts"])
+    app.include_router(skills.router, prefix="/api/skills", tags=["skills"])
     app.include_router(events.router, prefix="/api/events", tags=["events"])
     app.include_router(config.router, prefix="/api/config", tags=["config"])
     app.include_router(watch.router, prefix="/api/watch", tags=["watch"])

--- a/src/squire/api/dependencies.py
+++ b/src/squire/api/dependencies.py
@@ -8,12 +8,14 @@ from squire.config import AppConfig, DatabaseConfig, GuardrailsConfig, LLMConfig
 from squire.config.hosts import HostConfig
 from squire.database.service import DatabaseService
 from squire.notifications.webhook import WebhookDispatcher
+from squire.skills import SkillService
 from squire.system.registry import BackendRegistry
 
 # Singletons — populated by the lifespan context manager in app.py
 db: DatabaseService | None = None
 registry: BackendRegistry | None = None
 notifier: WebhookDispatcher | None = None
+skills_service: SkillService | None = None
 
 # Configs — loaded once at startup
 app_config: AppConfig | None = None
@@ -41,6 +43,12 @@ def get_notifier() -> WebhookDispatcher:
     if notifier is None:
         raise RuntimeError("WebhookDispatcher not initialized")
     return notifier
+
+
+def get_skills_service() -> SkillService:
+    if skills_service is None:
+        raise RuntimeError("SkillService not initialized")
+    return skills_service
 
 
 def get_app_config() -> AppConfig:

--- a/src/squire/api/routers/chat.py
+++ b/src/squire/api/routers/chat.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import re
 import uuid
 from typing import Any
 
@@ -22,6 +23,13 @@ from ..schemas import ChatSessionResponse
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+_SKILL_COMPLETE_RE = re.compile(r"\[SKILL\s+COMPLETE\]", re.IGNORECASE)
+
+
+def _is_skill_complete(text: str) -> bool:
+    """Check whether [SKILL COMPLETE] marker is present in text."""
+    return bool(_SKILL_COMPLETE_RE.search(text))
 
 
 class WebApprovalBridge:
@@ -140,6 +148,10 @@ async def chat_websocket(
     """Bidirectional chat WebSocket with streaming responses."""
     await websocket.accept()
 
+    # Read skill name from query params directly (more reliable than
+    # FastAPI parameter injection for WebSocket endpoints).
+    skill_name = websocket.query_params.get("skill") or None
+
     from .. import dependencies as deps
     from ..app import get_latest_snapshot
 
@@ -159,7 +171,12 @@ async def chat_websocket(
             approval_provider=approval_bridge,
         )
 
-    if app_config.multi_agent:
+    # Skills require direct tool access, so always use single-agent mode
+    # when executing a skill.  In multi-agent mode the root agent has no
+    # tools and cannot carry out skill instructions itself.
+    use_multi_agent = app_config.multi_agent and not skill_name
+
+    if use_multi_agent:
         agent = create_squire_agent(
             app_config=app_config,
             llm_config=llm_config,
@@ -170,8 +187,11 @@ async def chat_websocket(
             tool_risk_levels=TOOL_RISK_LEVELS,
             approval_provider=approval_bridge,
         )
+        # Override multi_agent so create_squire_agent takes the
+        # single-agent path even when the global config says otherwise.
+        agent_config = app_config.model_copy(update={"multi_agent": False})
         agent = create_squire_agent(
-            app_config=app_config,
+            app_config=agent_config,
             llm_config=llm_config,
             before_tool_callback=risk_gate_callback,
         )
@@ -201,6 +221,23 @@ async def chat_websocket(
         "available_hosts": registry.host_names,
         "host_configs": {name: cfg.model_dump() for name, cfg in registry.host_configs.items()},
     }
+
+    # Load skill context into session state if a skill name was provided.
+    # This MUST happen before create_session because InMemorySessionService
+    # deep-copies the state dict — later mutations won't be visible.
+    skill_active = False
+    if skill_name and deps.skills_service:
+        skill_data = deps.skills_service.get_skill(skill_name)
+        if skill_data and skill_data.instructions:
+            skill_active = True
+            session_state["active_skill"] = {
+                "skill_name": skill_data.name,
+                "host": skill_data.host,
+                "instructions": skill_data.instructions,
+            }
+            logger.info("Loaded skill '%s' into session %s", skill_name, session_id)
+        else:
+            logger.warning("Skill '%s' not found or has no instructions", skill_name)
 
     session = await runner.session_service.create_session(
         app_name=app_config.app_name,
@@ -277,8 +314,12 @@ async def chat_websocket(
                         app_config=app_config,
                         db=db,
                         notifier=notifier,
+                        skill_active=skill_active,
                     )
                 )
+                # Only auto-continue for the first message (skill execution).
+                # Subsequent user messages are normal chat turns.
+                skill_active = False
                 continue
 
             await websocket.send_json({"type": "error", "message": f"Unknown message type: {msg_type}"})
@@ -301,103 +342,62 @@ async def _stream_response(
     app_config,
     db,
     notifier,
+    skill_active: bool = False,
 ) -> None:
-    """Run the agent and stream response tokens over WebSocket."""
-    message = types.Content(parts=[types.Part(text=user_text)])
-    response_parts = []
-    run_config = RunConfig(streaming_mode=StreamingMode.SSE)
+    """Run the agent and stream response tokens over WebSocket.
+
+    When ``skill_active`` is set, the agent is automatically re-prompted
+    after each turn so it works through the skill instructions without the
+    user having to send "continue" manually.
+    """
+    max_turns = 15 if skill_active else 1
+    current_text = user_text
 
     try:
-        final_text = ""
+        all_response_text = ""
+        prev_response = ""
 
-        async for event in runner.run_async(
-            user_id=app_config.user_id,
-            session_id=session.id,
-            new_message=message,
-            run_config=run_config,
-        ):
-            if not event.content or not event.content.parts:
-                continue
+        for turn in range(max_turns):
+            turn_response, tools_used = await _run_single_turn(
+                websocket=websocket,
+                runner=runner,
+                session=session,
+                agent=agent,
+                user_text=current_text,
+                app_config=app_config,
+                db=db,
+            )
 
-            for part in event.content.parts:
-                if getattr(part, "thought", False):
-                    continue
+            # Persist assistant response
+            if db and turn_response:
+                await db.save_message(session_id=session.id, role="assistant", content=turn_response)
+                await db.update_session_active(session.id)
 
-                if part.function_call:
-                    fc = part.function_call
-                    # Reset so response_parts only tracks the text
-                    # segment *after* this tool call (prevents
-                    # concatenating prior sub-agent text into
-                    # message_complete).
-                    response_parts = []
-                    if fc.name in ADK_INTERNAL_TOOLS:
-                        continue
-                    request_id = str(uuid.uuid4())
-                    await websocket.send_json(
-                        {
-                            "type": "tool_call",
-                            "name": fc.name,
-                            "args": fc.args or {},
-                            "request_id": request_id,
-                        }
-                    )
-                    if db:
-                        await db.log_event(
-                            category="tool_call",
-                            summary=f"Called {fc.name}",
-                            session_id=session.id,
-                            tool_name=fc.name,
-                            details=json.dumps(fc.args or {}),
-                        )
+            # If this is not a skill session or we've exhausted turns, stop.
+            if not skill_active or turn >= max_turns - 1:
+                await websocket.send_json({"type": "message_complete", "content": turn_response})
+                break
 
-                elif part.function_response:
-                    fr = part.function_response
-                    response_parts = []
-                    if fr.name in ADK_INTERNAL_TOOLS:
-                        continue
-                    await websocket.send_json(
-                        {
-                            "type": "tool_result",
-                            "name": fr.name,
-                            "output": str(fr.response)[:500],
-                            "request_id": "",
-                        }
-                    )
+            await websocket.send_json({"type": "message_complete", "content": turn_response})
 
-                elif part.text and event.partial:
-                    response_parts.append(part.text)
-                    await websocket.send_json({"type": "token", "content": part.text})
+            all_response_text += "\n" + turn_response
 
-                elif part.text and event.is_final_response():
-                    final_text = part.text
-                    # In multi-agent mode, partial tokens may have streamed
-                    # the root agent's text while the sub-agent's response
-                    # arrives only in the final event.  Send any genuinely
-                    # new content as a token so the frontend displays it.
-                    streamed = "".join(response_parts)
-                    if final_text and final_text != streamed:
-                        delta = (
-                            final_text[len(streamed) :] if streamed and final_text.startswith(streamed) else final_text
-                        )
-                        if delta.strip():
-                            response_parts.append(delta)
-                            await websocket.send_json({"type": "token", "content": delta})
+            # Stop if [SKILL COMPLETE] marker detected (only when tools were used).
+            if tools_used and _is_skill_complete(all_response_text):
+                break
 
-        full_response = final_text or "".join(response_parts)
-        await websocket.send_json({"type": "message_complete", "content": full_response})
+            # Safety: stop if the agent repeated itself verbatim.
+            if turn > 0 and turn_response == prev_response:
+                break
+            prev_response = turn_response
 
-        # Persist assistant response
-        if db and full_response:
-            await db.save_message(session_id=session.id, role="assistant", content=full_response)
-            await db.update_session_active(session.id)
+            current_text = "Continue executing the skill. Use your tools."
+            if db:
+                await db.save_message(session_id=session.id, role="user", content=current_text)
 
     except asyncio.CancelledError:
-        partial = final_text or "".join(response_parts)
         try:
-            await websocket.send_json({"type": "message_complete", "content": partial, "stopped": True})
-            if db and partial:
-                await db.save_message(session_id=session.id, role="assistant", content=partial)
-                await db.update_session_active(session.id)
+            await websocket.send_json({"type": "message_complete", "content": "", "stopped": True})
         except Exception:
             pass
     except WebSocketDisconnect:
@@ -408,3 +408,94 @@ async def _stream_response(
             await websocket.send_json({"type": "error", "message": str(e)})
         except Exception:
             pass
+
+
+async def _run_single_turn(
+    websocket: WebSocket,
+    runner: InMemoryRunner,
+    session,
+    agent,
+    user_text: str,
+    app_config,
+    db,
+) -> tuple[str, bool]:
+    """Run one agent turn and stream events over the WebSocket.
+
+    Returns:
+        A tuple of (response_text, tools_were_called).
+    """
+    message = types.Content(parts=[types.Part(text=user_text)])
+    response_parts: list[str] = []
+    run_config = RunConfig(streaming_mode=StreamingMode.SSE)
+    final_text = ""
+    tools_called = False
+
+    async for event in runner.run_async(
+        user_id=app_config.user_id,
+        session_id=session.id,
+        new_message=message,
+        run_config=run_config,
+    ):
+        if not event.content or not event.content.parts:
+            continue
+
+        for part in event.content.parts:
+            if getattr(part, "thought", False):
+                continue
+
+            if part.function_call:
+                fc = part.function_call
+                # Reset so response_parts only tracks the text
+                # segment *after* this tool call (prevents
+                # concatenating prior sub-agent text into
+                # message_complete).
+                response_parts = []
+                if fc.name in ADK_INTERNAL_TOOLS:
+                    continue
+                tools_called = True
+                request_id = str(uuid.uuid4())
+                await websocket.send_json(
+                    {
+                        "type": "tool_call",
+                        "name": fc.name,
+                        "args": fc.args or {},
+                        "request_id": request_id,
+                    }
+                )
+                if db:
+                    await db.log_event(
+                        category="tool_call",
+                        summary=f"Called {fc.name}",
+                        session_id=session.id,
+                        tool_name=fc.name,
+                        details=json.dumps(fc.args or {}),
+                    )
+
+            elif part.function_response:
+                fr = part.function_response
+                response_parts = []
+                if fr.name in ADK_INTERNAL_TOOLS:
+                    continue
+                await websocket.send_json(
+                    {
+                        "type": "tool_result",
+                        "name": fr.name,
+                        "output": str(fr.response)[:500],
+                        "request_id": "",
+                    }
+                )
+
+            elif part.text and event.partial:
+                response_parts.append(part.text)
+                await websocket.send_json({"type": "token", "content": part.text})
+
+            elif part.text and event.is_final_response():
+                final_text = part.text
+                streamed = "".join(response_parts)
+                if final_text and final_text != streamed:
+                    delta = final_text[len(streamed) :] if streamed and final_text.startswith(streamed) else final_text
+                    if delta.strip():
+                        response_parts.append(delta)
+                        await websocket.send_json({"type": "token", "content": delta})
+
+    return final_text or "".join(response_parts), tools_called

--- a/src/squire/api/routers/skills.py
+++ b/src/squire/api/routers/skills.py
@@ -1,0 +1,113 @@
+"""Skill management endpoints."""
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from ...skills import Skill
+from ..dependencies import get_skills_service
+from ..schemas import SkillCreate, SkillUpdate
+
+router = APIRouter()
+
+VALID_TRIGGERS = ("manual", "watch")
+
+
+@router.get("", response_model=list[Skill])
+def list_skills(skills_service=Depends(get_skills_service)):
+    """List all skills."""
+    return skills_service.list_skills()
+
+
+@router.post("", response_model=Skill, status_code=201)
+def create_skill(body: SkillCreate, skills_service=Depends(get_skills_service)):
+    """Create a new skill."""
+    if body.trigger not in VALID_TRIGGERS:
+        raise HTTPException(status_code=422, detail=f"trigger must be one of {VALID_TRIGGERS}")
+    if not body.instructions.strip():
+        raise HTTPException(status_code=422, detail="Instructions are required")
+    if not body.description.strip():
+        raise HTTPException(status_code=422, detail="Description is required")
+
+    if skills_service.get_skill(body.name):
+        raise HTTPException(status_code=409, detail=f"A skill named '{body.name}' already exists")
+
+    try:
+        skill = Skill(
+            name=body.name,
+            description=body.description,
+            host=body.host,
+            trigger=body.trigger,
+            instructions=body.instructions,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    skills_service.save_skill(skill)
+    return skill
+
+
+@router.get("/{name}", response_model=Skill)
+def get_skill(name: str, skills_service=Depends(get_skills_service)):
+    """Get a skill by name."""
+    skill = skills_service.get_skill(name)
+    if not skill:
+        raise HTTPException(status_code=404, detail=f"No skill named '{name}' found")
+    return skill
+
+
+@router.put("/{name}", response_model=Skill)
+def update_skill(name: str, body: SkillUpdate, skills_service=Depends(get_skills_service)):
+    """Update a skill."""
+    skill = skills_service.get_skill(name)
+    if not skill:
+        raise HTTPException(status_code=404, detail=f"No skill named '{name}' found")
+
+    fields = body.model_dump(exclude_none=True)
+    if "trigger" in fields and fields["trigger"] not in VALID_TRIGGERS:
+        raise HTTPException(status_code=422, detail=f"trigger must be one of {VALID_TRIGGERS}")
+
+    if not fields:
+        raise HTTPException(status_code=422, detail="No fields to update")
+
+    updated = skill.model_copy(update=fields)
+    skills_service.save_skill(updated)
+    return updated
+
+
+@router.delete("/{name}")
+def delete_skill(name: str, skills_service=Depends(get_skills_service)):
+    """Delete a skill."""
+    deleted = skills_service.delete_skill(name)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"No skill named '{name}' found")
+    return {"deleted": True}
+
+
+@router.post("/{name}/toggle")
+def toggle_skill(name: str, skills_service=Depends(get_skills_service)):
+    """Toggle a skill's enabled state."""
+    skill = skills_service.get_skill(name)
+    if not skill:
+        raise HTTPException(status_code=404, detail=f"No skill named '{name}' found")
+
+    updated = skill.model_copy(update={"enabled": not skill.enabled})
+    skills_service.save_skill(updated)
+    return {"name": name, "enabled": updated.enabled}
+
+
+@router.post("/{name}/execute")
+def execute_skill(name: str, skills_service=Depends(get_skills_service)):
+    """Execute a skill by returning its name for the frontend to start a chat session.
+
+    The frontend creates a normal chat session, connects via WebSocket with
+    ``?skill={name}`` so the handler loads the skill into session state, and
+    sends the initial message to trigger execution.
+    """
+    skill = skills_service.get_skill(name)
+    if not skill:
+        raise HTTPException(status_code=404, detail=f"No skill named '{name}' found")
+    if not skill.enabled:
+        raise HTTPException(status_code=422, detail=f"Skill '{name}' is disabled")
+
+    return {
+        "skill_name": skill.name,
+        "instructions": skill.instructions,
+    }

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -101,6 +101,34 @@ class AlertRuleUpdate(BaseModel):
     cooldown_minutes: int | None = None
 
 
+# --- Skills ---
+
+
+class Skill(BaseModel):
+    name: str
+    description: str = ""
+    host: str = "all"
+    trigger: str = "manual"
+    enabled: bool = True
+    instructions: str = ""
+
+
+class SkillCreate(BaseModel):
+    name: str
+    description: str
+    host: str = "all"
+    trigger: str = "manual"
+    instructions: str
+
+
+class SkillUpdate(BaseModel):
+    description: str | None = None
+    host: str | None = None
+    trigger: str | None = None
+    enabled: bool | None = None
+    instructions: str | None = None
+
+
 # --- Events ---
 
 

--- a/src/squire/cli.py
+++ b/src/squire/cli.py
@@ -343,5 +343,191 @@ def alerts_disable(
         raise typer.Exit(1)
 
 
+# --- Skill management ---
+
+skills_app = typer.Typer(name="skills", help="Manage skills.")
+app.add_typer(skills_app)
+
+
+@skills_app.command("list")
+def skills_list() -> None:
+    """List all skills."""
+    from .config import SkillsConfig
+    from .skills import SkillService
+
+    skills_config = SkillsConfig()
+    service = SkillService(skills_config.path)
+    skills = service.list_skills()
+
+    if not skills:
+        typer.echo("No skills configured.")
+        return
+
+    console = Console()
+    table = Table(title="Skills")
+    table.add_column("Name", style="cyan", no_wrap=True)
+    table.add_column("Description", style="white")
+    table.add_column("Host", style="blue")
+    table.add_column("Trigger", style="yellow")
+    table.add_column("Status", style="green")
+
+    for s in skills:
+        status = "enabled" if s.enabled else "disabled"
+        table.add_row(
+            s.name,
+            (s.description or "")[:40],
+            s.host,
+            s.trigger,
+            status,
+        )
+
+    console.print(table)
+
+
+@skills_app.command("show")
+def skills_show(
+    name: Annotated[str, typer.Argument(help="Name of the skill to show")],
+) -> None:
+    """Show a skill's SKILL.md content."""
+    from .config import SkillsConfig
+    from .skills import SkillService
+
+    skills_config = SkillsConfig()
+    service = SkillService(skills_config.path)
+    skill = service.get_skill(name)
+
+    if not skill:
+        typer.echo(f"Error: no skill named '{name}' found.", err=True)
+        raise typer.Exit(1)
+
+    console = Console()
+    status = "enabled" if skill.enabled else "disabled"
+    console.print(f"[bold cyan]{skill.name}[/bold cyan]  [{status}]")
+    if skill.description:
+        console.print(f"  {skill.description}")
+    console.print(f"  Host: {skill.host}  |  Trigger: {skill.trigger}")
+    console.print()
+
+    if skill.instructions:
+        console.print("[bold]Instructions:[/bold]")
+        console.print(f"  {skill.instructions}")
+    else:
+        console.print("  (no instructions)")
+
+
+@skills_app.command("add")
+def skills_add(
+    name: Annotated[str, typer.Option("--name", "-n", help="Skill name (lowercase, hyphens, max 64 chars)")],
+    description: Annotated[str, typer.Option("--description", "-d", help="Skill description (required)")],
+    instructions_file: Annotated[
+        str | None, typer.Option("--instructions-file", "-f", help="Markdown file with skill instructions")
+    ] = None,
+    host: Annotated[str, typer.Option("--host", help="Target host ('all' or specific name)")] = "all",
+    trigger: Annotated[str, typer.Option("--trigger", "-t", help="'manual' or 'watch'")] = "manual",
+) -> None:
+    """Add a new skill."""
+    from pathlib import Path
+
+    from .config import SkillsConfig
+    from .skills import Skill, SkillService
+
+    if trigger not in ("manual", "watch"):
+        typer.echo("Error: trigger must be 'manual' or 'watch'.", err=True)
+        raise typer.Exit(1)
+
+    if not description.strip():
+        typer.echo("Error: --description is required.", err=True)
+        raise typer.Exit(1)
+
+    instructions = ""
+    if instructions_file:
+        path = Path(instructions_file)
+        if not path.exists():
+            typer.echo(f"Error: file not found: {instructions_file}", err=True)
+            raise typer.Exit(1)
+        instructions = path.read_text().strip()
+
+    if not instructions:
+        typer.echo("Error: provide instructions via --instructions-file.", err=True)
+        raise typer.Exit(1)
+
+    skills_config = SkillsConfig()
+    service = SkillService(skills_config.path)
+
+    if service.get_skill(name):
+        typer.echo(f"Error: a skill named '{name}' already exists.", err=True)
+        raise typer.Exit(1)
+
+    try:
+        skill = Skill(
+            name=name,
+            description=description,
+            host=host,
+            trigger=trigger,
+            instructions=instructions,
+        )
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+    service.save_skill(skill)
+    typer.echo(f"Skill '{name}' created.")
+
+
+@skills_app.command("remove")
+def skills_remove(
+    name: Annotated[str, typer.Argument(help="Name of the skill to remove")],
+) -> None:
+    """Remove a skill by name."""
+    from .config import SkillsConfig
+    from .skills import SkillService
+
+    skills_config = SkillsConfig()
+    service = SkillService(skills_config.path)
+    deleted = service.delete_skill(name)
+    if deleted:
+        typer.echo(f"Skill '{name}' removed.")
+    else:
+        typer.echo(f"Error: no skill named '{name}' found.", err=True)
+        raise typer.Exit(1)
+
+
+@skills_app.command("enable")
+def skills_enable(
+    name: Annotated[str, typer.Argument(help="Name of the skill to enable")],
+) -> None:
+    """Enable a skill."""
+    from .config import SkillsConfig
+    from .skills import SkillService
+
+    skills_config = SkillsConfig()
+    service = SkillService(skills_config.path)
+    skill = service.get_skill(name)
+    if not skill:
+        typer.echo(f"Error: no skill named '{name}' found.", err=True)
+        raise typer.Exit(1)
+    updated = skill.model_copy(update={"enabled": True})
+    service.save_skill(updated)
+    typer.echo(f"Skill '{name}' enabled.")
+
+
+@skills_app.command("disable")
+def skills_disable(
+    name: Annotated[str, typer.Argument(help="Name of the skill to disable")],
+) -> None:
+    """Disable a skill."""
+    from .config import SkillsConfig
+    from .skills import SkillService
+
+    skills_config = SkillsConfig()
+    service = SkillService(skills_config.path)
+    skill = service.get_skill(name)
+    if not skill:
+        typer.echo(f"Error: no skill named '{name}' found.", err=True)
+        raise typer.Exit(1)
+    updated = skill.model_copy(update={"enabled": False})
+    service.save_skill(updated)
+    typer.echo(f"Skill '{name}' disabled.")
+
+
 if __name__ == "__main__":
     app()

--- a/src/squire/config/__init__.py
+++ b/src/squire/config/__init__.py
@@ -4,6 +4,7 @@ from .guardrails import GuardrailsConfig
 from .hosts import HostConfig
 from .llm import LLMConfig
 from .notifications import NotificationsConfig, WebhookConfig
+from .skills import SkillsConfig
 from .watch import WatchConfig
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     "HostConfig",
     "LLMConfig",
     "NotificationsConfig",
+    "SkillsConfig",
     "WatchConfig",
     "WebhookConfig",
 ]

--- a/src/squire/config/skills.py
+++ b/src/squire/config/skills.py
@@ -1,0 +1,40 @@
+"""Skills configuration.
+
+Loaded from [skills] section in squire.toml and/or SQUIRE_SKILLS_ env vars.
+"""
+
+from functools import partial
+from pathlib import Path
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+
+from .loader import TomlSectionSource, get_section
+
+
+class SkillsConfig(BaseSettings):
+    """Configuration for file-based skills (Open Agent Skills spec)."""
+
+    model_config = SettingsConfigDict(env_prefix="SQUIRE_SKILLS_", case_sensitive=False, extra="ignore")
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            TomlSectionSource(settings_cls, partial(get_section, "skills")),
+            file_secret_settings,
+        )
+
+    path: Path = Field(
+        default=Path.home() / ".local" / "share" / "squire" / "skills",
+        description="Directory containing skill definitions (each in a NAME/SKILL.md subdirectory)",
+    )

--- a/src/squire/database/service.py
+++ b/src/squire/database/service.py
@@ -118,6 +118,7 @@ class DatabaseService:
             self._conn.row_factory = aiosqlite.Row
             await self._conn.execute("PRAGMA journal_mode=WAL")
             await self._conn.execute("PRAGMA busy_timeout=5000")
+            await self._conn.execute("PRAGMA foreign_keys=ON")
             await self._ensure_schema()
         return self._conn
 

--- a/src/squire/instructions/shared.py
+++ b/src/squire/instructions/shared.py
@@ -73,6 +73,37 @@ def build_system_state_section(ctx: ReadonlyContext) -> str:
     return f"## Current System State\n{system_context}"
 
 
+def build_skill_section(ctx: ReadonlyContext) -> str:
+    """Return the active skill section if a skill is loaded, else empty string."""
+    active_skill = ctx.state.get("active_skill")
+    if not active_skill:
+        return ""
+
+    skill_name = active_skill.get("skill_name", "unnamed")
+    instructions = active_skill.get("instructions", "")
+    if not instructions:
+        return ""
+
+    host = active_skill.get("host", "all")
+    host_line = ""
+    if host != "all":
+        host_line = f"\n**Target host:** `{host}` — pass this as the `host` parameter to every tool call."
+
+    return f"""
+## Active Skill: "{skill_name}"
+You are executing a skill. Follow the instructions below.{host_line}
+
+### Instructions
+{instructions}
+
+### Execution Rules
+- You MUST execute the instructions by calling your tools. Do NOT tell the user how to do it.
+- Work through the instructions methodically, calling tools as needed.
+- If a condition doesn't apply, explain why and move on.
+- If a tool call is blocked, note it and continue.
+- When you have completed all instructions, provide a summary, then emit [SKILL COMPLETE]."""
+
+
 def build_watch_mode_addendum(ctx: ReadonlyContext) -> str:
     """Return watch-mode instructions if watch_mode is active, else empty string."""
     if not ctx.state.get("watch_mode"):

--- a/src/squire/instructions/squire_agent.py
+++ b/src/squire/instructions/squire_agent.py
@@ -11,6 +11,7 @@ from .shared import (
     build_hosts_section,
     build_identity_section,
     build_risk_section,
+    build_skill_section,
     build_system_state_section,
     build_watch_mode_addendum,
 )
@@ -49,4 +50,5 @@ def build_instruction(ctx: ReadonlyContext) -> str:
 {build_risk_section(ctx)}
 {build_hosts_section(ctx)}\
 {build_system_state_section(ctx)}
-{build_watch_mode_addendum(ctx)}"""
+{build_watch_mode_addendum(ctx)}\
+{build_skill_section(ctx)}"""

--- a/src/squire/skills/__init__.py
+++ b/src/squire/skills/__init__.py
@@ -1,0 +1,5 @@
+"""File-based skill management aligned with the Open Agent Skills spec."""
+
+from .service import Skill, SkillService
+
+__all__ = ["Skill", "SkillService"]

--- a/src/squire/skills/service.py
+++ b/src/squire/skills/service.py
@@ -1,0 +1,149 @@
+"""SkillService — file-based CRUD for SKILL.md directories.
+
+Each skill lives in its own directory under the configured skills path:
+
+    skills/
+      restart-on-error/
+        SKILL.md
+
+SKILL.md uses YAML frontmatter + freeform Markdown body (Open Agent Skills spec).
+Squire-specific fields (host, trigger, enabled) are stored under the ``metadata``
+key to stay spec-compliant.
+"""
+
+import re
+import shutil
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, field_validator
+
+# Spec: lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, max 64 chars.
+_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+
+
+class Skill(BaseModel):
+    """A single skill definition parsed from a SKILL.md file."""
+
+    name: str
+    description: str = ""
+    host: str = "all"
+    trigger: str = "manual"  # "manual" | "watch"
+    enabled: bool = True
+    instructions: str = ""  # freeform Markdown body
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not v or len(v) > 64:
+            raise ValueError("name must be 1-64 characters")
+        if "--" in v:
+            raise ValueError("name must not contain consecutive hyphens")
+        if not _NAME_RE.match(v):
+            raise ValueError("name must be lowercase letters, numbers, and hyphens only (no leading/trailing hyphens)")
+        return v
+
+
+class SkillService:
+    """File-based skill CRUD backed by SKILL.md directories."""
+
+    def __init__(self, skills_dir: Path) -> None:
+        self._dir = skills_dir
+
+    def list_skills(self, *, enabled_only: bool = False, trigger: str | None = None) -> list[Skill]:
+        """List all skills, optionally filtered by enabled state and trigger type."""
+        if not self._dir.is_dir():
+            return []
+
+        skills: list[Skill] = []
+        for child in sorted(self._dir.iterdir()):
+            skill_file = child / "SKILL.md"
+            if not child.is_dir() or not skill_file.is_file():
+                continue
+            try:
+                skill = self._parse_skill_md(skill_file)
+            except Exception:
+                continue
+            if enabled_only and not skill.enabled:
+                continue
+            if trigger and skill.trigger != trigger:
+                continue
+            skills.append(skill)
+        return skills
+
+    def get_skill(self, name: str) -> Skill | None:
+        """Get a skill by name. Returns None if not found."""
+        skill_file = self._dir / name / "SKILL.md"
+        if not skill_file.is_file():
+            return None
+        try:
+            return self._parse_skill_md(skill_file)
+        except Exception:
+            return None
+
+    def save_skill(self, skill: Skill) -> Path:
+        """Create or update a skill directory with SKILL.md. Returns the file path."""
+        skill_dir = self._dir / skill.name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text(self._render_skill_md(skill))
+        return skill_file
+
+    def delete_skill(self, name: str) -> bool:
+        """Delete a skill directory. Returns True if it existed."""
+        skill_dir = self._dir / name
+        if not skill_dir.is_dir():
+            return False
+        shutil.rmtree(skill_dir)
+        return True
+
+    def _parse_skill_md(self, path: Path) -> Skill:
+        """Parse a SKILL.md file into a Skill model."""
+        content = path.read_text()
+        if not content.startswith("---"):
+            raise ValueError(f"Missing YAML frontmatter in {path}")
+
+        # Split frontmatter from body
+        parts = content.split("---", 2)
+        if len(parts) < 3:
+            raise ValueError(f"Invalid frontmatter format in {path}")
+
+        frontmatter = yaml.safe_load(parts[1]) or {}
+        body = parts[2].strip()
+
+        # Directory name is the canonical slug
+        dir_name = path.parent.name
+
+        # Squire-specific fields live under metadata (spec-compliant)
+        meta = frontmatter.get("metadata") or {}
+
+        return Skill(
+            name=frontmatter.get("name", dir_name),
+            description=frontmatter.get("description", ""),
+            host=meta.get("host", "all"),
+            trigger=meta.get("trigger", "manual"),
+            enabled=meta.get("enabled", True),
+            instructions=body,
+        )
+
+    def _render_skill_md(self, skill: Skill) -> str:
+        """Serialize a Skill model back to SKILL.md format.
+
+        Produces spec-compliant frontmatter: ``name`` and ``description`` at
+        the top level, Squire-specific fields under ``metadata``.
+        """
+        frontmatter: dict = {
+            "name": skill.name,
+            "description": skill.description,
+        }
+        metadata: dict = {}
+        if skill.host != "all":
+            metadata["host"] = skill.host
+        if skill.trigger != "manual":
+            metadata["trigger"] = skill.trigger
+        if not skill.enabled:
+            metadata["enabled"] = skill.enabled
+        if metadata:
+            frontmatter["metadata"] = metadata
+        fm_str = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False).strip()
+        return f"---\n{fm_str}\n---\n\n{skill.instructions}\n"

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -27,6 +27,7 @@ from .config import (
     GuardrailsConfig,
     LLMConfig,
     NotificationsConfig,
+    SkillsConfig,
     WatchConfig,
 )
 from .config.hosts import HostConfig
@@ -71,6 +72,7 @@ async def start_watch() -> None:
     db_config = DatabaseConfig()
     notif_config = NotificationsConfig()
     watch_config = WatchConfig()
+    skills_config = SkillsConfig()
 
     # Load host configuration and create backend registry
     host_dicts = get_list_section("hosts")
@@ -216,6 +218,27 @@ async def start_watch() -> None:
                     "Adjust your approach if needed (e.g. skip unavailable tools).\n\n"
                     f"{prompt}"
                 )
+
+            # Append watch-triggered skills
+            try:
+                from .skills import SkillService
+
+                skill_service = SkillService(skills_config.path)
+                watch_skills = skill_service.list_skills(enabled_only=True, trigger="watch")
+                if watch_skills:
+                    skill_sections = []
+                    for sk in watch_skills:
+                        if not sk.instructions:
+                            continue
+                        host_label = sk.host
+                        skill_sections.append(f"### Skill: {sk.name} (host: {host_label})\n{sk.instructions}")
+                    if skill_sections:
+                        prompt += (
+                            "\n\nIn addition to your routine check-in, execute the following skills:\n\n"
+                            + "\n\n".join(skill_sections)
+                        )
+            except Exception:
+                logger.debug("Failed to load watch skills", exc_info=True)
 
             # Run the watch cycle
             try:

--- a/tests/test_skill_markers.py
+++ b/tests/test_skill_markers.py
@@ -1,0 +1,26 @@
+"""Tests for skill execution completion marker parsing."""
+
+from squire.api.routers.chat import _is_skill_complete
+
+
+class TestIsSkillComplete:
+    def test_marker_present(self):
+        assert _is_skill_complete("Summary of results.\n[SKILL COMPLETE]") is True
+
+    def test_marker_absent(self):
+        assert _is_skill_complete("Still working on things.") is False
+
+    def test_case_insensitive(self):
+        assert _is_skill_complete("[skill complete]") is True
+        assert _is_skill_complete("[Skill Complete]") is True
+
+    def test_embedded_in_text(self):
+        text = "All done. Here is the summary:\n- OK\n[SKILL COMPLETE]\n"
+        assert _is_skill_complete(text) is True
+
+    def test_extra_whitespace(self):
+        assert _is_skill_complete("[SKILL  COMPLETE]") is True
+
+    def test_partial_match_is_not_complete(self):
+        assert _is_skill_complete("[SKILL") is False
+        assert _is_skill_complete("SKILL COMPLETE") is False

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,189 @@
+"""Tests for SkillService — file-based skill CRUD."""
+
+import pytest
+from pydantic import ValidationError
+
+from squire.skills import Skill, SkillService
+
+
+@pytest.fixture
+def skill_service(tmp_path):
+    """Provide a SkillService backed by a temporary directory."""
+    return SkillService(tmp_path)
+
+
+def _make_skill(**kwargs) -> Skill:
+    """Create a Skill with sensible defaults."""
+    defaults = {
+        "name": "test-skill",
+        "description": "A test skill",
+        "host": "all",
+        "trigger": "manual",
+        "enabled": True,
+        "instructions": "Check the status of all containers.",
+    }
+    defaults.update(kwargs)
+    return Skill(**defaults)
+
+
+class TestSaveAndGet:
+    def test_roundtrip(self, skill_service):
+        skill = _make_skill()
+        skill_service.save_skill(skill)
+        loaded = skill_service.get_skill("test-skill")
+        assert loaded is not None
+        assert loaded.name == "test-skill"
+        assert loaded.description == "A test skill"
+        assert loaded.host == "all"
+        assert loaded.trigger == "manual"
+        assert loaded.enabled is True
+        assert loaded.instructions == "Check the status of all containers."
+
+    def test_get_not_found(self, skill_service):
+        assert skill_service.get_skill("nonexistent") is None
+
+    def test_overwrite(self, skill_service):
+        skill = _make_skill(description="v1")
+        skill_service.save_skill(skill)
+        updated = skill.model_copy(update={"description": "v2"})
+        skill_service.save_skill(updated)
+        loaded = skill_service.get_skill("test-skill")
+        assert loaded.description == "v2"
+
+
+class TestListSkills:
+    def test_empty_dir(self, skill_service):
+        assert skill_service.list_skills() == []
+
+    def test_nonexistent_dir(self, tmp_path):
+        service = SkillService(tmp_path / "does-not-exist")
+        assert service.list_skills() == []
+
+    def test_list_all(self, skill_service):
+        skill_service.save_skill(_make_skill(name="alpha"))
+        skill_service.save_skill(_make_skill(name="beta"))
+        skills = skill_service.list_skills()
+        assert len(skills) == 2
+        names = {s.name for s in skills}
+        assert names == {"alpha", "beta"}
+
+    def test_filter_enabled_only(self, skill_service):
+        skill_service.save_skill(_make_skill(name="on", enabled=True))
+        skill_service.save_skill(_make_skill(name="off", enabled=False))
+        enabled = skill_service.list_skills(enabled_only=True)
+        assert len(enabled) == 1
+        assert enabled[0].name == "on"
+
+    def test_filter_trigger(self, skill_service):
+        skill_service.save_skill(_make_skill(name="manual-skill", trigger="manual"))
+        skill_service.save_skill(_make_skill(name="watch-skill", trigger="watch"))
+        watch = skill_service.list_skills(trigger="watch")
+        assert len(watch) == 1
+        assert watch[0].name == "watch-skill"
+
+    def test_combined_filters(self, skill_service):
+        skill_service.save_skill(_make_skill(name="a", trigger="watch", enabled=True))
+        skill_service.save_skill(_make_skill(name="b", trigger="watch", enabled=False))
+        skill_service.save_skill(_make_skill(name="c", trigger="manual", enabled=True))
+        result = skill_service.list_skills(enabled_only=True, trigger="watch")
+        assert len(result) == 1
+        assert result[0].name == "a"
+
+
+class TestDeleteSkill:
+    def test_delete_existing(self, skill_service):
+        skill_service.save_skill(_make_skill(name="to-delete"))
+        assert skill_service.delete_skill("to-delete") is True
+        assert skill_service.get_skill("to-delete") is None
+
+    def test_delete_not_found(self, skill_service):
+        assert skill_service.delete_skill("ghost") is False
+
+
+class TestParsing:
+    def test_malformed_frontmatter_skipped_in_list(self, skill_service, tmp_path):
+        """A directory with a malformed SKILL.md is silently skipped."""
+        bad_dir = tmp_path / "bad-skill"
+        bad_dir.mkdir()
+        (bad_dir / "SKILL.md").write_text("no frontmatter here")
+        skills = skill_service.list_skills()
+        assert len(skills) == 0
+
+    def test_missing_name_uses_directory(self, skill_service, tmp_path):
+        """If name is missing from frontmatter, use directory name."""
+        skill_dir = tmp_path / "dir-name"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\ndescription: test\n---\n\nDo something.")
+        skill = skill_service.get_skill("dir-name")
+        assert skill is not None
+        assert skill.name == "dir-name"
+        assert skill.instructions == "Do something."
+
+    def test_multiline_instructions(self, skill_service):
+        instructions = "Step 1: Check containers.\n\nStep 2: Restart if needed.\n\n- Item A\n- Item B"
+        skill = _make_skill(instructions=instructions)
+        skill_service.save_skill(skill)
+        loaded = skill_service.get_skill("test-skill")
+        assert loaded.instructions == instructions
+
+    def test_metadata_roundtrip(self, skill_service):
+        """Squire-specific fields survive a save/load cycle via metadata."""
+        skill = _make_skill(host="prod-01", trigger="watch", enabled=False)
+        skill_service.save_skill(skill)
+        loaded = skill_service.get_skill("test-skill")
+        assert loaded.host == "prod-01"
+        assert loaded.trigger == "watch"
+        assert loaded.enabled is False
+
+    def test_default_metadata_omitted(self, skill_service, tmp_path):
+        """When host/trigger/enabled are defaults, metadata key is omitted."""
+        skill = _make_skill()
+        skill_service.save_skill(skill)
+        content = (tmp_path / "test-skill" / "SKILL.md").read_text()
+        assert "metadata:" not in content
+
+    def test_spec_compliant_frontmatter(self, skill_service, tmp_path):
+        """Rendered SKILL.md has name/description at top level, custom fields under metadata."""
+        skill = _make_skill(host="nas", trigger="watch")
+        skill_service.save_skill(skill)
+        content = (tmp_path / "test-skill" / "SKILL.md").read_text()
+        assert content.startswith("---\n")
+        assert "name: test-skill\n" in content
+        assert "description: A test skill\n" in content
+        assert "metadata:\n" in content
+        assert "  host: nas\n" in content
+        assert "  trigger: watch\n" in content
+
+
+class TestNameValidation:
+    def test_valid_names(self):
+        for name in ("a", "abc", "my-skill", "check-containers-v2", "a1b2"):
+            Skill(name=name, description="test")
+
+    def test_uppercase_rejected(self):
+        with pytest.raises(ValidationError):
+            Skill(name="My-Skill", description="test")
+
+    def test_leading_hyphen_rejected(self):
+        with pytest.raises(ValidationError):
+            Skill(name="-bad", description="test")
+
+    def test_trailing_hyphen_rejected(self):
+        with pytest.raises(ValidationError):
+            Skill(name="bad-", description="test")
+
+    def test_consecutive_hyphens_rejected(self):
+        with pytest.raises(ValidationError):
+            Skill(name="bad--name", description="test")
+
+    def test_spaces_rejected(self):
+        with pytest.raises(ValidationError):
+            Skill(name="bad name", description="test")
+
+    def test_too_long_rejected(self):
+        with pytest.raises(ValidationError):
+            Skill(name="a" * 65, description="test")
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValidationError):
+            Skill(name="", description="test")

--- a/uv.lock
+++ b/uv.lock
@@ -2990,7 +2990,7 @@ wheels = [
 
 [[package]]
 name = "squire"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-risk-engine" },
@@ -3003,6 +3003,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "rich" },
     { name = "textual" },
     { name = "typer" },
@@ -3029,6 +3030,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "textual", specifier = ">=0.80.0" },
     { name = "typer", specifier = ">=0.12.0" },

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -90,9 +90,12 @@ function ChatPageInner() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const resumeSessionId = searchParams.get("session");
+  const skillName = searchParams.get("skill");
 
-  // Restore session from sessionStorage if no explicit session param
+  // Restore session from sessionStorage if no explicit session param.
+  // When executing a skill, always start fresh (don't reuse old session).
   const [sessionId, setSessionId] = useState<string | null>(() => {
+    if (skillName) return null;
     if (resumeSessionId) return resumeSessionId;
     if (typeof window !== "undefined") {
       return sessionStorage.getItem(SESSION_KEY);
@@ -143,7 +146,8 @@ function ChatPageInner() {
       });
   }, [sessionId, historyLoaded]);
 
-  const { status, send, setOnMessage } = useWebSocket(sessionId);
+  const wsQueryParams = skillName ? { skill: skillName } : undefined;
+  const { status, send, setOnMessage } = useWebSocket(sessionId, wsQueryParams);
 
   // Handle incoming WS messages
   useEffect(() => {
@@ -255,6 +259,21 @@ function ChatPageInner() {
       }
     });
   }, [setOnMessage]);
+
+  // Auto-send initial message for skill execution once WebSocket connects.
+  const skillSentRef = useRef(false);
+  useEffect(() => {
+    if (!skillName || skillSentRef.current || status !== "connected") return;
+    skillSentRef.current = true;
+    const text = `Execute your active skill "${skillName}" now. Use your tools.`;
+    const displayText = `Execute skill "${skillName}"`;
+    setMessages((prev) => [
+      ...prev,
+      { id: nextId(), role: "user", content: displayText },
+    ]);
+    setAgentState("thinking");
+    send({ type: "message", content: text });
+  }, [skillName, status, send]);
 
   // Create a new session if needed
   useEffect(() => {

--- a/web/src/app/skills/page.tsx
+++ b/web/src/app/skills/page.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import useSWR from "swr";
+import { useRouter } from "next/navigation";
+import { apiGet, apiPost, apiPut, apiDelete } from "@/lib/api";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { SkillForm } from "@/components/skills/skill-form";
+import {
+  ListChecks,
+  Plus,
+  Pencil,
+  Trash2,
+  Play,
+  ToggleLeft,
+  ToggleRight,
+} from "lucide-react";
+import type { Skill } from "@/lib/types";
+
+export default function SkillsPage() {
+  const router = useRouter();
+  const { data: skills, mutate } = useSWR("/api/skills", () =>
+    apiGet<Skill[]>("/api/skills")
+  );
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
+
+  const handleCreate = async (data: {
+    name: string;
+    description: string;
+    host: string;
+    trigger: string;
+    instructions: string;
+  }) => {
+    await apiPost("/api/skills", data);
+    setFormOpen(false);
+    mutate();
+  };
+
+  const handleUpdate = async (data: {
+    name: string;
+    description: string;
+    host: string;
+    trigger: string;
+    instructions: string;
+  }) => {
+    const { name, ...rest } = data;
+    await apiPut(`/api/skills/${name}`, rest);
+    setEditingSkill(null);
+    mutate();
+  };
+
+  const handleDelete = async (name: string) => {
+    if (!confirm(`Delete skill "${name}"?`)) return;
+    await apiDelete(`/api/skills/${name}`);
+    mutate();
+  };
+
+  const handleToggle = async (name: string) => {
+    await apiPost(`/api/skills/${name}/toggle`);
+    mutate();
+  };
+
+  const handleExecute = async (name: string) => {
+    const result = await apiPost<{ skill_name: string; instructions: string }>(
+      `/api/skills/${encodeURIComponent(name)}/execute`
+    );
+    router.push(
+      `/chat?skill=${encodeURIComponent(result.skill_name)}`
+    );
+  };
+
+  return (
+    <div className="space-y-6 animate-fade-in">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl">Skills</h1>
+          {skills && skills.length > 0 && (
+            <Badge variant="secondary">{skills.length}</Badge>
+          )}
+        </div>
+        <Button size="sm" onClick={() => setFormOpen(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          New Skill
+        </Button>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        Define instructions for Squire to follow. Skills can be executed manually
+        or attached to watch mode for automated checks.
+      </p>
+
+      {!skills || skills.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground gap-2">
+          <ListChecks className="h-8 w-8" />
+          <p className="text-sm">No skills configured</p>
+          <p className="text-xs">
+            Create a skill to give Squire guided, repeatable behavior.
+          </p>
+        </div>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Host</TableHead>
+              <TableHead>Trigger</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {skills.map((s) => (
+              <TableRow key={s.name} className="hover:bg-muted/50">
+                <TableCell className="font-medium">{s.name}</TableCell>
+                <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
+                  {s.description || "-"}
+                </TableCell>
+                <TableCell className="text-sm">{s.host}</TableCell>
+                <TableCell>
+                  <Badge variant={s.trigger === "watch" ? "secondary" : "outline"}>
+                    {s.trigger}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={s.enabled ? "default" : "outline"}>
+                    {s.enabled ? "enabled" : "disabled"}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="Execute"
+                      disabled={!s.enabled}
+                      onClick={() => handleExecute(s.name)}
+                    >
+                      <Play className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="Edit"
+                      onClick={() => setEditingSkill(s)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title={s.enabled ? "Disable" : "Enable"}
+                      onClick={() => handleToggle(s.name)}
+                    >
+                      {s.enabled ? (
+                        <ToggleRight className="h-4 w-4" />
+                      ) : (
+                        <ToggleLeft className="h-4 w-4 text-muted-foreground" />
+                      )}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="Delete"
+                      onClick={() => handleDelete(s.name)}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <SkillForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        onSubmit={handleCreate}
+      />
+
+      {editingSkill && (
+        <SkillForm
+          open={!!editingSkill}
+          onOpenChange={(open) => {
+            if (!open) setEditingSkill(null);
+          }}
+          onSubmit={handleUpdate}
+          skill={editingSkill}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/chat/message-bubble.tsx
+++ b/web/src/components/chat/message-bubble.tsx
@@ -7,6 +7,12 @@ import { cn } from "@/lib/utils";
 import type { ChatMessage } from "./message-list";
 import { User, Wrench } from "lucide-react";
 
+const SKILL_MARKER_RE = /^\[SKILL\s+COMPLETE\]\s*$/gim;
+
+function stripSkillMarkers(text: string): string {
+  return text.replace(SKILL_MARKER_RE, "").replace(/\n{3,}/g, "\n\n").trim();
+}
+
 interface MessageBubbleProps {
   message: ChatMessage;
 }
@@ -96,7 +102,7 @@ export function MessageBubble({ message }: MessageBubbleProps) {
                 },
               }}
             >
-              {content}
+              {stripSkillMarkers(content)}
             </ReactMarkdown>
           </div>
         )}

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Settings,
   Activity,
   History,
+  ListChecks,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -16,6 +17,7 @@ const mainNav = [
   { href: "/chat", label: "Chat", icon: MessageSquare },
   { href: "/activity", label: "Activity", icon: Activity },
   { href: "/sessions", label: "Sessions", icon: History },
+  { href: "/skills", label: "Skills", icon: ListChecks },
 ];
 
 const systemNav = [

--- a/web/src/components/skills/skill-form.tsx
+++ b/web/src/components/skills/skill-form.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Skill } from "@/lib/types";
+
+interface SkillFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: {
+    name: string;
+    description: string;
+    host: string;
+    trigger: string;
+    instructions: string;
+  }) => void;
+  skill?: Skill | null;
+}
+
+export function SkillForm({ open, onOpenChange, onSubmit, skill }: SkillFormProps) {
+  const [name, setName] = useState(skill?.name ?? "");
+  const [description, setDescription] = useState(skill?.description ?? "");
+  const [host, setHost] = useState(skill?.host ?? "all");
+  const [trigger, setTrigger] = useState(skill?.trigger ?? "manual");
+  const [instructions, setInstructions] = useState(skill?.instructions ?? "");
+
+  const isEdit = !!skill;
+
+  const namePattern = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+  const isNameValid = name.trim().length > 0 && name.trim().length <= 64
+    && namePattern.test(name.trim()) && !name.includes("--");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!isNameValid || !description.trim() || !instructions.trim()) return;
+    onSubmit({
+      name: name.trim(),
+      description: description.trim(),
+      host,
+      trigger,
+      instructions: instructions.trim(),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-h-[85vh] overflow-y-auto">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{isEdit ? "Edit Skill" : "New Skill"}</DialogTitle>
+            <DialogDescription>
+              {isEdit
+                ? "Update the skill configuration and instructions."
+                : "Define instructions for Squire to follow."}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="skill-name">Name</Label>
+              <Input
+                id="skill-name"
+                value={name}
+                onChange={(e) => setName(e.target.value.toLowerCase())}
+                placeholder="restart-on-error"
+                disabled={isEdit}
+                required
+              />
+              {!isEdit && name && !isNameValid && (
+                <p className="text-xs text-destructive">
+                  Lowercase letters, numbers, and hyphens only (max 64 chars).
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="skill-desc">Description</Label>
+              <Input
+                id="skill-desc"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What this skill does and when to use it..."
+                required
+              />
+            </div>
+
+            <div className="flex gap-4">
+              <div className="space-y-2 flex-1">
+                <Label>Host</Label>
+                <Input
+                  value={host}
+                  onChange={(e) => setHost(e.target.value)}
+                  placeholder="all"
+                />
+              </div>
+              <div className="space-y-2 flex-1">
+                <Label>Trigger</Label>
+                <Select value={trigger} onValueChange={(v) => setTrigger(v ?? "manual")}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="manual">Manual</SelectItem>
+                    <SelectItem value="watch">Watch</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="skill-instructions">Instructions</Label>
+              <Textarea
+                id="skill-instructions"
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                placeholder="Check the status of all Docker containers on the target host..."
+                rows={10}
+                className="font-mono text-sm"
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                Freeform Markdown instructions for the agent to follow.
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit">{isEdit ? "Update" : "Create"}</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/hooks/use-websocket.ts
+++ b/web/src/hooks/use-websocket.ts
@@ -9,7 +9,7 @@ export type WsStatus = "connecting" | "connected" | "disconnected";
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 1000;
 
-export function useWebSocket(sessionId: string | null) {
+export function useWebSocket(sessionId: string | null, queryParams?: Record<string, string>) {
   const wsRef = useRef<WebSocket | null>(null);
   const [status, setStatus] = useState<WsStatus>("disconnected");
   const onMessageRef = useRef<((msg: WsServerMessage) => void) | null>(null);
@@ -18,13 +18,22 @@ export function useWebSocket(sessionId: string | null) {
   // Track intentional close to avoid reconnecting on unmount
   const intentionalCloseRef = useRef(false);
 
+  // Serialize queryParams to a stable string for the dependency array
+  const queryString = queryParams
+    ? Object.entries(queryParams)
+        .filter(([, v]) => v)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join("&")
+    : "";
+
   useEffect(() => {
     if (!sessionId) return;
 
     intentionalCloseRef.current = false;
 
     function connect() {
-      const ws = new WebSocket(wsUrl(`/api/chat/ws/${sessionId}`));
+      const qs = queryString ? `?${queryString}` : "";
+      const ws = new WebSocket(wsUrl(`/api/chat/ws/${sessionId}${qs}`));
       wsRef.current = ws;
       setStatus("connecting");
 
@@ -75,7 +84,7 @@ export function useWebSocket(sessionId: string | null) {
       wsRef.current?.close();
       wsRef.current = null;
     };
-  }, [sessionId]);
+  }, [sessionId, queryString]);
 
   const send = useCallback(
     (data: Record<string, unknown>) => {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -63,6 +63,15 @@ export interface AlertRule {
   created_at?: string;
 }
 
+export interface Skill {
+  name: string;
+  description: string;
+  host: string;
+  trigger: string;
+  enabled: boolean;
+  instructions: string;
+}
+
 export interface EventInfo {
   id?: number;
   timestamp: string;


### PR DESCRIPTION
## Summary

- **Replace database-backed runbooks with file-based skills** aligned with the [Open Agent Skills spec](https://agentskills.io/specification). Each skill is a `SKILL.md` directory with YAML frontmatter + freeform Markdown instructions — version-controllable, no database required.
- **Spec-compliant format**: `name` and `description` at the top level (required), Squire-specific fields (`host`, `trigger`, `enabled`) under `metadata`. Name validation enforces lowercase alphanumeric + hyphens, max 64 chars.
- **Full stack**: SkillService (file CRUD), SkillsConfig (`~/.local/share/squire/skills`), REST API (`/api/skills`), CLI (`squire skills`), web UI (`/skills` page with form dialog + execute → chat), watch mode integration, and system prompt injection with host targeting.

### Breaking changes
- `squire runbooks` CLI commands → `squire skills`
- `/api/runbooks` endpoints → `/api/skills`
- WebSocket `?runbook=` query param → `?skill=`
- `[STEP N COMPLETE]` / `[RUNBOOK COMPLETE]` markers → single `[SKILL COMPLETE]`
- Runbook DB tables left in place but no longer queried

## Test plan

- [x] `make ci` — 204 tests pass (lint + format + pytest)
- [x] `make web-build` — frontend compiles with `/skills` route
- [x] Manual: create a skill via CLI (`squire skills add`), verify SKILL.md written to disk
- [x] Manual: execute from web UI, verify agent uses tools and loop stops at `[SKILL COMPLETE]`
- [x] Manual: verify `[SKILL COMPLETE]` marker stripped from chat bubbles
- [ ] Manual: verify watch mode picks up `trigger: watch` skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)