### PR TITLE
feat(config): allow editing and applying configuration from the Web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Runtime config editing from Web UI** — the `/config` page is now editable instead of read-only
+  - `PATCH /api/config/{section}` endpoint for app, llm, watch, guardrails, and notifications sections
+  - Per-section editable forms with appropriate input types (selects, switches, tag inputs)
+  - Env-var-override detection — locked fields show a lock icon with the env var name
+  - Optional persist-to-disk via `?persist=true` query parameter (writes back to `squire.toml` preserving comments)
+  - Redacted sentinel values (`••••••`) are automatically preserved during webhook updates
+  - Enriched `GET /api/config` response with `env_overrides` per section and `toml_path`
 - **Host enrollment system** — Squire generates dedicated SSH keys per host and manages the full lifecycle
   - `squire hosts add` / `remove` / `list` / `verify` CLI commands
   - Web UI host enrollment form with public key display for manual setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "asyncssh>=2.17.0",
     "pyyaml>=6.0",
     "agent-risk-engine>=0.2.0",
+    "tomlkit>=0.13.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
 ]

--- a/src/squire/api/routers/config.py
+++ b/src/squire/api/routers/config.py
@@ -1,10 +1,27 @@
 """Configuration endpoints."""
 
-from fastapi import APIRouter, Depends
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from squire.config import AppConfig, GuardrailsConfig, LLMConfig, NotificationsConfig, WatchConfig
+from squire.config.loader import get_env_overrides, get_toml_path, write_toml_section
+from squire.config.notifications import WebhookConfig
+from squire.notifications.webhook import WebhookDispatcher
 
 from .. import dependencies as deps
 from ..dependencies import get_app_config, get_llm_config
-from ..schemas import ConfigResponse
+from ..schemas import (
+    AppConfigUpdate,
+    ConfigDetailResponse,
+    ConfigSectionMeta,
+    GuardrailsConfigUpdate,
+    LLMConfigUpdate,
+    NotificationsConfigUpdate,
+    WatchConfigPatch,
+)
 
 router = APIRouter()
 
@@ -29,7 +46,59 @@ def _redact_notifications(data: dict) -> dict:
     return data
 
 
