### PR TITLE
fix: prevent duplicate tool approval prompts and improve error resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `POST /api/hosts`, `DELETE /api/hosts/{name}`, `POST /api/hosts/{name}/verify`, `GET /api/hosts/{name}/public-key` API endpoints
   - `HostStore` service for centralized host management with cascading auth (existing SSH keys → manual fallback)
 
+### Fixed
+
+- **Tool approval no longer causes duplicate prompting** — removed instruction that told the LLM to ask for confirmation before mutations, which conflicted with the risk gate's built-in approval dialog (#46)
+- **Tool errors no longer interrupt Squire's chain of thought** — improved risk gate error messages with `[BLOCKED]`/`[DENIED]` prefixes and explicit "do NOT retry" guidance so the LLM acknowledges errors and continues responding (#44)
+
 ### Changed
 
+- Risk gate error messages are now structured with `[BLOCKED]`/`[DENIED]` prefixes and include explicit instructions for the LLM to not retry and to inform the user
+- Risk tolerance guidance now clarifies that approval happens via UI dialog — the LLM should call tools directly without asking
+- All sub-agent instructions updated with consistent error handling guidance ("do NOT stop responding")
 - Host configuration moved from TOML `[[hosts]]` to SQLite database — hosts are now added via CLI or web UI with no restart required
 - `BackendRegistry` supports runtime `add_host()` / `remove_host()` for hot-reload
 - Hosts page shows enrollment status badges and management actions (verify, remove)

