### PR TITLE
docs: update configuration reference with missing options and tested models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **Configuration reference** — document email notifications (`[notifications.email]`), per-tool risk overrides (`tools_risk_overrides`), host fields (`key_file`, `service_root`), and fix misleading claim about `[[hosts]]` in TOML
+- **squire.example.toml** — add `multi_agent`, `tools_risk_overrides`, and `[notifications.email]` sections
+- **Tested models** — add model recommendations section with tested Ollama models and cloud provider guidance
+
 ### Changed
 
 - **UI color palette** — migrated web and TUI from amber/gold to purple primary (#8931c4) + orange accent (#ff7621) palette with matching semantic colors (danger, success, warning, info)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,8 @@ To get started, copy the example config:
 cp squire.example.toml squire.toml
 ```
 
+> **Looking for model recommendations?** See [Tested Models](#tested-models) for what's been validated.
+
 ---
 
 ## Top-Level Settings
@@ -103,6 +105,16 @@ tools_deny = ["run_command"]             # hard block, never execute
 | `tools_allow` | `[]` | `SQUIRE_GUARDRAILS_TOOLS_ALLOW` | Tool names that bypass risk check |
 | `tools_require_approval` | `[]` | `SQUIRE_GUARDRAILS_TOOLS_REQUIRE_APPROVAL` | Tool names that always require approval |
 | `tools_deny` | `[]` | `SQUIRE_GUARDRAILS_TOOLS_DENY` | Tool names that are hard-blocked |
+| `tools_risk_overrides` | `{}` | `SQUIRE_GUARDRAILS_TOOLS_RISK_OVERRIDES` | Per-tool risk level overrides (see below) |
+
+### Per-Tool Risk Level Overrides
+
+Override the built-in risk level for specific tools or tool actions. Values are integers 1--5. Keys can be a tool name (applies to all actions) or `tool:action` for granular control:
+
+```toml
+[guardrails]
+tools_risk_overrides = { "docker_compose:restart" = 4, "run_command" = 3 }
+```
 
 ### Command Guards
 
@@ -238,6 +250,19 @@ model = "gemini/gemini-2.0-flash"
 # Set GEMINI_API_KEY env var
 ```
 
+### Tested Models
+
+Squire relies heavily on tool/function calling. Models with strong tool-calling support produce the best results, especially for multi-step orchestration in watch mode.
+
+| Model | Provider | Status | Notes |
+|---|---|---|---|
+| `ollama_chat/mistral-small3.2:24b` | Ollama | **Recommended** | Current development model (v0.5.0+). Reliable tool-calling accuracy. |
+| `ollama_chat/llama3.1:8b` | Ollama | Not recommended | Used pre-v0.4.0. Tool-call accuracy was limited; suitable for basic queries only. |
+
+**Cloud providers (Anthropic, OpenAI, Gemini):** These are supported via LiteLLM and expected to perform well -- particularly larger models with strong tool-calling capabilities -- but have not been validated with Squire yet. If you try a cloud model, feedback is welcome via [GitHub issues](https://github.com/willdahern/squire/issues).
+
+**General guidance:** Larger parameter counts and models specifically fine-tuned for function calling tend to produce better results with Squire. If a model struggles with tool calls (wrong arguments, skipped calls, hallucinated tool names), try a larger variant or a different model family.
+
 ---
 
 ## Skills -- `[skills]`
@@ -305,7 +330,9 @@ snapshot_interval_minutes = 15
 
 ## Remote Hosts
 
-Hosts are managed at runtime through the CLI or web UI — there are no `[[hosts]]` entries in `squire.toml`. Squire persists host configuration in SQLite and makes changes available immediately without a restart.
+Hosts are managed at runtime through the CLI or web UI. Squire persists host configuration in SQLite and makes changes available immediately without a restart.
+
+> **Note:** While `[[hosts]]` entries can appear in `squire.toml`, they are **not loaded** by the application. Use the CLI or web UI to manage hosts.
 
 ### Adding a Host
 
@@ -320,8 +347,10 @@ squire hosts add --name nas --address 192.168.1.20 --user will --port 2222 --tag
 | `--address` | *(required)* | Hostname or IP address |
 | `--user` | `"root"` | SSH username |
 | `--port` | `22` | SSH port |
+| `--key-file` | *(auto-generated)* | Path to SSH private key (uses auto-generated ed25519 key by default) |
 | `--tags` | `[]` | Comma-separated tags for grouping |
 | `--services` | `[]` | Comma-separated Docker Compose service names on this host |
+| `--service-root` | `"/opt"` | Root directory for compose service directories on the host |
 
 ### Enrollment Flow
 
@@ -444,6 +473,35 @@ url = "https://ntfy.sh/squire-alerts"
 events = ["*"]
 headers = { Authorization = "Bearer tk_..." }
 ```
+
+### Email -- `[notifications.email]`
+
+Email-based notifications as an alternative (or complement) to webhooks.
+
+```toml
+[notifications.email]
+enabled = true
+smtp_host = "smtp.example.com"
+smtp_port = 587
+use_tls = true
+smtp_user = "squire@example.com"
+smtp_password = "app-password"
+from_address = "squire@example.com"
+to_addresses = ["admin@example.com"]
+events = ["watch.alert", "watch.action"]
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Whether email notifications are enabled |
+| `smtp_host` | `""` | SMTP server hostname |
+| `smtp_port` | `587` | SMTP port (typically 587 for TLS) |
+| `use_tls` | `true` | Use STARTTLS for SMTP connection |
+| `smtp_user` | `""` | SMTP authentication username |
+| `smtp_password` | `""` | SMTP authentication password |
+| `from_address` | `""` | Email sender address |
+| `to_addresses` | `[]` | Recipient email addresses |
+| `events` | `["*"]` | Event categories to send (`"*"` for all) |
 
 ### Event Categories
 

--- a/squire.example.toml
+++ b/squire.example.toml
@@ -15,6 +15,7 @@
 # risk_strict = false              # true = deny above threshold; false = prompt for approval
 # history_limit = 50               # Max messages in conversation context
 # max_tool_rounds = 10             # Max tool-call rounds per user message
+# multi_agent = false              # Enable sub-agent decomposition (Monitor, Container, Admin, Notifier)
 
 # --- LLM provider ---
 [llm]
@@ -33,6 +34,7 @@
 # tools_allow = ["docker_logs"]            # bypass risk check, auto-run
 # tools_require_approval = ["docker_compose"]  # always ask user first
 # tools_deny = ["run_command"]             # hard block, never run
+# tools_risk_overrides = {}                # per-tool risk overrides (tool name or tool:action -> 1-5)
 
 # Per-agent tolerance overrides (only relevant when multi_agent = true)
 # monitor_tolerance = "standard"
@@ -92,4 +94,16 @@
 # [[notifications.webhooks]]
 # name = "ntfy"
 # url = "https://ntfy.sh/squire-alerts"
+# events = ["*"]
+
+# --- Email notifications ---
+# [notifications.email]
+# enabled = false
+# smtp_host = ""
+# smtp_port = 587
+# use_tls = true
+# smtp_user = ""
+# smtp_password = ""
+# from_address = ""
+# to_addresses = []
 # events = ["*"]


### PR DESCRIPTION
## Problem

The configuration documentation (`docs/configuration.md`) had several gaps where implemented features were undocumented, and one actively misleading claim about host configuration.

## Context

An audit of `docs/configuration.md` against the actual config code in `src/squire/config/` revealed:
- Email notification support (`EmailConfig` in `notifications.py`) was completely undocumented
- Per-tool risk level overrides (`tools_risk_overrides` in `guardrails.py`) were missing from docs
- The hosts section falsely claimed "there are no `[[hosts]]` entries in `squire.toml`"
- Host fields `key_file` and `service_root` were undocumented
- `squire.example.toml` was missing several sections
- No guidance existed on which LLM models have been tested with Squire

## Solution

**`docs/configuration.md`:**
- Added quick-reference callout near the top linking to the new Tested Models section
- Added `tools_risk_overrides` to the guardrails table with a new "Per-Tool Risk Level Overrides" subsection and TOML example
- Added `[notifications.email]` subsection documenting all 9 `EmailConfig` fields with a TOML example
- Fixed the hosts section: replaced false claim with an accurate note that `[[hosts]]` entries are not loaded by the application, and added `--key-file` and `--service-root` to the CLI flags table
- Added "Tested Models" subsection under LLM Provider with a compatibility table, cloud provider guidance, and general model selection advice

**`squire.example.toml`:**
- Added `multi_agent = false` to top-level settings
- Added `tools_risk_overrides = {}` to guardrails section
- Added full `[notifications.email]` section (commented out)

## Testing

### Unit tests
No code changes — documentation only. Existing tests unaffected.

### Integration tests
N/A — no runtime behavior changed.

### Test results
```
ruff check: All checks passed!
ruff format: 103 files already formatted
```

## Reviewer Validation

1. Open `docs/configuration.md` and verify the callout link at the top resolves to the `### Tested Models` heading
2. Check the new `tools_risk_overrides` row in the guardrails table and its subsection
3. Check the `[notifications.email]` subsection matches the fields in `src/squire/config/notifications.py:24-35`
4. Verify the hosts section note accurately reflects that `[[hosts]]` entries are ignored (confirmed via `src/squire/hosts/store.py`)
5. Review `squire.example.toml` for the three new sections

## TODOs / Follow-Ups

- Validate cloud provider models (Anthropic, OpenAI, Gemini) with Squire and update the tested models table
- Consider adding `qwen3.5:35b` to the tested models table once re-evaluated with current codebase

Generated with [Claude Code](https://claude.com/claude-code)