### PR TITLE
fix(web): default Watch page to Live Stream tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Watch page now defaults to Live Stream tab instead of Cycle History (#37)
+
 ## [0.7.0] — 2026-04-05
 
 ### Changed

--- a/web/src/app/watch/page.tsx
+++ b/web/src/app/watch/page.tsx
@@ -35,7 +35,7 @@ export default function WatchPage() {
         <WatchStatsCard status={status ?? null} />
       </div>
 
-      <Tabs defaultValue={isRunning ? "stream" : "history"}>
+      <Tabs defaultValue="stream">
         <TabsList>
           <TabsTrigger value="stream">Live Stream</TabsTrigger>
           <TabsTrigger value="history">Cycle History</TabsTrigger>


### PR DESCRIPTION
## Summary

- Hardcode `defaultValue="stream"` on the Watch page Tabs component so Live Stream is always the default tab
- The previous conditional (`isRunning ? "stream" : "history"`) raced against the SWR status fetch, causing Cycle History to be selected on mount

Fixes #37

## Test plan

- [x] Open the Watch page — Live Stream tab should be selected by default
- [x] Verify tab switching between Live Stream and Cycle History still works
- [x] Next.js build passes (`cd web && npx next build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)