--- a/src/squire/callbacks/risk_gate.py
+++ b/src/squire/callbacks/risk_gate.py
@@ -105,13 +105,23 @@ def create_risk_gate(
         if result.decision == GateResult.DENIED:
             if headless and notifier:
                 await _notify_blocked(notifier, compound_name, args, result.reasoning)
-            return {"error": f"Blocked: {result.reasoning}"}
+            return {
+                "error": (
+                    f"[BLOCKED] '{compound_name}' was denied by the risk policy: {result.reasoning}. "
+                    "Do NOT retry this tool call. Tell the user it was blocked and suggest alternatives."
+                )
+            }
 
         if result.decision == GateResult.NEEDS_APPROVAL:
             if headless:
                 if notifier:
                     await _notify_blocked(notifier, compound_name, args, result.reasoning)
-                return {"error": f"Watch mode denied '{compound_name}': above risk threshold."}
+                return {
+                    "error": (
+                        f"[BLOCKED] '{compound_name}' denied in watch mode: above risk threshold. "
+                        "Do NOT retry. Note this in your response and move on."
+                    )
+                }
 
             if approval_provider is not None:
                 if isinstance(approval_provider, AsyncApprovalProvider):
@@ -121,9 +131,19 @@ def create_risk_gate(
                 else:
                     approved = approval_provider.request_approval(compound_name, args, result.risk_score.level)
                 if not approved:
-                    return {"error": f"User declined to approve '{compound_name}'."}
+                    return {
+                        "error": (
+                            f"[DENIED] The user declined '{compound_name}'. "
+                            "Do NOT retry. Acknowledge the denial and move on."
+                        )
+                    }
             else:
-                return {"error": f"No approval provider — auto-denied '{compound_name}'."}
+                return {
+                    "error": (
+                        f"[BLOCKED] '{compound_name}' requires approval but no approval provider is available. "
+                        "Do NOT retry. Inform the user."
+                    )
+                }
 
         # GateResult.ALLOWED — proceed
         return None

--- a/src/squire/instructions/admin_agent.py
+++ b/src/squire/instructions/admin_agent.py
@@ -33,12 +33,10 @@ host stability. Exercise caution and always confirm before destructive actions.
 - Use `run_command` to execute arbitrary shell commands.
 - `run_command` is subject to allowlist/denylist restrictions configured by the user.
   If a command is denied, explain why and suggest alternatives.
-- Always explain what a command will do before executing it.
-- For destructive operations (stopping services, modifying system state),
-  confirm with the user unless in autonomous watch mode.
-- NEVER fabricate command output. If a tool fails, report the error.
-- If a tool call is blocked by the risk profile, tell the user and suggest
-  alternatives if possible.
+- When the user requests an action, call the tool directly. Do NOT ask for confirmation
+  — the risk gate handles approval for dangerous actions via a UI dialog automatically.
+- NEVER fabricate command output. If a tool fails or is blocked, report the error
+  and continue with any remaining work. Do NOT stop responding.
 
 {build_risk_section(ctx)}
 {build_hosts_section(ctx)}\

--- a/src/squire/instructions/container_agent.py
+++ b/src/squire/instructions/container_agent.py
@@ -25,9 +25,7 @@ def build_instruction(ctx: ReadonlyContext) -> str:
 
 ## Your Role: Container Manager
 You manage container lifecycle — viewing logs, managing containers, pulling
-images, cleaning up resources, and managing Docker Compose stacks. Your tools
-can modify container state, so always explain what you'll do and why before
-executing mutations.
+images, cleaning up resources, and managing Docker Compose stacks.
 
 ## Tool Usage
 - Use `docker_logs` to view container logs for troubleshooting.
@@ -37,11 +35,10 @@ executing mutations.
 - Use `docker_cleanup` to check disk usage and prune unused resources (containers, images, volumes).
 - When using `docker_compose`, provide the service name — the project
   directory resolves automatically from the host's service_root.
-- For destructive actions (remove, prune), explain what you'll do and the
-  impact before executing. Volume pruning can cause data loss.
-- If a tool call is blocked by the risk profile, tell the user and suggest
-  alternatives if possible.
-- NEVER fabricate command output. If a tool fails, report the error.
+- When the user requests an action, call the tool directly. Do NOT ask for confirmation
+  — the risk gate handles approval for dangerous actions via a UI dialog automatically.
+- NEVER fabricate command output. If a tool fails or is blocked, report the error
+  and continue with any remaining work. Do NOT stop responding.
 
 {build_risk_section(ctx)}
 {build_hosts_section(ctx)}\

--- a/src/squire/instructions/monitor_agent.py
+++ b/src/squire/instructions/monitor_agent.py
@@ -36,7 +36,8 @@ system health, resource usage, container status, logs, and configuration.
 - Use `read_config` to inspect configuration files.
 - Only call tools when the user's message requires current system data.
   For high-level summaries, use the snapshot in your context.
-- NEVER fabricate command output. If a tool fails, report the error.
+- NEVER fabricate command output. If a tool fails or is blocked, report the error
+  and continue with any remaining work. Do NOT stop responding.
 
 {build_risk_section(ctx)}
 {build_hosts_section(ctx)}\

--- a/src/squire/instructions/notifier_agent.py
+++ b/src/squire/instructions/notifier_agent.py
@@ -39,7 +39,8 @@ or remove rules they no longer need.
 - Use `send_notification` to send a test or ad-hoc notification.
 - Help users formulate alert conditions from natural language descriptions
   (e.g., "alert me if disk is almost full" → `disk_percent > 90`).
-- NEVER fabricate tool output. If a tool fails, report the error.
+- NEVER fabricate tool output. If a tool fails or is blocked, report the error
+  and continue with any remaining work. Do NOT stop responding.
 
 {build_risk_section(ctx)}
 {build_hosts_section(ctx)}\

--- a/src/squire/instructions/shared.py
+++ b/src/squire/instructions/shared.py
@@ -219,6 +219,7 @@ def format_risk_guidance(threshold: int) -> str:
     return (
         f"Your risk tolerance is set to {threshold}/5 ({level_label}). "
         f"Tools at risk level {threshold} or below run automatically. "
-        f"Tools above level {threshold} require user approval before execution. "
+        f"Tools above level {threshold} require user approval via a UI dialog — "
+        f"you do NOT need to ask the user for confirmation yourself. Just call the tool. "
         f"Some tools may be individually overridden (always allowed, always prompted, or denied)."
     )

--- a/src/squire/instructions/squire_agent.py
+++ b/src/squire/instructions/squire_agent.py
@@ -37,15 +37,20 @@ def build_instruction(ctx: ReadonlyContext) -> str:
   specific recommendations. The snapshot is useful for high-level summaries but may be stale.
 - When you do need system data, use the provided tools —
   NEVER fabricate, simulate, or hallucinate command output.
-- NEVER pretend you have run a command or tool. If a tool call fails, is blocked, or is denied,
-  tell the user exactly what happened and why. Do not retry the same failing call.
 - When using `docker_compose`, just provide the service name —
   the project directory resolves automatically from the host's service_root.
-- For mutations (restarting containers, modifying configs),
-  explain what you'll do and why before executing.
-- If a tool call is blocked by the risk profile or a command is denied by the allowlist,
-  tell the user it was blocked and why. Suggest alternatives if possible.
+- When the user requests an action, call the tool directly. Do NOT ask the user for
+  confirmation before calling — the risk gate handles approval for dangerous actions
+  automatically. Just call the tool.
 - When reporting errors or issues, include relevant log snippets or error messages.
+
+## Handling Tool Errors and Blocks
+- If a tool result starts with [BLOCKED] or [DENIED], the risk gate prevented execution.
+  Do NOT retry the same call. Tell the user it was blocked, explain why, and suggest alternatives.
+- If a tool returns an error, acknowledge it, explain what went wrong, and continue
+  with any remaining work. Do NOT stop responding — always give the user a complete answer.
+- NEVER pretend you have run a command or tool. If a tool call fails, tell the user
+  exactly what happened.
 
 {build_risk_section(ctx)}
 {build_hosts_section(ctx)}\


### PR DESCRIPTION
## Summary

- Remove instruction that told the LLM to "explain what you'll do before executing" mutations — this conflicted with the risk gate's UI approval dialog, causing users to approve actions twice (#46)
- Restructure risk gate error messages with `[BLOCKED]`/`[DENIED]` prefixes and explicit "do NOT retry" guidance so the LLM acknowledges errors and continues responding instead of halting (#44)
- Update all agent instructions (root + 4 sub-agents) with consistent guidance: call tools directly without asking for confirmation, and always continue responding after tool errors

## Test plan

- [x] 333 tests pass (no test changes needed — existing assertions use broad string matching)
- [x] Lint and format clean
- [x] Manual: trigger a tool requiring approval, verify Squire calls it directly without asking in natural language first
- [x] Manual: deny an approval, verify Squire acknowledges denial and continues responding
- [x] Manual: trigger a tool error, verify Squire reports the error and completes its response

Fixes #46, fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)