-@router.get("", response_model=ConfigResponse)
+# --- Section dispatch registry ---
+
+
+@dataclass
+class _SectionInfo:
+    attr: str  # attribute name on deps module
+    config_cls: type
+    update_cls: type[BaseModel]
+    env_prefix: str
+    toml_section: str | None  # None = top-level keys
+    redact: Callable | None = None
+
+
+_SECTIONS: dict[str, _SectionInfo] = {
+    "app": _SectionInfo("app_config", AppConfig, AppConfigUpdate, "SQUIRE_", None),
+    "llm": _SectionInfo("llm_config", LLMConfig, LLMConfigUpdate, "SQUIRE_LLM_", "llm", _redact_llm),
+    "watch": _SectionInfo("watch_config", WatchConfig, WatchConfigPatch, "SQUIRE_WATCH_", "watch"),
+    "guardrails": _SectionInfo(
+        "guardrails",
+        GuardrailsConfig,
+        GuardrailsConfigUpdate,
+        "SQUIRE_GUARDRAILS_",
+        "guardrails",
+    ),
+    "notifications": _SectionInfo(
+        "notif_config",
+        NotificationsConfig,
+        NotificationsConfigUpdate,
+        "SQUIRE_NOTIFICATIONS_",
+        "notifications",
+        _redact_notifications,
+    ),
+}
+
+_IMMUTABLE_SECTIONS = {"database", "hosts", "skills"}
+
+
+def _section_meta(attr: str, info: _SectionInfo) -> ConfigSectionMeta:
+    """Build a ConfigSectionMeta for a config singleton."""
+    cfg = getattr(deps, attr, None)
+    if cfg is None:
+        return ConfigSectionMeta(values={}, env_overrides=[])
+    values = cfg.model_dump(mode="json")
+    if info.redact:
+        values = info.redact(values)
+    env_overrides = get_env_overrides(info.env_prefix, type(cfg).model_fields.keys())
+    return ConfigSectionMeta(values=values, env_overrides=env_overrides)
+
+
+# --- GET ---
+
+
+@router.get("", response_model=ConfigDetailResponse)
 async def get_config(
     app_config=Depends(get_app_config),
     llm_config=Depends(get_llm_config),
@@ -40,12 +109,116 @@ async def get_config(
         hosts = await deps.host_store.list_hosts()
         host_configs = [h.model_dump(mode="json") for h in hosts]
 
-    return ConfigResponse(
-        app=app_config.model_dump(mode="json"),
-        llm=_redact_llm(llm_config.model_dump(mode="json")),
-        database=deps.db_config.model_dump(mode="json") if deps.db_config else {},
-        notifications=_redact_notifications(deps.notif_config.model_dump(mode="json") if deps.notif_config else {}),
-        guardrails=deps.guardrails.model_dump(mode="json") if deps.guardrails else {},
-        watch=deps.watch_config.model_dump(mode="json") if deps.watch_config else {},
+    toml_path = get_toml_path()
+
+    return ConfigDetailResponse(
+        app=_section_meta("app_config", _SECTIONS["app"]),
+        llm=_section_meta("llm_config", _SECTIONS["llm"]),
+        database=ConfigSectionMeta(
+            values=deps.db_config.model_dump(mode="json") if deps.db_config else {},
+            env_overrides=(
+                get_env_overrides("SQUIRE_DB_", type(deps.db_config).model_fields.keys()) if deps.db_config else []
+            ),
+        ),
+        notifications=_section_meta("notif_config", _SECTIONS["notifications"]),
+        guardrails=_section_meta("guardrails", _SECTIONS["guardrails"]),
+        watch=_section_meta("watch_config", _SECTIONS["watch"]),
         hosts=host_configs,
+        toml_path=str(toml_path) if toml_path else None,
     )
+
+
+# --- PATCH ---
+
+
+def _merge_webhooks(existing: list[WebhookConfig], incoming: list[dict]) -> list[WebhookConfig]:
+    """Merge incoming webhook dicts with existing webhooks, preserving redacted fields."""
+    existing_by_name = {wh.name: wh for wh in existing}
+    result = []
+    for wh_dict in incoming:
+        name = wh_dict.get("name", "")
+        old = existing_by_name.get(name)
+        if old:
+            # Preserve redacted URL/headers from existing webhook
+            if wh_dict.get("url") == _REDACTED:
+                wh_dict["url"] = old.url
+            headers = wh_dict.get("headers", {})
+            if headers:
+                for k, v in headers.items():
+                    if v == _REDACTED and k in old.headers:
+                        headers[k] = old.headers[k]
+                wh_dict["headers"] = headers
+        result.append(WebhookConfig(**wh_dict))
+    return result
+
+
+@router.patch("/{section}")
+async def patch_config(
+    section: str,
+    body: dict = Body(...),
+    persist: bool = Query(False),
+):
+    """Update a configuration section at runtime.
+
+    Only changed fields need to be sent. Use ``?persist=true`` to also write to squire.toml.
+    """
+    if section in _IMMUTABLE_SECTIONS:
+        raise HTTPException(status_code=404, detail=f"Section '{section}' is not mutable at runtime")
+    info = _SECTIONS.get(section)
+    if info is None:
+        raise HTTPException(status_code=404, detail=f"Unknown config section '{section}'")
+
+    # Strip redacted sentinel values before validation (they may not parse as the target type)
+    cleaned = {k: v for k, v in body.items() if v != _REDACTED}
+
+    # Parse and validate through the update schema
+    update = info.update_cls.model_validate(cleaned)
+    fields = update.model_dump(exclude_none=True)
+
+    if not fields:
+        raise HTTPException(status_code=400, detail="No fields to update")
+
+    # Check for env-overridden fields
+    current = getattr(deps, info.attr)
+    locked = get_env_overrides(info.env_prefix, fields.keys())
+    if locked:
+        env_vars = [f"{info.env_prefix}{f.upper()}" for f in locked]
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot update env-var-overridden fields: {', '.join(env_vars)}",
+        )
+
+    # Special handling for notifications webhooks
+    if section == "notifications" and "webhooks" in fields:
+        fields["webhooks"] = _merge_webhooks(current.webhooks, fields["webhooks"])
+
+    # Create new config instance with updated fields
+    new_config = current.model_copy(update=fields)
+
+    # Replace the singleton
+    setattr(deps, info.attr, new_config)
+
+    # Recreate notifier if notifications changed
+    if section == "notifications" and deps.notifier is not None:
+        deps.notifier = WebhookDispatcher(new_config)
+
+    # Persist to TOML if requested
+    persist_path = None
+    if persist:
+        # For notifications webhooks, serialize back to dicts
+        persist_data = {}
+        for k, v in fields.items():
+            if k == "webhooks":
+                persist_data[k] = [wh.model_dump() if hasattr(wh, "model_dump") else wh for wh in v]
+            else:
+                persist_data[k] = v
+        persist_path = write_toml_section(info.toml_section, persist_data)
+
+    values = new_config.model_dump(mode="json")
+    if info.redact:
+        values = info.redact(values)
+
+    return {
+        "values": values,
+        "persisted": str(persist_path) if persist_path else None,
+    }

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -180,6 +180,62 @@ class ConfigResponse(BaseModel):
     hosts: list[dict]
 
 
+class ConfigSectionMeta(BaseModel):
+    values: dict
+    env_overrides: list[str] = []
+
+
+class ConfigDetailResponse(BaseModel):
+    app: ConfigSectionMeta
+    llm: ConfigSectionMeta
+    database: ConfigSectionMeta
+    notifications: ConfigSectionMeta
+    guardrails: ConfigSectionMeta
+    watch: ConfigSectionMeta
+    hosts: list[dict]
+    toml_path: str | None = None
+
+
+class AppConfigUpdate(BaseModel):
+    risk_tolerance: str | None = None
+    risk_strict: bool | None = None
+    history_limit: int | None = None
+    max_tool_rounds: int | None = None
+    multi_agent: bool | None = None
+
+
+class LLMConfigUpdate(BaseModel):
+    model: str | None = None
+    temperature: float | None = None
+    max_tokens: int | None = None
+
+
+class WatchConfigPatch(BaseModel):
+    interval_minutes: int | None = None
+    cycle_timeout_seconds: int | None = None
+    checkin_prompt: str | None = None
+    notify_on_action: bool | None = None
+    notify_on_blocked: bool | None = None
+
+
+class GuardrailsConfigUpdate(BaseModel):
+    tools_allow: list[str] | None = None
+    tools_require_approval: list[str] | None = None
+    tools_deny: list[str] | None = None
+    monitor_tolerance: str | None = None
+    container_tolerance: str | None = None
+    admin_tolerance: str | None = None
+    notifier_tolerance: str | None = None
+    watch_tolerance: str | None = None
+    watch_tools_allow: list[str] | None = None
+    watch_tools_deny: list[str] | None = None
+
+
+class NotificationsConfigUpdate(BaseModel):
+    enabled: bool | None = None
+    webhooks: list[dict] | None = None
+
+
 # --- Watch ---
 
 

--- a/src/squire/config/loader.py
+++ b/src/squire/config/loader.py
@@ -10,11 +10,13 @@ Search order:
   3. /etc/squire/squire.toml (system-wide)
 """
 
+import os
 import tomllib
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
+import tomlkit
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
 
 _SEARCH_PATHS = [
@@ -73,6 +75,68 @@ def get_top_level() -> dict:
     """Get top-level keys (everything not in a sub-table)."""
     data = _load_toml()
     return {k: v for k, v in data.items() if not isinstance(v, (dict, list))}
+
+
+def invalidate_cache() -> None:
+    """Clear the cached TOML data so the next read reloads from disk."""
+    global _cached
+    _cached = None
+
+
+def get_toml_path() -> Path | None:
+    """Return the path of the first existing squire.toml, or None."""
+    for path in _SEARCH_PATHS:
+        if path.is_file():
+            return path.resolve()
+    return None
+
+
+def get_env_overrides(prefix: str, field_names: Iterable[str]) -> list[str]:
+    """Return field names whose values are currently set via environment variables."""
+    overridden = []
+    for name in field_names:
+        env_key = f"{prefix}{name.upper()}"
+        if env_key in os.environ:
+            overridden.append(name)
+    return overridden
+
+
+def write_toml_section(section: str | None, data: dict) -> Path:
+    """Write config values to the TOML file, preserving comments and formatting.
+
+    Args:
+        section: TOML section name (e.g. ``"llm"``), or ``None`` for top-level keys.
+        data: Field names and values to write.
+
+    Returns:
+        Path to the written file.
+    """
+    path = get_toml_path()
+    if path is None:
+        # Create at the first search path location (project-local by default)
+        path = _SEARCH_PATHS[0].resolve()
+
+    if path.is_file():
+        with open(path) as f:
+            doc = tomlkit.load(f)
+    else:
+        doc = tomlkit.document()
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    if section is None:
+        for k, v in data.items():
+            doc[k] = v
+    else:
+        if section not in doc:
+            doc[section] = tomlkit.table()
+        for k, v in data.items():
+            doc[section][k] = v
+
+    with open(path, "w") as f:
+        tomlkit.dump(doc, f)
+
+    invalidate_cache()
+    return path
 
 
 class TomlSectionSource(PydanticBaseSettingsSource):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,13 @@
 
 import squire.config.loader as loader_mod
 from squire.config import AppConfig, DatabaseConfig, GuardrailsConfig, HostConfig, LLMConfig, NotificationsConfig
-from squire.config.loader import get_list_section
+from squire.config.loader import (
+    get_env_overrides,
+    get_list_section,
+    get_toml_path,
+    invalidate_cache,
+    write_toml_section,
+)
 
 
 class TestAppConfig:
@@ -202,3 +208,82 @@ class TestHostConfig:
         )
         assert host.name == "srv"
         assert host.tags == ["docker", "media"]
+
+
+class TestLoaderUtilities:
+    def test_get_env_overrides_detects_set_vars(self, monkeypatch):
+        monkeypatch.setenv("SQUIRE_RISK_TOLERANCE", "full-trust")
+        monkeypatch.setenv("SQUIRE_HISTORY_LIMIT", "100")
+        result = get_env_overrides("SQUIRE_", ["risk_tolerance", "history_limit", "multi_agent"])
+        assert "risk_tolerance" in result
+        assert "history_limit" in result
+        assert "multi_agent" not in result
+
+    def test_get_env_overrides_empty_when_none_set(self):
+        result = get_env_overrides("SQUIRE_TEST_PREFIX_", ["field_a", "field_b"])
+        assert result == []
+
+    def test_get_toml_path_returns_existing(self, tmp_path, monkeypatch):
+        toml_file = tmp_path / "squire.toml"
+        toml_file.write_text("")
+        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+        assert get_toml_path() == toml_file.resolve()
+
+    def test_get_toml_path_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [tmp_path / "nonexistent.toml"])
+        assert get_toml_path() is None
+
+    def test_invalidate_cache(self, monkeypatch):
+        monkeypatch.setattr(loader_mod, "_cached", {"key": "value"})
+        invalidate_cache()
+        assert loader_mod._cached is None
+
+    def test_write_toml_section_creates_file(self, tmp_path, monkeypatch):
+        toml_file = tmp_path / "squire.toml"
+        # File doesn't exist yet; write_toml_section falls back to first search path
+        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+
+        path = write_toml_section("llm", {"model": "gpt-4", "temperature": 0.5})
+        assert path == toml_file
+        assert toml_file.exists()
+
+        import tomlkit
+
+        with open(toml_file) as f:
+            doc = tomlkit.load(f)
+        assert doc["llm"]["model"] == "gpt-4"
+        assert doc["llm"]["temperature"] == 0.5
+
+    def test_write_toml_section_top_level(self, tmp_path, monkeypatch):
+        toml_file = tmp_path / "squire.toml"
+        toml_file.write_text("")
+        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+
+        write_toml_section(None, {"risk_tolerance": "standard", "history_limit": 100})
+
+        import tomlkit
+
+        with open(toml_file) as f:
+            doc = tomlkit.load(f)
+        assert doc["risk_tolerance"] == "standard"
+        assert doc["history_limit"] == 100
+
+    def test_write_toml_preserves_comments(self, tmp_path, monkeypatch):
+        toml_file = tmp_path / "squire.toml"
+        toml_file.write_text('# My config\nrisk_tolerance = "cautious"\n')
+        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+
+        write_toml_section(None, {"history_limit": 50})
+
+        content = toml_file.read_text()
+        assert "# My config" in content
+        assert "history_limit = 50" in content
+
+    def test_write_toml_invalidates_cache(self, tmp_path, monkeypatch):
+        toml_file = tmp_path / "squire.toml"
+        toml_file.write_text("")
+        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+        monkeypatch.setattr(loader_mod, "_cached", {"old": "data"})
+
+        write_toml_section("llm", {"model": "test"})
+        assert loader_mod._cached is None

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -1,0 +1,228 @@
+"""Tests for configuration API endpoints (GET detail + PATCH)."""
+
+import pytest
+
+import squire.api.dependencies as deps
+import squire.config.loader as loader_mod
+from squire.config import AppConfig, GuardrailsConfig, LLMConfig, NotificationsConfig, WatchConfig
+from squire.config.notifications import WebhookConfig
+
+
+@pytest.fixture(autouse=True)
+def _empty_toml(monkeypatch):
+    """Ensure tests don't read the real squire.toml."""
+    monkeypatch.setattr(loader_mod, "_cached", {})
+
+
+@pytest.fixture
+def _setup_deps(monkeypatch):
+    """Populate deps singletons with default configs."""
+    monkeypatch.setattr(deps, "app_config", AppConfig())
+    monkeypatch.setattr(deps, "llm_config", LLMConfig())
+    monkeypatch.setattr(deps, "watch_config", WatchConfig())
+    monkeypatch.setattr(deps, "guardrails", GuardrailsConfig())
+    monkeypatch.setattr(deps, "notif_config", NotificationsConfig())
+    monkeypatch.setattr(deps, "db_config", None)
+    monkeypatch.setattr(deps, "host_store", None)
+    monkeypatch.setattr(deps, "notifier", None)
+
+
+# --- GET /api/config ---
+
+
+@pytest.mark.usefixtures("_setup_deps")
+class TestGetConfig:
+    async def test_returns_env_overrides(self, monkeypatch):
+        from squire.api.routers.config import get_config
+
+        monkeypatch.setenv("SQUIRE_RISK_TOLERANCE", "full-trust")
+        # Recreate config so the env var is picked up
+        monkeypatch.setattr(deps, "app_config", AppConfig())
+
+        result = await get_config(app_config=deps.app_config, llm_config=deps.llm_config)
+        assert "risk_tolerance" in result.app.env_overrides
+
+    async def test_returns_section_values(self):
+        from squire.api.routers.config import get_config
+
+        result = await get_config(app_config=deps.app_config, llm_config=deps.llm_config)
+        assert result.app.values["app_name"] == "Squire"
+        assert "model" in result.llm.values
+
+    async def test_returns_toml_path(self, tmp_path, monkeypatch):
+        from squire.api.routers.config import get_config
+
+        toml_file = tmp_path / "squire.toml"
+        toml_file.write_text("[llm]\nmodel = 'test'\n")
+        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+
+        result = await get_config(app_config=deps.app_config, llm_config=deps.llm_config)
+        assert result.toml_path == str(toml_file)
+
+
+# --- PATCH /api/config/{section} ---
+
+
+@pytest.mark.usefixtures("_setup_deps")
+class TestPatchConfig:
+    async def test_patch_app_updates_in_memory(self):
+        from squire.api.routers.config import patch_config
+
+        result = await patch_config("app", {"risk_tolerance": "full-trust"}, persist=False)
+        assert result["values"]["risk_tolerance"] == "full-trust"
+        assert deps.app_config.risk_tolerance == "full-trust"
+
+    async def test_patch_llm_updates_in_memory(self):
+        from squire.api.routers.config import patch_config
+
+        result = await patch_config("llm", {"temperature": 0.8}, persist=False)
+        assert deps.llm_config.temperature == 0.8
+        # api_base should be redacted in response
+        assert result["values"].get("api_base") != deps.llm_config.api_base or deps.llm_config.api_base is None
+
+    async def test_patch_watch_updates_in_memory(self):
+        from squire.api.routers.config import patch_config
+
+        await patch_config("watch", {"interval_minutes": 10, "notify_on_action": False}, persist=False)
+        assert deps.watch_config.interval_minutes == 10
+        assert deps.watch_config.notify_on_action is False
+
+    async def test_patch_guardrails_updates_in_memory(self):
+        from squire.api.routers.config import patch_config
+
+        await patch_config("guardrails", {"tools_deny": ["run_command"]}, persist=False)
+        assert deps.guardrails.tools_deny == ["run_command"]
+
+    async def test_rejects_env_locked_field(self, monkeypatch):
+        from fastapi import HTTPException
+
+        from squire.api.routers.config import patch_config
+
+        monkeypatch.setenv("SQUIRE_RISK_TOLERANCE", "read-only")
+        with pytest.raises(HTTPException) as exc_info:
+            await patch_config("app", {"risk_tolerance": "full-trust"}, persist=False)
+        assert exc_info.value.status_code == 409
+        assert "SQUIRE_RISK_TOLERANCE" in exc_info.value.detail
+
+    async def test_strips_redacted_sentinel(self):
+        from squire.api.routers.config import patch_config
+
+        original_temp = deps.llm_config.temperature
+        await patch_config("llm", {"model": "new-model", "temperature": "••••••"}, persist=False)
+        assert deps.llm_config.model == "new-model"
+        assert deps.llm_config.temperature == original_temp
+
+    async def test_unknown_section_404(self):
+        from fastapi import HTTPException
+
+        from squire.api.routers.config import patch_config
+
+        with pytest.raises(HTTPException) as exc_info:
+            await patch_config("bogus", {"key": "val"}, persist=False)
+        assert exc_info.value.status_code == 404
+
+    async def test_immutable_section_404(self):
+        from fastapi import HTTPException
+
+        from squire.api.routers.config import patch_config
+
+        with pytest.raises(HTTPException) as exc_info:
+            await patch_config("database", {"path": "/tmp/db"}, persist=False)
+        assert exc_info.value.status_code == 404
+
+    async def test_empty_body_400(self):
+        from fastapi import HTTPException
+
+        from squire.api.routers.config import patch_config
+
+        with pytest.raises(HTTPException) as exc_info:
+            await patch_config("app", {}, persist=False)
+        assert exc_info.value.status_code == 400
+
+    async def test_all_redacted_body_400(self):
+        from fastapi import HTTPException
+
+        from squire.api.routers.config import patch_config
+
+        with pytest.raises(HTTPException) as exc_info:
+            await patch_config("llm", {"model": "••••••"}, persist=False)
+        assert exc_info.value.status_code == 400
+
+
+# --- Notifications webhook merge ---
+
+
+@pytest.mark.usefixtures("_setup_deps")
+class TestNotificationsWebhookMerge:
+    async def test_merge_preserves_redacted_url(self, monkeypatch):
+        from squire.api.routers.config import patch_config
+
+        # Set up existing webhook
+        existing = NotificationsConfig(
+            enabled=True,
+            webhooks=[WebhookConfig(name="discord", url="https://real-url.com", events=["*"])],
+        )
+        monkeypatch.setattr(deps, "notif_config", existing)
+
+        await patch_config(
+            "notifications",
+            {"webhooks": [{"name": "discord", "url": "••••••", "events": ["error"]}]},
+            persist=False,
+        )
+        assert deps.notif_config.webhooks[0].url == "https://real-url.com"
+        assert deps.notif_config.webhooks[0].events == ["error"]
+
+    async def test_merge_preserves_redacted_headers(self, monkeypatch):
+        from squire.api.routers.config import patch_config
+
+        existing = NotificationsConfig(
+            enabled=True,
+            webhooks=[
+                WebhookConfig(name="ntfy", url="https://ntfy.sh/topic", headers={"Authorization": "Bearer secret"})
+            ],
+        )
+        monkeypatch.setattr(deps, "notif_config", existing)
+
+        await patch_config(
+            "notifications",
+            {"webhooks": [{"name": "ntfy", "url": "••••••", "headers": {"Authorization": "••••••"}}]},
+            persist=False,
+        )
+        assert deps.notif_config.webhooks[0].headers["Authorization"] == "Bearer secret"
+
+
+# --- Persist to TOML ---
+
+
+@pytest.mark.usefixtures("_setup_deps")
+class TestPersist:
+    async def test_persist_writes_toml(self, tmp_path, monkeypatch):
+        import tomlkit
+
+        from squire.api.routers.config import patch_config
+
+        toml_file = tmp_path / "squire.toml"
+        toml_file.write_text("")
+        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+
+        result = await patch_config("llm", {"temperature": 0.9}, persist=True)
+        assert result["persisted"] is not None
+
+        with open(toml_file) as f:
+            doc = tomlkit.load(f)
+        assert doc["llm"]["temperature"] == 0.9
+
+    async def test_persist_top_level(self, tmp_path, monkeypatch):
+        import tomlkit
+
+        from squire.api.routers.config import patch_config
+
+        toml_file = tmp_path / "squire.toml"
+        toml_file.write_text("")
+        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+
+        await patch_config("app", {"history_limit": 100}, persist=True)
+
+        with open(toml_file) as f:
+            doc = tomlkit.load(f)
+        assert doc["history_limit"] == 100

--- a/uv.lock
+++ b/uv.lock
@@ -3003,6 +3003,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "textual" },
+    { name = "tomlkit" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -3030,6 +3031,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "textual", specifier = ">=0.80.0" },
+    { name = "tomlkit", specifier = ">=0.13.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
@@ -3165,6 +3167,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]

--- a/web/src/app/config/page.tsx
+++ b/web/src/app/config/page.tsx
@@ -4,7 +4,7 @@ import useSWR from "swr";
 import { apiGet } from "@/lib/api";
 import { ConfigEditor } from "@/components/config/config-editor";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { ConfigResponse } from "@/lib/types";
+import type { ConfigDetailResponse } from "@/lib/types";
 
 function ConfigSkeleton() {
   return (
@@ -17,8 +17,8 @@ function ConfigSkeleton() {
 }
 
 export default function ConfigPage() {
-  const { data: config, isLoading } = useSWR("/api/config", () =>
-    apiGet<ConfigResponse>("/api/config")
+  const { data: config, isLoading, mutate } = useSWR("/api/config", () =>
+    apiGet<ConfigDetailResponse>("/api/config")
   );
 
   if (isLoading || !config) {
@@ -28,7 +28,7 @@ export default function ConfigPage() {
   return (
     <div className="space-y-6 animate-fade-in">
       <h1 className="text-2xl">Configuration</h1>
-      <ConfigEditor config={config} />
+      <ConfigEditor config={config} onSaved={() => mutate()} />
     </div>
   );
 }

--- a/web/src/components/config/app-config-form.tsx
+++ b/web/src/components/config/app-config-form.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useState } from "react";
+import { Lock, Loader2, RotateCcw, Save } from "lucide-react";
+import { apiPatch } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface AppConfigFormProps {
+  values: Record<string, unknown>;
+  envOverrides: string[];
+  tomlPath: string | null;
+  onSaved: () => void;
+}
+
+const RISK_OPTIONS = [
+  { value: "read-only", label: "Read Only" },
+  { value: "cautious", label: "Cautious" },
+  { value: "standard", label: "Standard" },
+  { value: "full-trust", label: "Full Trust" },
+];
+
+function EnvLock({ field, prefix }: { field: string; prefix: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Set by {prefix}{field.toUpperCase()}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppConfigFormProps) {
+  const [riskTolerance, setRiskTolerance] = useState(String(values.risk_tolerance ?? "cautious"));
+  const [riskStrict, setRiskStrict] = useState(Boolean(values.risk_strict));
+  const [historyLimit, setHistoryLimit] = useState(Number(values.history_limit ?? 50));
+  const [maxToolRounds, setMaxToolRounds] = useState(Number(values.max_tool_rounds ?? 10));
+  const [multiAgent, setMultiAgent] = useState(Boolean(values.multi_agent));
+  const [persist, setPersist] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLocked = (field: string) => envOverrides.includes(field);
+
+  const isDirty =
+    riskTolerance !== String(values.risk_tolerance ?? "cautious") ||
+    riskStrict !== Boolean(values.risk_strict) ||
+    historyLimit !== Number(values.history_limit ?? 50) ||
+    maxToolRounds !== Number(values.max_tool_rounds ?? 10) ||
+    multiAgent !== Boolean(values.multi_agent);
+
+  const revert = () => {
+    setRiskTolerance(String(values.risk_tolerance ?? "cautious"));
+    setRiskStrict(Boolean(values.risk_strict));
+    setHistoryLimit(Number(values.history_limit ?? 50));
+    setMaxToolRounds(Number(values.max_tool_rounds ?? 10));
+    setMultiAgent(Boolean(values.multi_agent));
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const changed: Record<string, unknown> = {};
+      if (riskTolerance !== String(values.risk_tolerance ?? "cautious")) changed.risk_tolerance = riskTolerance;
+      if (riskStrict !== Boolean(values.risk_strict)) changed.risk_strict = riskStrict;
+      if (historyLimit !== Number(values.history_limit ?? 50)) changed.history_limit = historyLimit;
+      if (maxToolRounds !== Number(values.max_tool_rounds ?? 10)) changed.max_tool_rounds = maxToolRounds;
+      if (multiAgent !== Boolean(values.multi_agent)) changed.multi_agent = multiAgent;
+
+      const url = persist ? "/api/config/app?persist=true" : "/api/config/app";
+      await apiPatch(url, changed);
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">App</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Risk Tolerance</Label>
+            {isLocked("risk_tolerance") && <EnvLock field="risk_tolerance" prefix="SQUIRE_" />}
+          </div>
+          <Select
+            value={riskTolerance}
+            onValueChange={(v) => v && setRiskTolerance(v)}
+            disabled={isLocked("risk_tolerance")}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {RISK_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            <Label>Risk Strict</Label>
+            {isLocked("risk_strict") && <EnvLock field="risk_strict" prefix="SQUIRE_" />}
+          </div>
+          <Switch
+            checked={riskStrict}
+            onCheckedChange={setRiskStrict}
+            disabled={isLocked("risk_strict")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>History Limit</Label>
+            {isLocked("history_limit") && <EnvLock field="history_limit" prefix="SQUIRE_" />}
+          </div>
+          <Input
+            type="number"
+            min={1}
+            value={historyLimit}
+            onChange={(e) => setHistoryLimit(parseInt(e.target.value) || 1)}
+            disabled={isLocked("history_limit")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Max Tool Rounds</Label>
+            {isLocked("max_tool_rounds") && <EnvLock field="max_tool_rounds" prefix="SQUIRE_" />}
+          </div>
+          <Input
+            type="number"
+            min={1}
+            value={maxToolRounds}
+            onChange={(e) => setMaxToolRounds(parseInt(e.target.value) || 1)}
+            disabled={isLocked("max_tool_rounds")}
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            <Label>Multi-Agent</Label>
+            {isLocked("multi_agent") && <EnvLock field="multi_agent" prefix="SQUIRE_" />}
+          </div>
+          <Switch
+            checked={multiAgent}
+            onCheckedChange={setMultiAgent}
+            disabled={isLocked("multi_agent")}
+          />
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <div className="flex items-center justify-between pt-2 border-t">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={persist}
+              onChange={(e) => setPersist(e.target.checked)}
+              disabled={!tomlPath}
+              className="rounded"
+            />
+            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+          </label>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
+              <RotateCcw className="h-3.5 w-3.5 mr-1" />
+              Revert
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={!isDirty || saving}>
+              {saving ? <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" /> : <Save className="h-3.5 w-3.5 mr-1" />}
+              Save
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/config/config-editor.tsx
+++ b/web/src/components/config/config-editor.tsx
@@ -5,10 +5,16 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronRight } from "lucide-react";
-import type { ConfigResponse } from "@/lib/types";
+import type { ConfigDetailResponse } from "@/lib/types";
+import { AppConfigForm } from "./app-config-form";
+import { LLMConfigForm } from "./llm-config-form";
+import { WatchConfigForm } from "./watch-config-form";
+import { GuardrailsConfigForm } from "./guardrails-config-form";
+import { NotificationsConfigForm } from "./notifications-config-form";
 
 interface ConfigEditorProps {
-  config: ConfigResponse;
+  config: ConfigDetailResponse;
+  onSaved: () => void;
 }
 
 function ConfigKeyValue({ data }: { data: Record<string, unknown> }) {
@@ -18,7 +24,7 @@ function ConfigKeyValue({ data }: { data: Record<string, unknown> }) {
         const display =
           typeof value === "object" && value !== null
             ? JSON.stringify(value, null, 2)
-            : String(value ?? "—");
+            : String(value ?? "\u2014");
         const isComplex = typeof value === "object" && value !== null;
 
         return (
@@ -40,7 +46,7 @@ function ConfigKeyValue({ data }: { data: Record<string, unknown> }) {
   );
 }
 
-function ConfigSection({
+function ReadOnlySection({
   title,
   data,
 }: {
@@ -83,31 +89,71 @@ function ConfigSection({
   );
 }
 
-export function ConfigEditor({ config }: ConfigEditorProps) {
-  const sections = [
-    { key: "app", label: "App", data: config.app },
-    { key: "llm", label: "LLM", data: config.llm },
-    { key: "database", label: "Database", data: config.database },
-    { key: "guardrails", label: "Guardrails", data: config.guardrails },
-    { key: "watch", label: "Watch", data: config.watch },
-    { key: "notifications", label: "Notifications", data: config.notifications },
-    { key: "hosts", label: "Hosts", data: config.hosts },
-  ];
-
+export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
   return (
     <Tabs defaultValue="app">
       <TabsList className="flex flex-wrap">
-        {sections.map((s) => (
-          <TabsTrigger key={s.key} value={s.key}>
-            {s.label}
-          </TabsTrigger>
-        ))}
+        <TabsTrigger value="app">App</TabsTrigger>
+        <TabsTrigger value="llm">LLM</TabsTrigger>
+        <TabsTrigger value="database">Database</TabsTrigger>
+        <TabsTrigger value="guardrails">Guardrails</TabsTrigger>
+        <TabsTrigger value="watch">Watch</TabsTrigger>
+        <TabsTrigger value="notifications">Notifications</TabsTrigger>
+        <TabsTrigger value="hosts">Hosts</TabsTrigger>
       </TabsList>
-      {sections.map((s) => (
-        <TabsContent key={s.key} value={s.key}>
-          <ConfigSection title={s.label} data={s.data} />
-        </TabsContent>
-      ))}
+
+      <TabsContent value="app">
+        <AppConfigForm
+          values={config.app.values}
+          envOverrides={config.app.env_overrides}
+          tomlPath={config.toml_path}
+          onSaved={onSaved}
+        />
+      </TabsContent>
+
+      <TabsContent value="llm">
+        <LLMConfigForm
+          values={config.llm.values}
+          envOverrides={config.llm.env_overrides}
+          tomlPath={config.toml_path}
+          onSaved={onSaved}
+        />
+      </TabsContent>
+
+      <TabsContent value="database">
+        <ReadOnlySection title="Database" data={config.database.values} />
+      </TabsContent>
+
+      <TabsContent value="guardrails">
+        <GuardrailsConfigForm
+          values={config.guardrails.values}
+          envOverrides={config.guardrails.env_overrides}
+          tomlPath={config.toml_path}
+          onSaved={onSaved}
+        />
+      </TabsContent>
+
+      <TabsContent value="watch">
+        <WatchConfigForm
+          values={config.watch.values}
+          envOverrides={config.watch.env_overrides}
+          tomlPath={config.toml_path}
+          onSaved={onSaved}
+        />
+      </TabsContent>
+
+      <TabsContent value="notifications">
+        <NotificationsConfigForm
+          values={config.notifications.values}
+          envOverrides={config.notifications.env_overrides}
+          tomlPath={config.toml_path}
+          onSaved={onSaved}
+        />
+      </TabsContent>
+
+      <TabsContent value="hosts">
+        <ReadOnlySection title="Hosts" data={config.hosts} />
+      </TabsContent>
     </Tabs>
   );
 }

--- a/web/src/components/config/guardrails-config-form.tsx
+++ b/web/src/components/config/guardrails-config-form.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useState } from "react";
+import { Lock, Loader2, RotateCcw, Save, X } from "lucide-react";
+import { apiPatch } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface GuardrailsConfigFormProps {
+  values: Record<string, unknown>;
+  envOverrides: string[];
+  tomlPath: string | null;
+  onSaved: () => void;
+}
+
+const TOLERANCE_OPTIONS = [
+  { value: "", label: "Default (inherit)" },
+  { value: "read-only", label: "Read Only" },
+  { value: "cautious", label: "Cautious" },
+  { value: "standard", label: "Standard" },
+  { value: "full-trust", label: "Full Trust" },
+];
+
+function EnvLock({ field, prefix }: { field: string; prefix: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Set by {prefix}{field.toUpperCase()}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function TagInput({
+  value,
+  onChange,
+  disabled,
+  placeholder,
+}: {
+  value: string[];
+  onChange: (v: string[]) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}) {
+  const [input, setInput] = useState("");
+
+  const addTag = () => {
+    const tag = input.trim();
+    if (tag && !value.includes(tag)) {
+      onChange([...value, tag]);
+    }
+    setInput("");
+  };
+
+  const removeTag = (tag: string) => {
+    onChange(value.filter((t) => t !== tag));
+  };
+
+  return (
+    <div className="space-y-1.5">
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {value.map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-xs gap-1">
+              {tag}
+              {!disabled && (
+                <button onClick={() => removeTag(tag)} className="hover:text-destructive">
+                  <X className="h-3 w-3" />
+                </button>
+              )}
+            </Badge>
+          ))}
+        </div>
+      )}
+      {!disabled && (
+        <Input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addTag();
+            }
+          }}
+          placeholder={placeholder ?? "Type and press Enter"}
+          className="text-xs"
+        />
+      )}
+    </div>
+  );
+}
+
+function arraysEqual(a: unknown, b: string[]): boolean {
+  const arr = Array.isArray(a) ? (a as string[]) : [];
+  return arr.length === b.length && arr.every((v, i) => v === b[i]);
+}
+
+export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }: GuardrailsConfigFormProps) {
+  const toArr = (v: unknown): string[] => (Array.isArray(v) ? (v as string[]) : []);
+  const toStr = (v: unknown): string => (v != null ? String(v) : "");
+
+  const [toolsAllow, setToolsAllow] = useState(toArr(values.tools_allow));
+  const [toolsRequireApproval, setToolsRequireApproval] = useState(toArr(values.tools_require_approval));
+  const [toolsDeny, setToolsDeny] = useState(toArr(values.tools_deny));
+  const [monitorTolerance, setMonitorTolerance] = useState(toStr(values.monitor_tolerance));
+  const [containerTolerance, setContainerTolerance] = useState(toStr(values.container_tolerance));
+  const [adminTolerance, setAdminTolerance] = useState(toStr(values.admin_tolerance));
+  const [notifierTolerance, setNotifierTolerance] = useState(toStr(values.notifier_tolerance));
+  const [watchTolerance, setWatchTolerance] = useState(toStr(values.watch_tolerance));
+  const [watchToolsAllow, setWatchToolsAllow] = useState(toArr(values.watch_tools_allow));
+  const [watchToolsDeny, setWatchToolsDeny] = useState(toArr(values.watch_tools_deny));
+  const [persist, setPersist] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLocked = (field: string) => envOverrides.includes(field);
+
+  const isDirty =
+    !arraysEqual(values.tools_allow, toolsAllow) ||
+    !arraysEqual(values.tools_require_approval, toolsRequireApproval) ||
+    !arraysEqual(values.tools_deny, toolsDeny) ||
+    monitorTolerance !== toStr(values.monitor_tolerance) ||
+    containerTolerance !== toStr(values.container_tolerance) ||
+    adminTolerance !== toStr(values.admin_tolerance) ||
+    notifierTolerance !== toStr(values.notifier_tolerance) ||
+    watchTolerance !== toStr(values.watch_tolerance) ||
+    !arraysEqual(values.watch_tools_allow, watchToolsAllow) ||
+    !arraysEqual(values.watch_tools_deny, watchToolsDeny);
+
+  const revert = () => {
+    setToolsAllow(toArr(values.tools_allow));
+    setToolsRequireApproval(toArr(values.tools_require_approval));
+    setToolsDeny(toArr(values.tools_deny));
+    setMonitorTolerance(toStr(values.monitor_tolerance));
+    setContainerTolerance(toStr(values.container_tolerance));
+    setAdminTolerance(toStr(values.admin_tolerance));
+    setNotifierTolerance(toStr(values.notifier_tolerance));
+    setWatchTolerance(toStr(values.watch_tolerance));
+    setWatchToolsAllow(toArr(values.watch_tools_allow));
+    setWatchToolsDeny(toArr(values.watch_tools_deny));
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const changed: Record<string, unknown> = {};
+      if (!arraysEqual(values.tools_allow, toolsAllow)) changed.tools_allow = toolsAllow;
+      if (!arraysEqual(values.tools_require_approval, toolsRequireApproval))
+        changed.tools_require_approval = toolsRequireApproval;
+      if (!arraysEqual(values.tools_deny, toolsDeny)) changed.tools_deny = toolsDeny;
+      const tolFields = [
+        ["monitor_tolerance", monitorTolerance, values.monitor_tolerance],
+        ["container_tolerance", containerTolerance, values.container_tolerance],
+        ["admin_tolerance", adminTolerance, values.admin_tolerance],
+        ["notifier_tolerance", notifierTolerance, values.notifier_tolerance],
+        ["watch_tolerance", watchTolerance, values.watch_tolerance],
+      ] as const;
+      for (const [key, cur, orig] of tolFields) {
+        if (cur !== toStr(orig)) changed[key] = cur || null;
+      }
+      if (!arraysEqual(values.watch_tools_allow, watchToolsAllow)) changed.watch_tools_allow = watchToolsAllow;
+      if (!arraysEqual(values.watch_tools_deny, watchToolsDeny)) changed.watch_tools_deny = watchToolsDeny;
+
+      const url = persist ? "/api/config/guardrails?persist=true" : "/api/config/guardrails";
+      await apiPatch(url, changed);
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Guardrails</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Tools Allow</Label>
+            {isLocked("tools_allow") && <EnvLock field="tools_allow" prefix="SQUIRE_GUARDRAILS_" />}
+          </div>
+          <TagInput
+            value={toolsAllow}
+            onChange={setToolsAllow}
+            disabled={isLocked("tools_allow")}
+            placeholder="Tool name, press Enter"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Tools Require Approval</Label>
+            {isLocked("tools_require_approval") && (
+              <EnvLock field="tools_require_approval" prefix="SQUIRE_GUARDRAILS_" />
+            )}
+          </div>
+          <TagInput
+            value={toolsRequireApproval}
+            onChange={setToolsRequireApproval}
+            disabled={isLocked("tools_require_approval")}
+            placeholder="Tool name, press Enter"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Tools Deny</Label>
+            {isLocked("tools_deny") && <EnvLock field="tools_deny" prefix="SQUIRE_GUARDRAILS_" />}
+          </div>
+          <TagInput
+            value={toolsDeny}
+            onChange={setToolsDeny}
+            disabled={isLocked("tools_deny")}
+            placeholder="Tool name, press Enter"
+          />
+        </div>
+
+        <div className="border-t pt-4 space-y-3">
+          <Label className="text-sm font-medium">Per-Agent Tolerance</Label>
+          {(
+            [
+              ["monitor_tolerance", "Monitor", monitorTolerance, setMonitorTolerance],
+              ["container_tolerance", "Container", containerTolerance, setContainerTolerance],
+              ["admin_tolerance", "Admin", adminTolerance, setAdminTolerance],
+              ["notifier_tolerance", "Notifier", notifierTolerance, setNotifierTolerance],
+            ] as const
+          ).map(([field, label, value, setter]) => (
+            <div key={field} className="flex items-center gap-3">
+              <Label className="w-24 text-xs">{label}</Label>
+              <Select
+                value={value}
+                onValueChange={(v) => v != null && setter(v)}
+                disabled={isLocked(field)}
+              >
+                <SelectTrigger className="flex-1">
+                  <SelectValue placeholder="Default" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TOLERANCE_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {isLocked(field) && <EnvLock field={field} prefix="SQUIRE_GUARDRAILS_" />}
+            </div>
+          ))}
+        </div>
+
+        <div className="border-t pt-4 space-y-3">
+          <Label className="text-sm font-medium">Watch Mode Overrides</Label>
+          <div className="flex items-center gap-3">
+            <Label className="w-24 text-xs">Tolerance</Label>
+            <Select
+              value={watchTolerance}
+              onValueChange={(v) => v != null && setWatchTolerance(v)}
+              disabled={isLocked("watch_tolerance")}
+            >
+              <SelectTrigger className="flex-1">
+                <SelectValue placeholder="Default" />
+              </SelectTrigger>
+              <SelectContent>
+                {TOLERANCE_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label className="text-xs">Watch Tools Allow</Label>
+            <TagInput value={watchToolsAllow} onChange={setWatchToolsAllow} disabled={isLocked("watch_tools_allow")} />
+          </div>
+          <div className="space-y-2">
+            <Label className="text-xs">Watch Tools Deny</Label>
+            <TagInput value={watchToolsDeny} onChange={setWatchToolsDeny} disabled={isLocked("watch_tools_deny")} />
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <div className="flex items-center justify-between pt-2 border-t">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={persist}
+              onChange={(e) => setPersist(e.target.checked)}
+              disabled={!tomlPath}
+              className="rounded"
+            />
+            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+          </label>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
+              <RotateCcw className="h-3.5 w-3.5 mr-1" />
+              Revert
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={!isDirty || saving}>
+              {saving ? <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" /> : <Save className="h-3.5 w-3.5 mr-1" />}
+              Save
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/config/llm-config-form.tsx
+++ b/web/src/components/config/llm-config-form.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+import { Lock, Loader2, RotateCcw, Save } from "lucide-react";
+import { apiPatch } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface LLMConfigFormProps {
+  values: Record<string, unknown>;
+  envOverrides: string[];
+  tomlPath: string | null;
+  onSaved: () => void;
+}
+
+function EnvLock({ field, prefix }: { field: string; prefix: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Set by {prefix}{field.toUpperCase()}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMConfigFormProps) {
+  const [model, setModel] = useState(String(values.model ?? ""));
+  const [temperature, setTemperature] = useState(Number(values.temperature ?? 0.2));
+  const [maxTokens, setMaxTokens] = useState(Number(values.max_tokens ?? 4096));
+  const [persist, setPersist] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLocked = (field: string) => envOverrides.includes(field);
+
+  const isDirty =
+    model !== String(values.model ?? "") ||
+    temperature !== Number(values.temperature ?? 0.2) ||
+    maxTokens !== Number(values.max_tokens ?? 4096);
+
+  const revert = () => {
+    setModel(String(values.model ?? ""));
+    setTemperature(Number(values.temperature ?? 0.2));
+    setMaxTokens(Number(values.max_tokens ?? 4096));
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const changed: Record<string, unknown> = {};
+      if (model !== String(values.model ?? "")) changed.model = model;
+      if (temperature !== Number(values.temperature ?? 0.2)) changed.temperature = temperature;
+      if (maxTokens !== Number(values.max_tokens ?? 4096)) changed.max_tokens = maxTokens;
+
+      const url = persist ? "/api/config/llm?persist=true" : "/api/config/llm";
+      await apiPatch(url, changed);
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">LLM</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Model</Label>
+            {isLocked("model") && <EnvLock field="model" prefix="SQUIRE_LLM_" />}
+          </div>
+          <Input
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            disabled={isLocked("model")}
+            placeholder="e.g. ollama_chat/llama3.1:8b"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Temperature</Label>
+            {isLocked("temperature") && <EnvLock field="temperature" prefix="SQUIRE_LLM_" />}
+          </div>
+          <Input
+            type="number"
+            min={0}
+            max={2}
+            step={0.1}
+            value={temperature}
+            onChange={(e) => setTemperature(parseFloat(e.target.value) || 0)}
+            disabled={isLocked("temperature")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Max Tokens</Label>
+            {isLocked("max_tokens") && <EnvLock field="max_tokens" prefix="SQUIRE_LLM_" />}
+          </div>
+          <Input
+            type="number"
+            min={1}
+            value={maxTokens}
+            onChange={(e) => setMaxTokens(parseInt(e.target.value) || 1)}
+            disabled={isLocked("max_tokens")}
+          />
+        </div>
+
+        {values.api_base != null && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5">
+              <Label>API Base</Label>
+              <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+            </div>
+            <Input value={String(values.api_base)} disabled className="font-mono text-xs" />
+            <p className="text-xs text-muted-foreground">Sensitive — change via env var or squire.toml</p>
+          </div>
+        )}
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <div className="flex items-center justify-between pt-2 border-t">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={persist}
+              onChange={(e) => setPersist(e.target.checked)}
+              disabled={!tomlPath}
+              className="rounded"
+            />
+            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+          </label>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
+              <RotateCcw className="h-3.5 w-3.5 mr-1" />
+              Revert
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={!isDirty || saving}>
+              {saving ? <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" /> : <Save className="h-3.5 w-3.5 mr-1" />}
+              Save
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/config/notifications-config-form.tsx
+++ b/web/src/components/config/notifications-config-form.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState } from "react";
+import { Lock, Loader2, RotateCcw, Save, Plus, Trash2, X } from "lucide-react";
+import { apiPatch } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface NotificationsConfigFormProps {
+  values: Record<string, unknown>;
+  envOverrides: string[];
+  tomlPath: string | null;
+  onSaved: () => void;
+}
+
+interface WebhookState {
+  name: string;
+  url: string;
+  events: string[];
+  headers: Record<string, string>;
+  isNew?: boolean;
+}
+
+const REDACTED = "\u2022\u2022\u2022\u2022\u2022\u2022";
+
+function EnvLock({ field, prefix }: { field: string; prefix: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Set by {prefix}{field.toUpperCase()}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function parseWebhooks(raw: unknown): WebhookState[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((wh) => ({
+    name: String(wh.name ?? ""),
+    url: String(wh.url ?? ""),
+    events: Array.isArray(wh.events) ? (wh.events as string[]) : ["*"],
+    headers: typeof wh.headers === "object" && wh.headers ? (wh.headers as Record<string, string>) : {},
+  }));
+}
+
+export function NotificationsConfigForm({ values, envOverrides, tomlPath, onSaved }: NotificationsConfigFormProps) {
+  const [enabled, setEnabled] = useState(Boolean(values.enabled));
+  const [webhooks, setWebhooks] = useState<WebhookState[]>(parseWebhooks(values.webhooks));
+  const [persist, setPersist] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLocked = (field: string) => envOverrides.includes(field);
+
+  const origWebhooks = parseWebhooks(values.webhooks);
+  const webhooksDirty = JSON.stringify(webhooks) !== JSON.stringify(origWebhooks);
+  const isDirty = enabled !== Boolean(values.enabled) || webhooksDirty;
+
+  const revert = () => {
+    setEnabled(Boolean(values.enabled));
+    setWebhooks(parseWebhooks(values.webhooks));
+    setError(null);
+  };
+
+  const updateWebhook = (index: number, patch: Partial<WebhookState>) => {
+    setWebhooks((prev) => prev.map((wh, i) => (i === index ? { ...wh, ...patch } : wh)));
+  };
+
+  const removeWebhook = (index: number) => {
+    setWebhooks((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const addWebhook = () => {
+    setWebhooks((prev) => [...prev, { name: "", url: "", events: ["*"], headers: {}, isNew: true }]);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const changed: Record<string, unknown> = {};
+      if (enabled !== Boolean(values.enabled)) changed.enabled = enabled;
+      if (webhooksDirty) {
+        changed.webhooks = webhooks.map(({ isNew: _, ...wh }) => wh);
+      }
+
+      const url = persist ? "/api/config/notifications?persist=true" : "/api/config/notifications";
+      await apiPatch(url, changed);
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Notifications</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            <Label>Enabled</Label>
+            {isLocked("enabled") && <EnvLock field="enabled" prefix="SQUIRE_NOTIFICATIONS_" />}
+          </div>
+          <Switch
+            checked={enabled}
+            onCheckedChange={setEnabled}
+            disabled={isLocked("enabled")}
+          />
+        </div>
+
+        <div className="border-t pt-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <Label className="text-sm font-medium">Webhooks</Label>
+            <Button variant="outline" size="sm" onClick={addWebhook}>
+              <Plus className="h-3.5 w-3.5 mr-1" />
+              Add
+            </Button>
+          </div>
+
+          {webhooks.length === 0 && (
+            <p className="text-xs text-muted-foreground">No webhooks configured.</p>
+          )}
+
+          {webhooks.map((wh, i) => (
+            <div key={i} className="border rounded-lg p-3 space-y-2">
+              <div className="flex items-center justify-between">
+                <Input
+                  value={wh.name}
+                  onChange={(e) => updateWebhook(i, { name: e.target.value })}
+                  placeholder="Webhook name"
+                  className="text-sm font-medium max-w-48"
+                />
+                <Button variant="ghost" size="sm" onClick={() => removeWebhook(i)}>
+                  <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
+                </Button>
+              </div>
+
+              <div className="space-y-1">
+                <Label className="text-xs">URL</Label>
+                {wh.isNew ? (
+                  <Input
+                    value={wh.url}
+                    onChange={(e) => updateWebhook(i, { url: e.target.value })}
+                    placeholder="https://..."
+                    className="text-xs font-mono"
+                  />
+                ) : (
+                  <Input value={wh.url} disabled className="text-xs font-mono" />
+                )}
+                {!wh.isNew && wh.url === REDACTED && (
+                  <p className="text-xs text-muted-foreground">URL is hidden for security</p>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <Label className="text-xs">Events</Label>
+                <div className="flex flex-wrap gap-1">
+                  {wh.events.map((ev) => (
+                    <Badge key={ev} variant="secondary" className="text-xs gap-1">
+                      {ev}
+                      <button
+                        onClick={() =>
+                          updateWebhook(i, { events: wh.events.filter((e) => e !== ev) })
+                        }
+                        className="hover:text-destructive"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+                <Input
+                  placeholder="Add event, press Enter"
+                  className="text-xs"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      const val = e.currentTarget.value.trim();
+                      if (val && !wh.events.includes(val)) {
+                        updateWebhook(i, { events: [...wh.events, val] });
+                      }
+                      e.currentTarget.value = "";
+                    }
+                  }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <div className="flex items-center justify-between pt-2 border-t">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={persist}
+              onChange={(e) => setPersist(e.target.checked)}
+              disabled={!tomlPath}
+              className="rounded"
+            />
+            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+          </label>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
+              <RotateCcw className="h-3.5 w-3.5 mr-1" />
+              Revert
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={!isDirty || saving}>
+              {saving ? <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" /> : <Save className="h-3.5 w-3.5 mr-1" />}
+              Save
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/config/watch-config-form.tsx
+++ b/web/src/components/config/watch-config-form.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState } from "react";
+import { Lock, Loader2, RotateCcw, Save } from "lucide-react";
+import { apiPatch } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface WatchConfigFormProps {
+  values: Record<string, unknown>;
+  envOverrides: string[];
+  tomlPath: string | null;
+  onSaved: () => void;
+}
+
+function EnvLock({ field, prefix }: { field: string; prefix: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Set by {prefix}{field.toUpperCase()}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: WatchConfigFormProps) {
+  const [intervalMinutes, setIntervalMinutes] = useState(Number(values.interval_minutes ?? 5));
+  const [cycleTimeout, setCycleTimeout] = useState(Number(values.cycle_timeout_seconds ?? 300));
+  const [checkinPrompt, setCheckinPrompt] = useState(String(values.checkin_prompt ?? ""));
+  const [notifyOnAction, setNotifyOnAction] = useState(Boolean(values.notify_on_action ?? true));
+  const [notifyOnBlocked, setNotifyOnBlocked] = useState(Boolean(values.notify_on_blocked ?? true));
+  const [persist, setPersist] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLocked = (field: string) => envOverrides.includes(field);
+
+  const isDirty =
+    intervalMinutes !== Number(values.interval_minutes ?? 5) ||
+    cycleTimeout !== Number(values.cycle_timeout_seconds ?? 300) ||
+    checkinPrompt !== String(values.checkin_prompt ?? "") ||
+    notifyOnAction !== Boolean(values.notify_on_action ?? true) ||
+    notifyOnBlocked !== Boolean(values.notify_on_blocked ?? true);
+
+  const revert = () => {
+    setIntervalMinutes(Number(values.interval_minutes ?? 5));
+    setCycleTimeout(Number(values.cycle_timeout_seconds ?? 300));
+    setCheckinPrompt(String(values.checkin_prompt ?? ""));
+    setNotifyOnAction(Boolean(values.notify_on_action ?? true));
+    setNotifyOnBlocked(Boolean(values.notify_on_blocked ?? true));
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const changed: Record<string, unknown> = {};
+      if (intervalMinutes !== Number(values.interval_minutes ?? 5)) changed.interval_minutes = intervalMinutes;
+      if (cycleTimeout !== Number(values.cycle_timeout_seconds ?? 300)) changed.cycle_timeout_seconds = cycleTimeout;
+      if (checkinPrompt !== String(values.checkin_prompt ?? "")) changed.checkin_prompt = checkinPrompt;
+      if (notifyOnAction !== Boolean(values.notify_on_action ?? true)) changed.notify_on_action = notifyOnAction;
+      if (notifyOnBlocked !== Boolean(values.notify_on_blocked ?? true)) changed.notify_on_blocked = notifyOnBlocked;
+
+      const url = persist ? "/api/config/watch?persist=true" : "/api/config/watch";
+      await apiPatch(url, changed);
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Watch</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Interval (minutes)</Label>
+            {isLocked("interval_minutes") && <EnvLock field="interval_minutes" prefix="SQUIRE_WATCH_" />}
+          </div>
+          <Input
+            type="number"
+            min={1}
+            value={intervalMinutes}
+            onChange={(e) => setIntervalMinutes(parseInt(e.target.value) || 1)}
+            disabled={isLocked("interval_minutes")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Cycle Timeout (seconds)</Label>
+            {isLocked("cycle_timeout_seconds") && <EnvLock field="cycle_timeout_seconds" prefix="SQUIRE_WATCH_" />}
+          </div>
+          <Input
+            type="number"
+            min={30}
+            value={cycleTimeout}
+            onChange={(e) => setCycleTimeout(parseInt(e.target.value) || 30)}
+            disabled={isLocked("cycle_timeout_seconds")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Check-in Prompt</Label>
+            {isLocked("checkin_prompt") && <EnvLock field="checkin_prompt" prefix="SQUIRE_WATCH_" />}
+          </div>
+          <Textarea
+            rows={4}
+            value={checkinPrompt}
+            onChange={(e) => setCheckinPrompt(e.target.value)}
+            disabled={isLocked("checkin_prompt")}
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            <Label>Notify on Action</Label>
+            {isLocked("notify_on_action") && <EnvLock field="notify_on_action" prefix="SQUIRE_WATCH_" />}
+          </div>
+          <Switch
+            checked={notifyOnAction}
+            onCheckedChange={setNotifyOnAction}
+            disabled={isLocked("notify_on_action")}
+          />
+        </div>
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            <Label>Notify on Blocked</Label>
+            {isLocked("notify_on_blocked") && <EnvLock field="notify_on_blocked" prefix="SQUIRE_WATCH_" />}
+          </div>
+          <Switch
+            checked={notifyOnBlocked}
+            onCheckedChange={setNotifyOnBlocked}
+            disabled={isLocked("notify_on_blocked")}
+          />
+        </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        <div className="flex items-center justify-between pt-2 border-t">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={persist}
+              onChange={(e) => setPersist(e.target.checked)}
+              disabled={!tomlPath}
+              className="rounded"
+            />
+            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+          </label>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
+              <RotateCcw className="h-3.5 w-3.5 mr-1" />
+              Revert
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={!isDirty || saving}>
+              {saving ? <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" /> : <Save className="h-3.5 w-3.5 mr-1" />}
+              Save
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -41,6 +41,13 @@ export function apiPut<T>(path: string, body: unknown): Promise<T> {
   });
 }
 
+export function apiPatch<T>(path: string, body: unknown): Promise<T> {
+  return apiFetch<T>(path, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
 export async function apiDelete(path: string): Promise<void> {
   const headers: Record<string, string> = {};
   const res = await fetch(`${API_BASE}${path}`, {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -168,6 +168,22 @@ export interface ConfigResponse {
   hosts: Record<string, unknown>[];
 }
 
+export interface ConfigSectionMeta {
+  values: Record<string, unknown>;
+  env_overrides: string[];
+}
+
+export interface ConfigDetailResponse {
+  app: ConfigSectionMeta;
+  llm: ConfigSectionMeta;
+  database: ConfigSectionMeta;
+  notifications: ConfigSectionMeta;
+  guardrails: ConfigSectionMeta;
+  watch: ConfigSectionMeta;
+  hosts: Record<string, unknown>[];
+  toml_path: string | null;
+}
+
 // WebSocket message types
 export interface WsToken {
   type: "token";


### PR DESCRIPTION
## Summary

- Add `PATCH /api/config/{section}` endpoints for `app`, `llm`, `watch`, `guardrails`, and `notifications` sections with runtime in-memory updates and optional persist-to-disk (`?persist=true`) via tomlkit round-trip writing
- Enrich `GET /api/config` response with per-section `env_overrides` lists and `toml_path` so the frontend can show lock icons on env-var-overridden fields
- Convert the read-only `/config` page into per-section editable forms with appropriate input types (selects, switches, tag inputs, textareas), dirty tracking, save/revert buttons, and inline error display
- Handle redacted sentinel values (`••••••`) during webhook updates by merging with existing sensitive data

## Test plan

- [x] 333 existing + 26 new tests pass (`pytest`)
- [x] Lint clean (`ruff check`)
- [x] Format clean (`ruff format --check`)
- [x] Frontend builds (`next build`)
- [x] Manual: start `make web`, navigate to `/config`, verify editable forms render with correct values
- [x] Manual: change a field, save, verify GET returns new value
- [x] Manual: set an env var (e.g. `SQUIRE_RISK_TOLERANCE`), verify field shows lock icon and is disabled
- [x] Manual: toggle "Save to disk", verify `squire.toml` is updated preserving comments

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)