### PR TITLE
feat: async Docker state monitoring with wait_for_state tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **squire.example.toml** — add `multi_agent`, `tools_risk_overrides`, and `[notifications.email]` sections
 - **Tested models** — add model recommendations section with tested Ollama models and cloud provider guidance
 
+### Fixed
+
+- **Agent instructions** — clarify that `docker_ps` (not `docker_compose ps`) is the correct tool for listing all containers on a host; add fallback hint in `docker_compose` error output when compose file is missing
+
 ### Changed
 
 - **UI color palette** — migrated web and TUI from amber/gold to purple primary (#8931c4) + orange accent (#ff7621) palette with matching semantic colors (danger, success, warning, info)
@@ -35,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Web chat:** `wait_for_state` no longer breaks tool schema discovery — removed deferred annotations so `ToolContext` resolves under `safe_tool` wrappers (ADK `get_type_hints` previously evaluated hints in `_safe`’s globals and raised `NameError`)
 - **Tests:** `NotificationsConfig` and `WatchConfig` default tests no longer pick up `~/.config/squire/squire.toml` from the developer machine
 - **Docker:** create `/root/.ssh/known_hosts` in the image so SSH to remote hosts works with strict host key checking (#66)
 - **Web:** Watch nav item missing from sidebar on initial page load due to hydration mismatch (#35)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent:** `wait_for_state` tool — framework-level Docker container polling (`healthy` / `running` / `exited`) without LLM calls per tick; web chat delivers results via `monitor_complete` WebSocket messages; TUI and watch mode register session sinks for background completion (#67)
 - **Watch:** "Clear History" button on Cycle History tab with confirmation dialog; calls `DELETE /api/watch/cycles` to truncate cycle data (#36)
 - **Watch:** "Clear Stream" button on Live Stream tab to clear in-memory event buffer (#36)
 - **Watch:** Accumulating "Load More" pagination on Cycle History — cycles append instead of replacing; "Back to Latest" button resets to page 1 (#22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Multi-agent tool tables** — Container sub-agent lists `wait_for_state` alongside Docker lifecycle tools (aligned with `CONTAINER_TOOLS`)
 - **Architecture overview** — new `docs/architecture.md` with Mermaid diagrams covering system overview, agent modes, request flow, risk pipeline, watch loop, tech stack, database schema, and backend registry
 - **Usage guide** — new `docs/usage.md` comprehensive guide covering all three interfaces, configuration, remote hosts, multi-agent mode, watch mode, alert rules, skills, notifications, and Docker deployment
 - **CONTRIBUTING.md** — expand from 54 lines to ~200 lines; add prerequisites, project structure, detailed code conventions, step-by-step tool-authoring guide with accurate registration instructions, testing section with fixture usage, and PR workflow
@@ -28,8 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **UI color palette** — migrated web and TUI from amber/gold to purple primary (#8931c4) + orange accent (#ff7621) palette with matching semantic colors (danger, success, warning, info)
 
+### Security
+
+- Pin runtime and dev dependencies in `pyproject.toml` to exact versions (aligned with `uv.lock`) so installs do not float to newer PyPI releases without an explicit lock update (#65)
+
 ### Fixed
 
+- **Tests:** `NotificationsConfig` and `WatchConfig` default tests no longer pick up `~/.config/squire/squire.toml` from the developer machine
+- **Docker:** create `/root/.ssh/known_hosts` in the image so SSH to remote hosts works with strict host key checking (#66)
 - **Web:** Watch nav item missing from sidebar on initial page load due to hydration mismatch (#35)
 - Watch page now defaults to Live Stream tab instead of Cycle History (#37)
 - **docker_ps**: add missing `timeout=30.0` to `backend.run()` call to prevent indefinite hangs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,9 @@ COPY src/ src/
 ENV SQUIRE_RISK_PROFILE=cautious
 ENV SQUIRE_DB_PATH=/data/squire.db
 
+# Strict host key checking requires known_hosts to exist; mount over /root/.ssh for persistence (#66)
+RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh && touch /root/.ssh/known_hosts
+
 VOLUME ["/data"]
 
 ENTRYPOINT ["uv", "run", "squire"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,7 @@ In both modes, the user always sees the single "Squire" persona — sub-agent na
 | Agent | Domain | Tools | Characteristic Risk |
 |---|---|---|---|
 | Monitor | System observation | `system_info`, `network_info`, `docker_ps`, `journalctl`, `read_config` | Read-only, risk 1 |
-| Container | Docker lifecycle | `docker_logs`, `docker_compose`, `docker_container`, `docker_image`, `docker_cleanup` | Cautious, risk 1–4 |
+| Container | Docker lifecycle | `docker_logs`, `docker_compose`, `docker_container`, `docker_image`, `docker_cleanup`, `wait_for_state` | Cautious, risk 1–4 |
 | Admin | System administration | `systemctl`, `run_command` | Elevated, risk 1–4 |
 | Notifier | Alert management | `send_notification`, `list_alert_rules`, `create_alert_rule`, `update_alert_rule`, `delete_alert_rule` | Mostly read-only, risk 1–2 |
 
@@ -74,7 +74,7 @@ flowchart TD
     Root["Root Agent<br/>(Squire — no tools)"]
 
     Monitor["Monitor<br/>system_info · network_info<br/>docker_ps · journalctl · read_config"]
-    Container["Container<br/>docker_logs · docker_compose<br/>docker_container · docker_image · docker_cleanup"]
+    Container["Container<br/>docker_logs · docker_compose<br/>docker_container · docker_image<br/>docker_cleanup · wait_for_state"]
     Admin["Admin<br/>systemctl · run_command"]
     Notifier["Notifier<br/>send_notification · alert rule tools"]
 

--- a/docs/superpowers/plans/2026-04-05-docker-web-app.md
+++ b/docs/superpowers/plans/2026-04-05-docker-web-app.md
@@ -1,0 +1,595 @@
+# Docker Web App Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the Docker setup from TUI-first to web-first with a multi-stage build, health check endpoint, docker-compose, and updated documentation.
+
+**Architecture:** Multi-stage Dockerfile (Node builds frontend, Python serves everything). All persistent data consolidated under `/data` via environment variables. A new `/api/health` endpoint supports Docker health checks.
+
+**Tech Stack:** Docker multi-stage (Node 22-slim + Python 3.12-slim), FastAPI, docker-compose
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/squire/api/routers/health.py` | Create | Health check endpoint |
+| `src/squire/api/app.py` | Modify | Include health router |
+| `src/squire/system/keys.py` | Modify | Configurable keys directory via env var |
+| `tests/test_health.py` | Create | Health endpoint test |
+| `tests/test_keys.py` | Create | Keys directory configurability test |
+| `docker/Dockerfile` | Rewrite | Multi-stage build with web default |
+| `docker-compose.yml` | Create | Compose file for quickstart |
+| `Makefile` | Modify | Update `docker-run` target |
+| `docs/usage.md` | Modify | Rewrite Docker Deployment section |
+| `CHANGELOG.md` | Modify | Add entries |
+
+---
+
+### Task 1: Health Check Endpoint
+
+**Files:**
+- Create: `tests/test_health.py`
+- Create: `src/squire/api/routers/health.py`
+- Modify: `src/squire/api/app.py:166-177`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_health.py`:
+
+```python
+"""Health check endpoint tests."""
+
+from fastapi.testclient import TestClient
+
+from squire.api.app import create_app
+
+
+def test_health_returns_ok():
+    app = create_app()
+    client = TestClient(app)
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_health.py::test_health_returns_ok -v`
+Expected: FAIL — 404 because the route doesn't exist yet.
+
+- [ ] **Step 3: Create the health router**
+
+Create `src/squire/api/routers/health.py`:
+
+```python
+"""Health check endpoint."""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("")
+async def health():
+    """Lightweight liveness check — confirms the web server is responsive."""
+    return {"status": "ok"}
+```
+
+- [ ] **Step 4: Register the health router in the app**
+
+In `src/squire/api/app.py`, add the import alongside the existing router imports (around line 37) and mount it alongside the other routers (around line 167).
+
+Add to the import block where other routers are imported:
+
+```python
+from .routers import health
+```
+
+Add after the existing `app.include_router(...)` lines (before the `if static_dir:` block):
+
+```python
+app.include_router(health.router, prefix="/api/health", tags=["health"])
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_health.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_health.py src/squire/api/routers/health.py src/squire/api/app.py
+git commit -m "feat(api): add /api/health endpoint for Docker health checks"
+```
+
+---
+
+### Task 2: Configurable SSH Keys Directory
+
+**Files:**
+- Create: `tests/test_keys.py`
+- Modify: `src/squire/system/keys.py:16-18`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_keys.py`:
+
+```python
+"""SSH keys directory configurability tests."""
+
+from pathlib import Path
+
+from squire.system.keys import _keys_dir
+
+
+def test_keys_dir_default():
+    """Without env var, uses ~/.config/squire/keys/."""
+    result = _keys_dir()
+    assert result == Path.home() / ".config" / "squire" / "keys"
+
+
+def test_keys_dir_from_env(monkeypatch, tmp_path):
+    """SQUIRE_KEYS_DIR overrides the default."""
+    custom = tmp_path / "custom-keys"
+    monkeypatch.setenv("SQUIRE_KEYS_DIR", str(custom))
+    result = _keys_dir()
+    assert result == custom
+```
+
+- [ ] **Step 2: Run tests to verify the env var test fails**
+
+Run: `uv run pytest tests/test_keys.py -v`
+Expected: `test_keys_dir_default` PASSES, `test_keys_dir_from_env` FAILS because `_keys_dir()` ignores the env var.
+
+- [ ] **Step 3: Update `_keys_dir()` to read env var**
+
+In `src/squire/system/keys.py`, replace the `_keys_dir` function:
+
+Old:
+```python
+def _keys_dir() -> Path:
+    """Return the keys storage directory."""
+    return Path.home() / ".config" / "squire" / "keys"
+```
+
+New:
+```python
+def _keys_dir() -> Path:
+    """Return the keys storage directory.
+
+    Reads SQUIRE_KEYS_DIR env var, falling back to ~/.config/squire/keys/.
+    """
+    if env := os.environ.get("SQUIRE_KEYS_DIR"):
+        return Path(env)
+    return Path.home() / ".config" / "squire" / "keys"
+```
+
+Also update the module docstring — replace the first two lines:
+
+Old:
+```python
+"""SSH key management — generate, retrieve, and delete ed25519 key pairs.
+
+Keys are stored in ~/.config/squire/keys/ with one file per host:
+```
+
+New:
+```python
+"""SSH key management — generate, retrieve, and delete ed25519 key pairs.
+
+Keys are stored in SQUIRE_KEYS_DIR (default ~/.config/squire/keys/) with one file per host:
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_keys.py -v`
+Expected: Both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_keys.py src/squire/system/keys.py
+git commit -m "feat(keys): make SSH keys directory configurable via SQUIRE_KEYS_DIR"
+```
+
+---
+
+### Task 3: Multi-Stage Dockerfile
+
+**Files:**
+- Rewrite: `docker/Dockerfile`
+
+- [ ] **Step 1: Rewrite the Dockerfile**
+
+Replace the entire contents of `docker/Dockerfile` with:
+
+```dockerfile
+# Stage 1: Build the Next.js frontend
+FROM node:22-slim AS frontend
+
+WORKDIR /web
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
+
+# Stage 2: Python application
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install uv for fast dependency management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copy dependency metadata first (cache-friendly layer ordering)
+COPY pyproject.toml uv.lock ./
+COPY README.md ./
+
+# Install dependencies
+RUN uv sync --no-dev --frozen
+
+# Copy application source
+COPY src/ src/
+
+# Copy frontend build from Stage 1
+COPY --from=frontend /web/out web/out
+
+# Consolidate all persistent data under /data
+ENV SQUIRE_DB_PATH=/data/squire.db
+ENV SQUIRE_SKILLS_PATH=/data/skills
+ENV SQUIRE_KEYS_DIR=/data/keys
+ENV SQUIRE_RISK_PROFILE=cautious
+
+VOLUME ["/data"]
+EXPOSE 8420
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=10s \
+    CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8420/api/health')"]
+
+ENTRYPOINT ["uv", "run", "squire"]
+CMD ["web"]
+```
+
+- [ ] **Step 2: Verify the build works**
+
+Run: `docker build -f docker/Dockerfile -t squire .`
+Expected: Both stages complete successfully. The image should contain `web/out/` with the static export.
+
+- [ ] **Step 3: Verify the container starts and health check passes**
+
+Run: `docker run --rm -d --name squire-test -p 8420:8420 -e SQUIRE_LLM_MODEL=ollama_chat/llama3.1:8b squire`
+
+Wait ~15 seconds, then:
+
+Run: `curl -s http://localhost:8420/api/health`
+Expected: `{"status":"ok"}`
+
+Run: `docker ps --filter name=squire-test --format '{{.Status}}'`
+Expected: Shows `(healthy)` after the start period.
+
+Clean up: `docker stop squire-test`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker/Dockerfile
+git commit -m "feat(docker): multi-stage build with web frontend and health check"
+```
+
+---
+
+### Task 4: docker-compose.yml
+
+**Files:**
+- Create: `docker-compose.yml`
+
+- [ ] **Step 1: Create the compose file**
+
+Create `docker-compose.yml` at the project root:
+
+```yaml
+# Squire — AI-powered homelab monitoring and management
+# Quick start: docker compose up -d
+# Web UI: http://localhost:8420
+
+services:
+  squire:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8420:8420"
+    volumes:
+      - squire-data:/data
+    environment:
+      # LLM provider — configure one of these:
+      # Ollama (default — assumes Ollama running on the Docker host)
+      - SQUIRE_LLM_MODEL=ollama_chat/llama3.1:8b
+      - SQUIRE_LLM_API_BASE=http://host.docker.internal:11434
+      # Anthropic:
+      # - SQUIRE_LLM_MODEL=anthropic/claude-sonnet-4-20250514
+      # - ANTHROPIC_API_KEY=sk-ant-...
+      # OpenAI:
+      # - SQUIRE_LLM_MODEL=openai/gpt-4o
+      # - OPENAI_API_KEY=sk-...
+      # Google Gemini:
+      # - SQUIRE_LLM_MODEL=gemini/gemini-2.0-flash
+      # - GEMINI_API_KEY=...
+
+      # Risk tolerance (read-only | cautious | standard | full-trust)
+      # - SQUIRE_RISK_TOLERANCE=cautious
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8420/api/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+    # To mount a config file instead of using env vars:
+    # volumes:
+    #   - squire-data:/data
+    #   - ./squire.toml:/app/squire.toml:ro
+
+    # To run watch mode instead of the web UI:
+    # command: watch
+
+volumes:
+  squire-data:
+```
+
+- [ ] **Step 2: Verify compose starts**
+
+Run: `docker compose up -d --build`
+Expected: Container starts, becomes healthy.
+
+Run: `curl -s http://localhost:8420/api/health`
+Expected: `{"status":"ok"}`
+
+Clean up: `docker compose down`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat(docker): add docker-compose.yml for quickstart deployment"
+```
+
+---
+
+### Task 5: Update Makefile
+
+**Files:**
+- Modify: `Makefile:79-85`
+
+- [ ] **Step 1: Update the docker-run target**
+
+In `Makefile`, replace the `docker-run` target:
+
+Old:
+```makefile
+.PHONY: docker-run
+docker-run: ## Run Docker container
+	docker run --rm -it -v squire-data:/data squire
+```
+
+New:
+```makefile
+.PHONY: docker-run
+docker-run: ## Run Docker container (web UI on port 8420)
+	docker run --rm -d -p 8420:8420 -v squire-data:/data --name squire squire
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Makefile
+git commit -m "chore: update docker-run target for web UI"
+```
+
+---
+
+### Task 6: Update Documentation
+
+**Files:**
+- Modify: `docs/usage.md:471-501`
+
+- [ ] **Step 1: Rewrite the Docker Deployment section**
+
+In `docs/usage.md`, replace everything from `## Docker Deployment` (line 475) to the end of the file with:
+
+```markdown
+## Docker Deployment
+
+The Docker image runs the **web interface** by default — the TUI is not supported in containers. The image includes a pre-built frontend, so no separate Node.js process is needed.
+
+### Quick Start (docker-compose)
+
+The recommended way to run Squire in Docker:
+
+```bash
+docker compose up -d
+```
+
+The web UI is available at **http://localhost:8420**.
+
+The default `docker-compose.yml` assumes Ollama is running on the Docker host. Edit the `environment` section to configure your LLM provider — see the comments in the file for examples with Anthropic, OpenAI, and Gemini.
+
+### Manual Docker Run
+
+```bash
+# Build the image
+make docker-build
+# or: docker build -f docker/Dockerfile -t squire .
+
+# Run the web UI
+docker run -d -p 8420:8420 -v squire-data:/data \
+  -e SQUIRE_LLM_MODEL=ollama_chat/llama3.1:8b \
+  -e SQUIRE_LLM_API_BASE=http://host.docker.internal:11434 \
+  --name squire squire
+```
+
+### Ports
+
+| Port | Service |
+|---|---|
+| **8420** | Web UI + REST API + WebSocket (single port) |
+
+### Data Volume
+
+All persistent data lives under `/data` inside the container. Mount a named volume or host directory to preserve state across restarts:
+
+| Path | Contents |
+|---|---|
+| `/data/squire.db` | SQLite database (sessions, events, alert rules, watch state) |
+| `/data/skills/` | Skill definitions (Open Agent Skills format) |
+| `/data/keys/` | SSH key pairs for managed remote hosts |
+
+```bash
+# Use a named volume (recommended)
+docker run -v squire-data:/data ...
+
+# Or bind-mount a host directory
+docker run -v /opt/squire/data:/data ...
+```
+
+### Configuration
+
+Configuration can be provided via environment variables or a config file:
+
+**Environment variables** (recommended for Docker):
+
+```bash
+docker run -d -p 8420:8420 -v squire-data:/data \
+  -e SQUIRE_LLM_MODEL=anthropic/claude-sonnet-4-20250514 \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -e SQUIRE_RISK_TOLERANCE=standard \
+  squire
+```
+
+**Config file** (bind-mount):
+
+```bash
+docker run -d -p 8420:8420 \
+  -v squire-data:/data \
+  -v ./squire.toml:/app/squire.toml:ro \
+  squire
+```
+
+See the [Configuration Reference](configuration.md) for all available options.
+
+### LLM Provider Setup
+
+**Ollama (local):** If Ollama runs on the Docker host, use `host.docker.internal` to reach it:
+
+```bash
+-e SQUIRE_LLM_MODEL=ollama_chat/llama3.1:8b
+-e SQUIRE_LLM_API_BASE=http://host.docker.internal:11434
+```
+
+> **Note:** `host.docker.internal` works on Docker Desktop (macOS/Windows). On Linux, add `--add-host=host.docker.internal:host-gateway` to your `docker run` command, or use the host's LAN IP address.
+
+**Cloud providers:** Set the model and API key as environment variables:
+
+```bash
+# Anthropic
+-e SQUIRE_LLM_MODEL=anthropic/claude-sonnet-4-20250514 -e ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI
+-e SQUIRE_LLM_MODEL=openai/gpt-4o -e OPENAI_API_KEY=sk-...
+
+# Google Gemini
+-e SQUIRE_LLM_MODEL=gemini/gemini-2.0-flash -e GEMINI_API_KEY=...
+```
+
+### Watch Mode
+
+To run autonomous monitoring instead of the web UI, override the command:
+
+```bash
+# docker-compose: uncomment "command: watch" in docker-compose.yml
+
+# Manual:
+docker run -d -v squire-data:/data \
+  -e SQUIRE_LLM_MODEL=ollama_chat/llama3.1:8b \
+  -e SQUIRE_LLM_API_BASE=http://host.docker.internal:11434 \
+  --name squire-watch squire watch
+```
+
+You can run both side by side — the web UI on one container and watch mode on another — sharing the same data volume:
+
+```bash
+docker run -d -p 8420:8420 -v squire-data:/data --name squire-web squire
+docker run -d -v squire-data:/data --name squire-watch squire watch
+```
+
+### CLI Commands
+
+Run one-off CLI commands against a running container or the data volume:
+
+```bash
+# Against a running container
+docker exec squire uv run squire alerts list
+docker exec squire uv run squire sessions list
+
+# One-off with the data volume
+docker run --rm -v squire-data:/data squire alerts list
+docker run --rm -v squire-data:/data squire hosts list
+```
+
+### Health Check
+
+The container includes a built-in health check (`GET /api/health`) that verifies the web server is responsive. Docker reports health status in `docker ps`:
+
+```
+CONTAINER ID   IMAGE    STATUS                    PORTS
+abc123         squire   Up 2 minutes (healthy)    0.0.0.0:8420->8420/tcp
+```
+
+The health check runs every 30 seconds with a 10-second startup grace period.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/usage.md
+git commit -m "docs: rewrite Docker deployment section for web-first container"
+```
+
+---
+
+### Task 7: Update CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md:10-14`
+
+- [ ] **Step 1: Add changelog entries**
+
+In `CHANGELOG.md`, add the following entries under `## [Unreleased]` → `### Added` (after the existing Watch entries at line 14):
+
+```markdown
+- **Docker:** Multi-stage Dockerfile that builds the Next.js frontend and serves the web UI by default; includes `HEALTHCHECK` directive
+- **Docker:** `docker-compose.yml` quickstart with volume, port, and LLM provider configuration
+- **API:** `GET /api/health` liveness endpoint returning `{"status": "ok"}`
+- **Config:** `SQUIRE_KEYS_DIR` environment variable to override the SSH keys storage directory (default `~/.config/squire/keys/`)
+```
+
+- [ ] **Step 2: Run linter**
+
+Run: `uv run ruff check src/ tests/`
+Expected: No errors.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest`
+Expected: All tests pass including new health and keys tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add changelog entries for Docker web app support"
+```

--- a/docs/superpowers/specs/2026-04-05-docker-web-app-design.md
+++ b/docs/superpowers/specs/2026-04-05-docker-web-app-design.md
@@ -1,0 +1,120 @@
+# Docker Web App Support
+
+**Date:** 2026-04-05
+**Status:** Approved
+
+## Problem
+
+The Dockerfile defaults to `squire chat` (TUI mode), which requires an interactive terminal and doesn't suit containerized deployment. The web frontend is not built into the image, and data paths are not consolidated for volume mounting.
+
+## Design
+
+### Multi-stage Dockerfile
+
+**Stage 1 (Node 22-slim):** Install frontend dependencies and run `npm run build` to produce the `web/out/` static export.
+
+**Stage 2 (Python 3.12-slim):** Install Python dependencies with `uv`, copy application source, and copy `web/out/` from the Node stage. The `_find_static_dir()` function in `src/squire/api/app.py` already looks for `web/out/` relative to the package root, so no application code changes are needed for frontend serving.
+
+Key properties:
+
+- `EXPOSE 8420`
+- Default `CMD ["web"]` (replaces `chat`)
+- `HEALTHCHECK` using the new `/api/health` endpoint
+- Environment variables consolidate all persistent data under `/data`:
+  - `SQUIRE_DB_PATH=/data/squire.db`
+  - `SQUIRE_SKILLS_PATH=/data/skills`
+  - `SQUIRE_KEYS_DIR=/data/keys`
+- Single `VOLUME ["/data"]`
+
+### Health check endpoint
+
+New `GET /api/health` endpoint on the FastAPI app:
+
+- Returns `{"status": "ok"}` with HTTP 200
+- No database or LLM connectivity check -- just confirms the web server is responsive
+- Mounted at `/api/health` alongside existing API routers
+- Used by Docker `HEALTHCHECK` and compose `healthcheck:`
+
+Implementation: a simple router in `src/squire/api/routers/health.py` included in `create_app()`.
+
+### Configurable SSH keys directory
+
+The keys directory is currently hardcoded to `~/.config/squire/keys/` in `src/squire/system/keys.py`. Add support for a `SQUIRE_KEYS_DIR` environment variable so Docker can redirect keys storage to `/data/keys/`.
+
+Change `_keys_dir()` to read `os.environ.get("SQUIRE_KEYS_DIR")` with the existing `~/.config/squire/keys/` as fallback.
+
+### docker-compose.yml
+
+New file at project root:
+
+```yaml
+services:
+  squire:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8420:8420"
+    volumes:
+      - squire-data:/data
+    environment:
+      - SQUIRE_LLM_MODEL=ollama_chat/llama3.1:8b
+      - SQUIRE_LLM_API_BASE=http://host.docker.internal:11434
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8420/api/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  squire-data:
+```
+
+Includes commented examples for:
+
+- Config file bind-mount (`./squire.toml:/app/squire.toml:ro`)
+- Cloud provider API keys (`ANTHROPIC_API_KEY`, etc.)
+- Watch mode as alternate command
+
+### Makefile updates
+
+- `docker-run`: expose port 8420, drop `-it` flag, run in detached mode with port mapping
+
+### Documentation updates
+
+Update the "Docker Deployment" section of `docs/usage.md` to cover:
+
+- **Quickstart** with docker-compose as the recommended path
+- **Ports:** 8420 (web UI + API, single port)
+- **Data volume:** `/data` contains database (`squire.db`), skills, and SSH keys
+- **Configuration:** env vars (primary) or bind-mount `squire.toml:/app/squire.toml:ro`
+- **LLM provider setup:** Ollama via `host.docker.internal`, cloud providers via API key env vars
+- **Watch mode:** override command to `watch`
+- **CLI commands:** via `docker exec` or one-off `docker run`
+- **Health check:** built-in, visible via `docker ps` HEALTH column
+- **No TUI:** the container does not support `squire chat`
+
+### CHANGELOG
+
+Add entry for Docker web app support, health check endpoint, and configurable keys directory.
+
+## Out of scope
+
+- TUI support in Docker
+- Separate frontend/backend containers
+- Deep health checks (database connectivity, LLM reachability)
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `docker/Dockerfile` | Multi-stage build, new defaults |
+| `docker-compose.yml` | New file |
+| `src/squire/api/routers/health.py` | New health check router |
+| `src/squire/api/app.py` | Include health router |
+| `src/squire/system/keys.py` | Configurable keys directory |
+| `Makefile` | Update `docker-run` target |
+| `docs/usage.md` | Rewrite Docker Deployment section |
+| `CHANGELOG.md` | New entry |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -214,7 +214,7 @@ multi_agent = true
 | Sub-agent | Role | Default risk tolerance | Tools |
 |---|---|---|---|
 | Monitor | Read-only system observation | `read-only` | `system_info`, `network_info`, `docker_ps`, `journalctl`, `read_config` |
-| Container | Docker lifecycle management | `cautious` | `docker_logs`, `docker_compose`, `docker_container`, `docker_image`, `docker_cleanup` |
+| Container | Docker lifecycle management | `cautious` | `docker_logs`, `docker_compose`, `docker_container`, `docker_image`, `docker_cleanup`, `wait_for_state` |
 | Admin | Systemd and command execution | `standard` | `systemctl`, `run_command` |
 | Notifier | Alerts and notifications | `read-only` | `send_notification`, `list_alert_rules`, `create_alert_rule`, `delete_alert_rule` |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,22 +24,22 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "google-adk>=1.23.0",
-    "litellm>=1.81.1",
-    "pydantic>=2.12.0",
-    "pydantic-settings>=2.0.0",
-    "python-dotenv>=1.0.0",
-    "typer>=0.12.0",
-    "textual>=0.80.0",
-    "rich>=13.0.0",
-    "aiosqlite>=0.19.0",
-    "httpx>=0.27.0",
-    "asyncssh>=2.17.0",
-    "pyyaml>=6.0",
-    "agent-risk-engine>=0.2.0",
-    "tomlkit>=0.13.0",
-    "fastapi>=0.115.0",
-    "uvicorn[standard]>=0.32.0",
+    "google-adk==1.27.1",
+    "litellm==1.82.2",
+    "pydantic==2.12.5",
+    "pydantic-settings==2.13.1",
+    "python-dotenv==1.2.2",
+    "typer==0.24.1",
+    "textual==8.1.1",
+    "rich==14.3.3",
+    "aiosqlite==0.22.1",
+    "httpx==0.28.1",
+    "asyncssh==2.22.0",
+    "pyyaml==6.0.3",
+    "agent-risk-engine==0.2.0",
+    "tomlkit==0.14.0",
+    "fastapi==0.135.1",
+    "uvicorn[standard]==0.41.0",
 ]
 
 [project.scripts]
@@ -47,10 +47,10 @@ squire = "squire.cli:app"
 
 [dependency-groups]
 dev = [
-    "pytest>=9.0.0",
-    "pytest-asyncio>=1.0.0",
-    "ruff>=0.14.0",
-    "mypy>=1.10.0",
+    "pytest==9.0.2",
+    "pytest-asyncio==1.3.0",
+    "ruff==0.15.6",
+    "mypy==1.19.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/squire/agents/container_agent.py
+++ b/src/squire/agents/container_agent.py
@@ -1,6 +1,7 @@
 """Container sub-agent — container lifecycle management.
 
-Tools: docker_logs, docker_compose
+Tools: docker_logs, docker_compose, docker_container, docker_image, docker_cleanup,
+wait_for_state
 """
 
 from google.adk.agents.llm_agent import Agent
@@ -13,8 +14,9 @@ from ..tools.groups import CONTAINER_RISK_LEVELS, CONTAINER_TOOLS
 from ..types import RiskGateFactory
 
 DESCRIPTION = (
-    "Container lifecycle management: viewing container logs, restarting services, "
-    "and managing Docker Compose stacks. Use for container operations and troubleshooting."
+    "Container lifecycle management: logs, Compose stacks, container and image lifecycle, "
+    "Docker cleanup, and async wait-for-container-state after deploys. "
+    "Use for container operations and troubleshooting."
 )
 
 

--- a/src/squire/api/routers/chat.py
+++ b/src/squire/api/routers/chat.py
@@ -18,7 +18,12 @@ from ...agents import create_squire_agent
 from ...callbacks.risk_gate import ADK_INTERNAL_TOOLS, build_pattern_analyzer, create_risk_gate
 from ...config import GuardrailsConfig
 from ...monitoring.registry import cancel_session_monitor_tasks
-from ...monitoring.sinks import WebChatMonitorSink, register_monitor_session_sink, unregister_monitor_session_sink
+from ...monitoring.sinks import (
+    WebChatMonitorSink,
+    get_monitor_session_sink,
+    register_monitor_session_sink,
+    unregister_monitor_session_sink,
+)
 from ...tools import TOOL_RISK_LEVELS
 from ..dependencies import get_app_config, get_db, get_llm_config, get_registry
 from ..schemas import ChatSessionResponse
@@ -360,11 +365,16 @@ async def _stream_response(
     max_turns = 15 if skill_active else 1
     current_text = user_text
 
+    sink = get_monitor_session_sink(session.id)
+
     try:
         all_response_text = ""
         prev_response = ""
 
         for turn in range(max_turns):
+            if isinstance(sink, WebChatMonitorSink):
+                sink.mark_streaming()
+
             turn_response, tools_used = await _run_single_turn(
                 websocket=websocket,
                 runner=runner,
@@ -383,9 +393,13 @@ async def _stream_response(
             # If this is not a skill session or we've exhausted turns, stop.
             if not skill_active or turn >= max_turns - 1:
                 await websocket.send_json({"type": "message_complete", "content": turn_response})
+                if isinstance(sink, WebChatMonitorSink):
+                    sink.mark_idle()
                 break
 
             await websocket.send_json({"type": "message_complete", "content": turn_response})
+            if isinstance(sink, WebChatMonitorSink):
+                sink.mark_idle()
 
             all_response_text += "\n" + turn_response
 
@@ -415,6 +429,9 @@ async def _stream_response(
             await websocket.send_json({"type": "error", "message": str(e)})
         except Exception:
             pass
+    finally:
+        if isinstance(sink, WebChatMonitorSink):
+            sink.mark_idle()
 
 
 async def _run_single_turn(

--- a/src/squire/api/routers/chat.py
+++ b/src/squire/api/routers/chat.py
@@ -272,9 +272,25 @@ async def chat_websocket(
                 )
                 await runner.session_service.append_event(session, event)
 
+    async def _inject_monitor_event(content: str) -> None:
+        """Append the monitor result to the ADK session so the LLM has context on the next turn."""
+        from google.adk.events.event import Event as AdkEvent
+
+        evt = AdkEvent(
+            author=agent.name,
+            invocation_id=AdkEvent.new_id(),
+            content=types.Content(role="model", parts=[types.Part(text=content)]),
+        )
+        await runner.session_service.append_event(session, evt)
+
     register_monitor_session_sink(
         session_id,
-        WebChatMonitorSink(websocket=websocket, db=db, session_id=session_id),
+        WebChatMonitorSink(
+            websocket=websocket,
+            db=db,
+            session_id=session_id,
+            _on_complete=_inject_monitor_event,
+        ),
     )
 
     streaming_task: asyncio.Task | None = None

--- a/src/squire/api/routers/chat.py
+++ b/src/squire/api/routers/chat.py
@@ -17,6 +17,8 @@ from google.genai import types
 from ...agents import create_squire_agent
 from ...callbacks.risk_gate import ADK_INTERNAL_TOOLS, build_pattern_analyzer, create_risk_gate
 from ...config import GuardrailsConfig
+from ...monitoring.registry import cancel_session_monitor_tasks
+from ...monitoring.sinks import WebChatMonitorSink, register_monitor_session_sink, unregister_monitor_session_sink
 from ...tools import TOOL_RISK_LEVELS
 from ..dependencies import get_app_config, get_db, get_llm_config, get_registry
 from ..schemas import ChatSessionResponse
@@ -265,6 +267,11 @@ async def chat_websocket(
                 )
                 await runner.session_service.append_event(session, event)
 
+    register_monitor_session_sink(
+        session_id,
+        WebChatMonitorSink(websocket=websocket, db=db, session_id=session_id),
+    )
+
     streaming_task: asyncio.Task | None = None
 
     try:
@@ -327,6 +334,8 @@ async def chat_websocket(
     except Exception:
         logger.exception("WebSocket error for session %s", session_id)
     finally:
+        cancel_session_monitor_tasks(session_id)
+        unregister_monitor_session_sink(session_id)
         if streaming_task and not streaming_task.done():
             streaming_task.cancel()
 

--- a/src/squire/api/routers/tools.py
+++ b/src/squire/api/routers/tools.py
@@ -21,6 +21,7 @@ from ...tools.read_config import read_config
 from ...tools.run_command import run_command
 from ...tools.system_info import system_info
 from ...tools.systemctl import systemctl
+from ...tools.wait_for_state import wait_for_state
 from ..dependencies import get_guardrails
 from ..schemas import ToolAction, ToolInfo, ToolParameter
 
@@ -40,6 +41,7 @@ _TOOL_ENTRIES: list[tuple[str, object]] = [
     ("journalctl", journalctl),
     ("systemctl", systemctl),
     ("run_command", run_command),
+    ("wait_for_state", wait_for_state),
 ]
 
 
@@ -59,6 +61,8 @@ def _extract_parameters(func: object) -> list[ToolParameter]:
     sig = inspect.signature(func)
     params = []
     for name, param in sig.parameters.items():
+        if name == "tool_context":
+            continue
         hint = param.annotation
         if hint is inspect.Parameter.empty:
             type_name = "str"

--- a/src/squire/instructions/container_agent.py
+++ b/src/squire/instructions/container_agent.py
@@ -25,17 +25,13 @@ def build_instruction(ctx: ReadonlyContext) -> str:
 
 ## Your Role: Container Manager
 You manage container lifecycle — viewing logs, managing containers, pulling
-images, inspecting volumes and networks, cleaning up resources, and managing
-Docker Compose stacks.
+images, cleaning up resources, and managing Docker Compose stacks.
 
 ## Tool Usage
 - Use `docker_logs` to view container logs for troubleshooting.
 - Use `docker_compose` to manage Compose stacks (start, stop, restart, pull, up, down).
 - Use `docker_container` to manage individual containers (inspect, start, stop, restart, remove).
 - Use `docker_image` to manage images (list, inspect, pull, remove).
-- Use `docker_volume` to list volumes or inspect a volume (Mountpoint, driver).
-  For aggregate Docker disk usage, use `docker_cleanup` with action `df`.
-- Use `docker_network` to list networks or inspect a network (containers, IPAM).
 - Use `docker_cleanup` to check disk usage and prune unused resources (containers, images, volumes).
 - Use `wait_for_state` after a restart or deploy when the user asked to wait for a state
   (e.g. healthy, running, stopped). It polls in the background (web/TUI) without burning

--- a/src/squire/instructions/container_agent.py
+++ b/src/squire/instructions/container_agent.py
@@ -25,14 +25,22 @@ def build_instruction(ctx: ReadonlyContext) -> str:
 
 ## Your Role: Container Manager
 You manage container lifecycle — viewing logs, managing containers, pulling
-images, cleaning up resources, and managing Docker Compose stacks.
+images, inspecting volumes and networks, cleaning up resources, and managing
+Docker Compose stacks.
 
 ## Tool Usage
 - Use `docker_logs` to view container logs for troubleshooting.
 - Use `docker_compose` to manage Compose stacks (start, stop, restart, pull, up, down).
 - Use `docker_container` to manage individual containers (inspect, start, stop, restart, remove).
 - Use `docker_image` to manage images (list, inspect, pull, remove).
+- Use `docker_volume` to list volumes or inspect a volume (Mountpoint, driver).
+  For aggregate Docker disk usage, use `docker_cleanup` with action `df`.
+- Use `docker_network` to list networks or inspect a network (containers, IPAM).
 - Use `docker_cleanup` to check disk usage and prune unused resources (containers, images, volumes).
+- Use `wait_for_state` after a restart or deploy when the user asked to wait for a state
+  (e.g. healthy, running, stopped). It polls in the background (web/TUI) without burning
+  tokens each tick. Defaults: interval 5s; use timeout 120s for health, longer for image pulls
+  or slow hosts if appropriate.
 - When using `docker_compose`, provide the service name — the project
   directory resolves automatically from the host's service_root.
 - When the user requests an action, call the tool directly. Do NOT ask for confirmation

--- a/src/squire/instructions/container_agent.py
+++ b/src/squire/instructions/container_agent.py
@@ -28,8 +28,12 @@ You manage container lifecycle — viewing logs, managing containers, pulling
 images, cleaning up resources, and managing Docker Compose stacks.
 
 ## Tool Usage
+- To list containers on a host, use `docker_ps` — it works host-wide with no arguments.
+  Do NOT use `docker_compose ps` for general container listing; it requires a specific
+  service/project and will fail without one.
 - Use `docker_logs` to view container logs for troubleshooting.
 - Use `docker_compose` to manage Compose stacks (start, stop, restart, pull, up, down).
+  Always provide the service name — it is required.
 - Use `docker_container` to manage individual containers (inspect, start, stop, restart, remove).
 - Use `docker_image` to manage images (list, inspect, pull, remove).
 - Use `docker_cleanup` to check disk usage and prune unused resources (containers, images, volumes).

--- a/src/squire/instructions/monitor_agent.py
+++ b/src/squire/instructions/monitor_agent.py
@@ -31,7 +31,8 @@ system health, resource usage, container status, logs, and configuration.
 ## Tool Usage
 - Use `system_info` for CPU, memory, disk, and uptime data.
 - Use `network_info` for network interfaces, routes, and connectivity.
-- Use `docker_ps` to list containers and their states.
+- Use `docker_ps` to list containers and their states. This is the right tool for
+  "what containers are running" — it works host-wide with no arguments.
 - Use `journalctl` to view system and service logs.
 - Use `read_config` to inspect configuration files.
 - Only call tools when the user's message requires current system data.

--- a/src/squire/instructions/squire_agent.py
+++ b/src/squire/instructions/squire_agent.py
@@ -43,6 +43,8 @@ def build_instruction(ctx: ReadonlyContext) -> str:
   confirmation before calling — the risk gate handles approval for dangerous actions
   automatically. Just call the tool.
 - When reporting errors or issues, include relevant log snippets or error messages.
+- When the user wants confirmation after a container action (e.g. restart and wait until
+  healthy), use `wait_for_state` with kind `docker_container` after the mutating tool.
 
 ## Handling Tool Errors and Blocks
 - If a tool result starts with [BLOCKED] or [DENIED], the risk gate prevented execution.

--- a/src/squire/instructions/squire_agent.py
+++ b/src/squire/instructions/squire_agent.py
@@ -37,8 +37,11 @@ def build_instruction(ctx: ReadonlyContext) -> str:
   specific recommendations. The snapshot is useful for high-level summaries but may be stale.
 - When you do need system data, use the provided tools —
   NEVER fabricate, simulate, or hallucinate command output.
-- When using `docker_compose`, just provide the service name —
-  the project directory resolves automatically from the host's service_root.
+- To list containers on a host, use `docker_ps` — it works host-wide with no arguments.
+  Do NOT use `docker_compose ps` for general container listing; it requires a specific
+  service/project and will fail without one.
+- When using `docker_compose`, always provide the service name — the project
+  directory resolves automatically from the host's service_root.
 - When the user requests an action, call the tool directly. Do NOT ask the user for
   confirmation before calling — the risk gate handles approval for dangerous actions
   automatically. Just call the tool.

--- a/src/squire/monitoring/__init__.py
+++ b/src/squire/monitoring/__init__.py
@@ -1,0 +1,25 @@
+"""Framework-level state polling for post-action monitoring (no LLM per tick)."""
+
+from .docker_state import evaluate_container_condition, fetch_container_state_json
+from .registry import cancel_session_monitor_tasks, track_monitor_task
+from .sinks import (
+    TuiChatMonitorSink,
+    WatchNotifierMonitorSink,
+    WebChatMonitorSink,
+    get_monitor_session_sink,
+    register_monitor_session_sink,
+    unregister_monitor_session_sink,
+)
+
+__all__ = [
+    "TuiChatMonitorSink",
+    "WatchNotifierMonitorSink",
+    "WebChatMonitorSink",
+    "cancel_session_monitor_tasks",
+    "evaluate_container_condition",
+    "fetch_container_state_json",
+    "get_monitor_session_sink",
+    "register_monitor_session_sink",
+    "track_monitor_task",
+    "unregister_monitor_session_sink",
+]

--- a/src/squire/monitoring/docker_state.py
+++ b/src/squire/monitoring/docker_state.py
@@ -1,0 +1,74 @@
+"""Docker container state inspection for monitor loops."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal
+
+from ..system.registry import BackendRegistry
+
+logger = logging.getLogger(__name__)
+
+Outcome = Literal["met", "failed", "pending"]
+
+
+async def fetch_container_state_json(registry: BackendRegistry, host: str, container: str) -> dict[str, Any] | None:
+    """Return Docker ``.State`` object as dict, or None if inspect failed."""
+    backend = registry.get(host)
+    result = await backend.run(
+        ["docker", "inspect", "--format", "{{json .State}}", container],
+        timeout=30.0,
+    )
+    if result.returncode != 0:
+        err = (result.stderr or "").strip() or "unknown error"
+        logger.debug("docker inspect failed for %s on %s: %s", container, host, err)
+        return None
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        logger.debug("Invalid docker inspect JSON for %s", container, exc_info=True)
+        return None
+
+
+def evaluate_container_condition(state: dict[str, Any], condition: str) -> tuple[Outcome, str]:
+    """Classify whether ``condition`` is satisfied given Docker ``State`` JSON.
+
+    Returns:
+        (outcome, human-readable detail). ``met`` means stop successfully;
+        ``failed`` means abort; ``pending`` means keep polling.
+    """
+    condition = condition.strip().lower()
+    running = bool(state.get("Running"))
+    status = str(state.get("Status", ""))
+    exit_code = state.get("ExitCode")
+    health = state.get("Health")
+
+    if condition == "running":
+        if running:
+            return "met", "Container is running."
+        if "dead" in status.lower():
+            return "failed", f"Container is dead (status: {status})."
+        if exit_code not in (None, 0) and not running:
+            return "failed", f"Container stopped with exit code {exit_code}."
+        return "pending", f"Not running yet (status: {status})."
+
+    if condition == "healthy":
+        if not health:
+            return "failed", "Container has no health check configured; cannot wait for healthy."
+        hs = str(health.get("Status", "")).lower()
+        if hs == "healthy":
+            return "met", "Health check reports healthy."
+        if hs == "unhealthy":
+            return "failed", "Health check reports unhealthy."
+        return "pending", f"Health status: {health.get('Status', hs)}."
+
+    if condition == "exited":
+        if not running:
+            return "met", "Container is stopped."
+        return "pending", "Container still running."
+
+    return "failed", f"Unknown condition '{condition}'. Use: running, healthy, or exited."

--- a/src/squire/monitoring/loop.py
+++ b/src/squire/monitoring/loop.py
@@ -1,0 +1,88 @@
+"""Async poll loop until condition, timeout, or failure."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from ..system.registry import BackendRegistry
+from .docker_state import evaluate_container_condition, fetch_container_state_json
+
+ProgressCallback = Callable[[str], Awaitable[None]]
+
+
+@dataclass
+class MonitorLoopResult:
+    """Outcome of a monitor loop."""
+
+    status: Literal["success", "timeout", "error"]
+    message: str
+    elapsed_seconds: float
+    last_detail: str = ""
+
+
+async def run_docker_container_monitor(
+    *,
+    registry: BackendRegistry,
+    host: str,
+    container: str,
+    condition: str,
+    interval_seconds: int,
+    timeout_seconds: int,
+    on_progress: ProgressCallback | None = None,
+) -> MonitorLoopResult:
+    """Poll ``docker inspect`` until ``evaluate_container_condition`` reports met/failed or time runs out."""
+    deadline = time.monotonic() + timeout_seconds
+    last_detail = ""
+    cond = condition.strip().lower()
+
+    while time.monotonic() < deadline:
+        state = await fetch_container_state_json(registry, host, container)
+        if state is None:
+            return MonitorLoopResult(
+                status="error",
+                message=f"Could not inspect container '{container}' on host '{host}' (missing or docker error).",
+                elapsed_seconds=timeout_seconds - max(0.0, deadline - time.monotonic()),
+                last_detail=last_detail,
+            )
+
+        outcome, detail = evaluate_container_condition(state, cond)
+        last_detail = detail
+        elapsed = timeout_seconds - max(0.0, deadline - time.monotonic())
+
+        if outcome == "met":
+            return MonitorLoopResult(
+                status="success",
+                message=f"✓ {container} on {host}: {detail} (after {elapsed:.0f}s).",
+                elapsed_seconds=elapsed,
+                last_detail=detail,
+            )
+        if outcome == "failed":
+            return MonitorLoopResult(
+                status="error",
+                message=f"✗ {container} on {host}: {detail}",
+                elapsed_seconds=elapsed,
+                last_detail=detail,
+            )
+
+        if on_progress:
+            await on_progress(f"⏳ {detail} ({elapsed:.0f}s / {timeout_seconds}s)")
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        await asyncio.sleep(min(float(interval_seconds), max(remaining, 0.01)))
+
+    elapsed = timeout_seconds
+    return MonitorLoopResult(
+        status="timeout",
+        message=(
+            f"Timed out after {timeout_seconds}s waiting for '{container}' on '{host}' "
+            f"to reach '{cond}'. Last state: {last_detail}"
+        ),
+        elapsed_seconds=float(timeout_seconds),
+        last_detail=last_detail,
+    )

--- a/src/squire/monitoring/loop.py
+++ b/src/squire/monitoring/loop.py
@@ -32,9 +32,19 @@ async def run_docker_container_monitor(
     condition: str,
     interval_seconds: int,
     timeout_seconds: int,
+    initial_delay_seconds: float = 0,
     on_progress: ProgressCallback | None = None,
 ) -> MonitorLoopResult:
-    """Poll ``docker inspect`` until ``evaluate_container_condition`` reports met/failed or time runs out."""
+    """Poll ``docker inspect`` until ``evaluate_container_condition`` reports met/failed or time runs out.
+
+    Args:
+        initial_delay_seconds: Sleep this long before the first poll.
+            Useful after a state-changing action (e.g. ``docker restart``)
+            so Docker has time to reset health status.
+    """
+    if initial_delay_seconds > 0:
+        await asyncio.sleep(initial_delay_seconds)
+
     deadline = time.monotonic() + timeout_seconds
     last_detail = ""
     cond = condition.strip().lower()

--- a/src/squire/monitoring/registry.py
+++ b/src/squire/monitoring/registry.py
@@ -1,0 +1,46 @@
+"""Track and cancel background monitor tasks per chat session."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+# session_id -> list of asyncio Tasks
+_session_tasks: dict[str, list[asyncio.Task]] = {}
+
+
+def _prune_task(session_id: str, task: asyncio.Task) -> None:
+    lst = _session_tasks.get(session_id)
+    if not lst:
+        return
+    try:
+        lst.remove(task)
+    except ValueError:
+        pass
+    if not lst:
+        _session_tasks.pop(session_id, None)
+
+
+def track_monitor_task(session_id: str, task: asyncio.Task) -> None:
+    """Register a background monitor task so it can be cancelled on disconnect."""
+
+    def _done(t: asyncio.Task) -> None:
+        _prune_task(session_id, t)
+        if t.cancelled():
+            return
+        exc = t.exception()
+        if exc is not None:
+            logger.debug("Monitor task ended with error", exc_info=exc)
+
+    _session_tasks.setdefault(session_id, []).append(task)
+    task.add_done_callback(_done)
+
+
+def cancel_session_monitor_tasks(session_id: str) -> None:
+    """Cancel all monitor tasks for a session (e.g. WebSocket disconnect)."""
+    tasks = _session_tasks.pop(session_id, [])
+    for t in tasks:
+        if not t.done():
+            t.cancel()

--- a/src/squire/monitoring/sinks.py
+++ b/src/squire/monitoring/sinks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
@@ -52,6 +53,7 @@ class WebChatMonitorSink:
     db: DatabaseService | None
     session_id: str
     use_background: bool = True
+    _on_complete: Callable[[str], Awaitable[None]] | None = None
     _send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _turn_idle: asyncio.Event = field(default_factory=asyncio.Event)
 
@@ -101,6 +103,12 @@ class WebChatMonitorSink:
             except Exception:
                 logger.debug("WebSocket send failed for monitor_complete", exc_info=True)
 
+            if self._on_complete:
+                try:
+                    await self._on_complete(content)
+                except Exception:
+                    logger.debug("_on_complete callback failed", exc_info=True)
+
 
 @dataclass
 class TuiChatMonitorSink:
@@ -112,6 +120,7 @@ class TuiChatMonitorSink:
     app: object
     add_message: object
     use_background: bool = True
+    _on_complete: Callable[[str], Awaitable[None]] | None = None
 
     async def deliver_monitor_result(self, monitor_id: str, content: str) -> None:
         if self.db:
@@ -139,6 +148,12 @@ class TuiChatMonitorSink:
             except Exception:
                 logger.debug("Notifier dispatch failed for monitor", exc_info=True)
         self.app.call_from_thread(self.add_message, content, "assistant")
+
+        if self._on_complete:
+            try:
+                await self._on_complete(content)
+            except Exception:
+                logger.debug("_on_complete callback failed (TUI)", exc_info=True)
 
 
 @dataclass

--- a/src/squire/monitoring/sinks.py
+++ b/src/squire/monitoring/sinks.py
@@ -1,0 +1,154 @@
+"""Per-session delivery of monitor results (Web UI, TUI, watch)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+from fastapi import WebSocket
+
+if TYPE_CHECKING:
+    from ..database.service import DatabaseService
+
+logger = logging.getLogger(__name__)
+
+_SESSION_SINKS: dict[str, MonitorSessionSink] = {}
+
+
+class MonitorSessionSink(Protocol):
+    """Delivers monitor completion to the right channel for this session."""
+
+    use_background: bool
+
+    async def deliver_monitor_result(self, monitor_id: str, content: str) -> None:
+        """Persist and notify the user that a monitor finished."""
+
+
+def register_monitor_session_sink(session_id: str, sink: MonitorSessionSink) -> None:
+    _SESSION_SINKS[session_id] = sink
+
+
+def unregister_monitor_session_sink(session_id: str) -> None:
+    _SESSION_SINKS.pop(session_id, None)
+
+
+def get_monitor_session_sink(session_id: str) -> MonitorSessionSink | None:
+    return _SESSION_SINKS.get(session_id)
+
+
+@dataclass
+class WebChatMonitorSink:
+    """Inject assistant text over the chat WebSocket (Option B)."""
+
+    websocket: WebSocket
+    db: DatabaseService | None
+    session_id: str
+    use_background: bool = True
+    _send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def deliver_monitor_result(self, monitor_id: str, content: str) -> None:
+        from starlette.websockets import WebSocketState
+
+        async with self._send_lock:
+            if self.db:
+                try:
+                    await self.db.save_message(session_id=self.session_id, role="assistant", content=content)
+                    await self.db.update_session_active(self.session_id)
+                    await self.db.log_event(
+                        category="monitor",
+                        summary=f"Monitor {monitor_id} completed",
+                        session_id=self.session_id,
+                        tool_name="wait_for_state",
+                        details=content[:2000],
+                    )
+                except Exception:
+                    logger.debug("Failed to persist monitor result", exc_info=True)
+            if self.websocket.client_state != WebSocketState.CONNECTED:
+                return
+            try:
+                await self.websocket.send_json(
+                    {
+                        "type": "monitor_complete",
+                        "content": content,
+                        "monitor_id": monitor_id,
+                    }
+                )
+            except Exception:
+                logger.debug("WebSocket send failed for monitor_complete", exc_info=True)
+
+
+@dataclass
+class TuiChatMonitorSink:
+    """Append a monitor result bubble in the Textual chat (main thread)."""
+
+    db: DatabaseService | None
+    notifier: object | None
+    session_id: str
+    app: object
+    add_message: object
+    use_background: bool = True
+
+    async def deliver_monitor_result(self, monitor_id: str, content: str) -> None:
+        if self.db:
+            try:
+                await self.db.save_message(session_id=self.session_id, role="assistant", content=content)
+                await self.db.update_session_active(self.session_id)
+                await self.db.log_event(
+                    category="monitor",
+                    summary=f"Monitor {monitor_id} completed",
+                    session_id=self.session_id,
+                    tool_name="wait_for_state",
+                    details=content[:2000],
+                )
+            except Exception:
+                logger.debug("Failed to persist monitor result (TUI)", exc_info=True)
+        if self.notifier:
+            try:
+                await self.notifier.dispatch(
+                    category="monitor",
+                    summary=f"Monitor {monitor_id} completed",
+                    session_id=self.session_id,
+                    tool_name="wait_for_state",
+                    details=content[:500],
+                )
+            except Exception:
+                logger.debug("Notifier dispatch failed for monitor", exc_info=True)
+        self.app.call_from_thread(self.add_message, content, "assistant")
+
+
+@dataclass
+class WatchNotifierMonitorSink:
+    """Watch mode: log and notify; no UI injection."""
+
+    db: DatabaseService | None
+    notifier: object | None
+    session_id: str
+    use_background: bool = True
+
+    async def deliver_monitor_result(self, monitor_id: str, content: str) -> None:
+        if self.db:
+            try:
+                await self.db.save_message(session_id=self.session_id, role="assistant", content=content)
+                await self.db.update_session_active(self.session_id)
+                await self.db.log_event(
+                    category="monitor",
+                    summary=f"Monitor {monitor_id} completed",
+                    session_id=self.session_id,
+                    tool_name="wait_for_state",
+                    details=content[:2000],
+                )
+            except Exception:
+                logger.debug("Failed to persist monitor result (watch)", exc_info=True)
+        if self.notifier:
+            try:
+                await self.notifier.dispatch(
+                    category="monitor",
+                    summary=f"[Watch] {content[:200]}",
+                    session_id=self.session_id,
+                    tool_name="wait_for_state",
+                    details=content[:2000],
+                )
+            except Exception:
+                logger.debug("Notifier dispatch failed for watch monitor", exc_info=True)

--- a/src/squire/monitoring/sinks.py
+++ b/src/squire/monitoring/sinks.py
@@ -40,16 +40,39 @@ def get_monitor_session_sink(session_id: str) -> MonitorSessionSink | None:
 
 @dataclass
 class WebChatMonitorSink:
-    """Inject assistant text over the chat WebSocket (Option B)."""
+    """Inject assistant text over the chat WebSocket (Option B).
+
+    Delivery is gated by ``_turn_idle`` — an event that is cleared while an
+    LLM streaming turn is in progress and set once ``message_complete`` has
+    been sent.  This prevents monitor results from appearing *before* the
+    agent's conversational response in the chat timeline.
+    """
 
     websocket: WebSocket
     db: DatabaseService | None
     session_id: str
     use_background: bool = True
     _send_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _turn_idle: asyncio.Event = field(default_factory=asyncio.Event)
+
+    def __post_init__(self) -> None:
+        self._turn_idle.set()
+
+    def mark_streaming(self) -> None:
+        """Call when an LLM streaming turn starts."""
+        self._turn_idle.clear()
+
+    def mark_idle(self) -> None:
+        """Call when the LLM turn finishes (``message_complete`` sent)."""
+        self._turn_idle.set()
 
     async def deliver_monitor_result(self, monitor_id: str, content: str) -> None:
         from starlette.websockets import WebSocketState
+
+        try:
+            await asyncio.wait_for(self._turn_idle.wait(), timeout=300)
+        except TimeoutError:
+            logger.warning("Timed out waiting for LLM turn to finish; delivering monitor result anyway")
 
         async with self._send_lock:
             if self.db:

--- a/src/squire/tools/__init__.py
+++ b/src/squire/tools/__init__.py
@@ -10,7 +10,7 @@ Tool conventions:
   can relay them to the user. Only use exceptions for truly unexpected
   failures that should surface as system errors.
 - Single-action tools set a module-level ``RISK_LEVEL`` int (1–5).
-  Multi-action tools set ``RISK_LEVELS: dict[str, int]`` with
+- Multi-action tools set ``RISK_LEVELS: dict[str, int]`` with
   ``"tool:action"`` keys.  Both are used by the risk gate callback
   to decide whether user approval is needed.
 """
@@ -46,6 +46,8 @@ from .system_info import RISK_LEVEL as _si_risk
 from .system_info import system_info
 from .systemctl import RISK_LEVELS as _sctl_risks
 from .systemctl import systemctl
+from .wait_for_state import RISK_LEVEL as _wfs_risk
+from .wait_for_state import wait_for_state
 
 ALL_TOOLS = [
     safe_tool(system_info),
@@ -60,6 +62,7 @@ ALL_TOOLS = [
     safe_tool(journalctl),
     safe_tool(systemctl),
     safe_tool(run_command),
+    safe_tool(wait_for_state),
 ]
 
 TOOL_RISK_LEVELS: dict[str, int] = {
@@ -75,4 +78,5 @@ TOOL_RISK_LEVELS: dict[str, int] = {
     "journalctl": _jctl_risk,
     **_sctl_risks,
     "run_command": _runcmd_risk,
+    "wait_for_state": _wfs_risk,
 }

--- a/src/squire/tools/docker_compose.py
+++ b/src/squire/tools/docker_compose.py
@@ -82,7 +82,10 @@ async def docker_compose(
 
     if result.returncode != 0:
         path_info = f" (resolved path: {resolved_dir}/docker-compose.yml)" if resolved_dir else ""
-        return f"Error running 'docker compose {action}'{path_info}: {result.stderr}"
+        hint = ""
+        if action == "ps" and not service and "not found" in (result.stderr or "").lower():
+            hint = " Hint: to list ALL containers on a host, use `docker_ps` instead."
+        return f"Error running 'docker compose {action}'{path_info}: {result.stderr}{hint}"
 
     output = result.stdout.strip()
     return output if output else f"docker compose {action} completed successfully."

--- a/src/squire/tools/groups.py
+++ b/src/squire/tools/groups.py
@@ -18,6 +18,7 @@ from .read_config import read_config
 from .run_command import run_command
 from .system_info import system_info
 from .systemctl import systemctl
+from .wait_for_state import wait_for_state
 
 # Monitor agent — read-only system observation
 MONITOR_TOOLS = [
@@ -39,6 +40,7 @@ CONTAINER_TOOLS = [
     safe_tool(docker_container),
     safe_tool(docker_image),
     safe_tool(docker_cleanup),
+    safe_tool(wait_for_state),
 ]
 CONTAINER_TOOL_NAMES = {t.__name__ for t in CONTAINER_TOOLS}
 CONTAINER_RISK_LEVELS = {

--- a/src/squire/tools/run_command.py
+++ b/src/squire/tools/run_command.py
@@ -1,7 +1,5 @@
 """run_command tool — guarded shell execution with command allow/block lists."""
 
-import shlex
-
 from ..config import GuardrailsConfig
 from ._registry import get_registry
 
@@ -24,6 +22,9 @@ async def run_command(command: str, timeout: float = 30.0, host: str = "local") 
     and blocklist before execution. Blocked commands are denied entirely.
     Commands not on the allowlist require approval via the risk profile.
 
+    Supports shell syntax including pipes (|), semicolons (;), and
+    chained commands (&&, ||).
+
     Args:
         command: The shell command to execute (e.g., "ping -c 4 8.8.8.8").
         timeout: Maximum seconds to wait for the command to complete (default 30).
@@ -31,23 +32,19 @@ async def run_command(command: str, timeout: float = 30.0, host: str = "local") 
 
     Returns the command output (stdout + stderr) as text.
     """
-    try:
-        parts = shlex.split(command)
-    except ValueError as e:
-        return f"Invalid command syntax: {e}"
-
-    if not parts:
+    stripped = command.strip()
+    if not stripped:
         return "Empty command."
 
-    base_cmd = parts[0]
+    base_cmd = stripped.split()[0].rstrip(";|&")
+    if not base_cmd:
+        return "Empty command."
 
     guardrails = _get_guardrails_config()
 
-    # Check blocklist first
     if base_cmd in guardrails.commands_block:
         return f"DENIED: '{base_cmd}' is on the command blocklist. Tell the user this command is not allowed."
 
-    # Check allowlist
     if guardrails.commands_allow and base_cmd not in guardrails.commands_allow:
         return (
             f"DENIED: '{base_cmd}' is not on the command allowlist. Tell the user this command is not allowed.\n"
@@ -55,7 +52,7 @@ async def run_command(command: str, timeout: float = 30.0, host: str = "local") 
         )
 
     backend = get_registry().get(host)
-    result = await backend.run(parts, timeout=min(timeout, 120.0))
+    result = await backend.run(["bash", "-c", stripped], timeout=min(timeout, 120.0))
 
     output_parts = []
     if result.stdout:

--- a/src/squire/tools/wait_for_state.py
+++ b/src/squire/tools/wait_for_state.py
@@ -1,7 +1,5 @@
 """wait_for_state — poll until a Docker container reaches a target condition."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import uuid
@@ -20,6 +18,7 @@ RISK_LEVEL = 1  # read-only polling
 _MAX_TIMEOUT = 3600
 _MAX_INTERVAL = 120
 _KIND_DOCKER_CONTAINER = "docker_container"
+_INITIAL_DELAY = 2.0
 
 
 async def wait_for_state(
@@ -86,6 +85,7 @@ async def wait_for_state(
                 condition=cond,
                 interval_seconds=interval,
                 timeout_seconds=timeout,
+                initial_delay_seconds=_INITIAL_DELAY,
                 on_progress=None,
             )
             if result.status == "success":
@@ -117,6 +117,7 @@ async def wait_for_state(
             condition=cond,
             interval_seconds=interval,
             timeout_seconds=timeout,
+            initial_delay_seconds=_INITIAL_DELAY,
             on_progress=_progress,
         )
     except Exception as exc:

--- a/src/squire/tools/wait_for_state.py
+++ b/src/squire/tools/wait_for_state.py
@@ -1,0 +1,126 @@
+"""wait_for_state — poll until a Docker container reaches a target condition."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+
+from google.adk.tools.tool_context import ToolContext
+
+from ..monitoring.loop import run_docker_container_monitor
+from ..monitoring.registry import track_monitor_task
+from ..monitoring.sinks import get_monitor_session_sink
+from ._registry import get_registry
+
+logger = logging.getLogger(__name__)
+
+RISK_LEVEL = 1  # read-only polling
+
+_MAX_TIMEOUT = 3600
+_MAX_INTERVAL = 120
+_KIND_DOCKER_CONTAINER = "docker_container"
+
+
+async def wait_for_state(
+    kind: str,
+    container: str,
+    condition: str,
+    host: str = "local",
+    interval_seconds: int = 5,
+    timeout_seconds: int = 120,
+    tool_context: ToolContext | None = None,
+) -> str:
+    """Poll infrastructure state until a condition is met, without LLM calls each tick.
+
+    Use after a state-changing action when the user asked to wait for a stable state
+    (e.g. restart + "make sure it's healthy").
+
+    Args:
+        kind: What to watch. Supported: ``docker_container``.
+        container: Docker container name or ID.
+        condition: Target state: ``healthy`` (requires a health check), ``running``, or ``exited``.
+        host: Target host (default ``local``).
+        interval_seconds: Seconds between checks (default 5, max 120).
+        timeout_seconds: Max wait in seconds (default 120, max 3600).
+        tool_context: Injected by ADK (session id for background delivery).
+
+    Returns:
+        Immediate acknowledgment when monitoring runs in the background; otherwise
+        the final result string after polling completes.
+    """
+    kind_norm = (kind or "").strip().lower()
+    if kind_norm != _KIND_DOCKER_CONTAINER:
+        return f"Unsupported kind '{kind}'. Use '{_KIND_DOCKER_CONTAINER}'."
+
+    if not container.strip():
+        return "Error: container name is required."
+
+    cond = (condition or "").strip().lower()
+    if cond not in ("healthy", "running", "exited"):
+        return "Invalid condition. Use: healthy, running, or exited."
+
+    interval = max(1, min(int(interval_seconds), _MAX_INTERVAL))
+    timeout = max(1, min(int(timeout_seconds), _MAX_TIMEOUT))
+
+    registry = get_registry()
+    resolved_host = host
+    if host == "local":
+        matched = registry.resolve_host_for_service(container)
+        if matched:
+            resolved_host = matched
+
+    session_id = tool_context.session.id if tool_context else ""
+    sink = get_monitor_session_sink(session_id) if session_id else None
+    use_background = bool(sink and getattr(sink, "use_background", False))
+
+    monitor_id = str(uuid.uuid4())[:8]
+
+    async def _run() -> None:
+        assert sink is not None
+        try:
+            result = await run_docker_container_monitor(
+                registry=registry,
+                host=resolved_host,
+                container=container.strip(),
+                condition=cond,
+                interval_seconds=interval,
+                timeout_seconds=timeout,
+                on_progress=None,
+            )
+            if result.status == "success":
+                body = result.message
+            else:
+                body = f"[Monitor {monitor_id}] {result.message}"
+
+            await sink.deliver_monitor_result(monitor_id, body)
+        except asyncio.CancelledError:
+            raise
+
+    if use_background:
+        task = asyncio.create_task(_run())
+        track_monitor_task(session_id, task)
+        return (
+            f"Monitor {monitor_id} started: waiting for container '{container}' on host '{resolved_host}' "
+            f"to be '{cond}' (every {interval}s, timeout {timeout}s). "
+            "You will get another message when it finishes."
+        )
+
+    async def _progress(line: str) -> None:
+        print(line, flush=True)
+
+    try:
+        result = await run_docker_container_monitor(
+            registry=registry,
+            host=resolved_host,
+            container=container.strip(),
+            condition=cond,
+            interval_seconds=interval,
+            timeout_seconds=timeout,
+            on_progress=_progress,
+        )
+    except Exception as exc:
+        logger.exception("wait_for_state failed")
+        return f"Error while monitoring: {exc}"
+
+    return result.message

--- a/src/squire/tui/chat_pane.py
+++ b/src/squire/tui/chat_pane.py
@@ -132,6 +132,19 @@ class ChatPane(Static):
 
             session_id = self._session.id
 
+            runner = self._runner
+            session_obj = self._session
+
+            async def _inject_monitor_event(content: str) -> None:
+                from google.adk.events.event import Event as AdkEvent
+
+                evt = AdkEvent(
+                    author="Squire",
+                    invocation_id=AdkEvent.new_id(),
+                    content=types.Content(role="model", parts=[types.Part(text=content)]),
+                )
+                await runner.session_service.append_event(session_obj, evt)
+
             register_monitor_session_sink(
                 session_id,
                 TuiChatMonitorSink(
@@ -140,6 +153,7 @@ class ChatPane(Static):
                     session_id=session_id,
                     app=self.app,
                     add_message=self._add_message,
+                    _on_complete=_inject_monitor_event,
                 ),
             )
 

--- a/src/squire/tui/chat_pane.py
+++ b/src/squire/tui/chat_pane.py
@@ -13,6 +13,7 @@ from textual.containers import VerticalScroll
 from textual.widgets import Input, Static
 
 from ..database.service import DatabaseService
+from ..monitoring.sinks import TuiChatMonitorSink, register_monitor_session_sink, unregister_monitor_session_sink
 from ..notifications.webhook import WebhookDispatcher
 
 
@@ -123,12 +124,24 @@ class ChatPane(Static):
     async def _send_message(self, user_text: str) -> None:
         """Send the user message to the ADK runner and stream the response."""
         self._processing = True
+        session_id: str | None = None
         try:
             if not self._runner or not self._session:
                 self.app.call_from_thread(self._add_message, "Agent not connected. Check your configuration.", "system")
                 return
 
             session_id = self._session.id
+
+            register_monitor_session_sink(
+                session_id,
+                TuiChatMonitorSink(
+                    db=self._db,
+                    notifier=self._notifier,
+                    session_id=session_id,
+                    app=self.app,
+                    add_message=self._add_message,
+                ),
+            )
 
             # Persist user message
             await self._persist_message(session_id, "user", user_text)
@@ -217,6 +230,8 @@ class ChatPane(Static):
                 tb = traceback.format_exc()
                 await self._log_event(sid, "error", str(e), details=tb)
         finally:
+            if session_id:
+                unregister_monitor_session_sink(session_id)
             self._processing = False
 
     async def _persist_message(self, session_id: str, role: str, content: str) -> None:

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -34,6 +34,12 @@ from .config import (
 from .database.service import DatabaseService
 from .hosts.store import HostStore
 from .main import _collect_all_snapshots
+from .monitoring.registry import cancel_session_monitor_tasks
+from .monitoring.sinks import (
+    WatchNotifierMonitorSink,
+    register_monitor_session_sink,
+    unregister_monitor_session_sink,
+)
 from .notifications.alert_evaluator import evaluate_alerts
 from .notifications.email import EmailNotifier
 from .notifications.router import NotificationRouter
@@ -206,6 +212,10 @@ async def start_watch() -> None:
         state=session_state,
     )
     await db.create_session(session.id)
+    register_monitor_session_sink(
+        session.id,
+        WatchNotifierMonitorSink(db=db, notifier=notifier, session_id=session.id),
+    )
 
     # Signal handling for graceful shutdown
     shutdown = asyncio.Event()
@@ -355,6 +365,10 @@ async def start_watch() -> None:
                 except (TimeoutError, Exception):
                     summary = "(session summary unavailable)"
 
+                old_session_id = session.id
+                cancel_session_monitor_tasks(old_session_id)
+                unregister_monitor_session_sink(old_session_id)
+
                 session = await runner.session_service.create_session(
                     app_name=app_config.app_name,
                     user_id=app_config.user_id,
@@ -362,6 +376,10 @@ async def start_watch() -> None:
                 )
                 await db.create_session(session.id)
                 await db.set_watch_state("session_id", session.id)
+                register_monitor_session_sink(
+                    session.id,
+                    WatchNotifierMonitorSink(db=db, notifier=notifier, session_id=session.id),
+                )
 
                 if summary:
                     event = Event(
@@ -380,6 +398,8 @@ async def start_watch() -> None:
             await _interruptible_sleep(db, shutdown, watch_config.interval_minutes * 60, watch_config=watch_config)
 
     finally:
+        cancel_session_monitor_tasks(session.id)
+        unregister_monitor_session_sink(session.id)
         await db.set_watch_state("status", "stopped")
         await db.set_watch_state("stopped_at", datetime.now(UTC).isoformat())
         await _dispatch(notifier, "watch.stop", "Squire watch mode stopped.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,9 @@ class MockRegistry:
     def get(self, host: str = "local"):
         return self._backend
 
+    def resolve_host_for_service(self, service: str) -> str | None:
+        return None
+
     @property
     def host_names(self) -> list[str]:
         return ["local"]

--- a/tests/test_agents/test_agent_tree.py
+++ b/tests/test_agents/test_agent_tree.py
@@ -18,7 +18,7 @@ class TestSingleAgentMode:
         agent = create_squire_agent(app_config=config)
         assert agent.name == "Squire"
         assert len(agent.sub_agents) == 0
-        assert len(agent.tools) == 12
+        assert len(agent.tools) == 13
 
     def test_explicit_callback(self):
         config = AppConfig(multi_agent=False)
@@ -77,7 +77,7 @@ class TestMultiAgentMode:
             risk_gate_factory=_make_factory(),
         )
         tool_counts = {sa.name: len(sa.tools) for sa in agent.sub_agents}
-        assert tool_counts == {"Monitor": 5, "Container": 5, "Admin": 2, "Notifier": 5}
+        assert tool_counts == {"Monitor": 5, "Container": 6, "Admin": 2, "Notifier": 5}
 
     def test_requires_risk_gate_factory(self):
         config = AppConfig(multi_agent=True)

--- a/tests/test_api/test_tools_endpoint.py
+++ b/tests/test_api/test_tools_endpoint.py
@@ -12,7 +12,8 @@ class TestBuildToolCatalog:
         assert "system_info" in names
         assert "docker_container" in names
         assert "run_command" in names
-        assert len(tools) == 12  # all 12 registered tools
+        assert "wait_for_state" in names
+        assert len(tools) == 13  # all registered tools
 
     def test_single_action_tool_has_risk_level(self):
         guardrails = GuardrailsConfig()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for configuration classes."""
 
+import pytest
+
 import squire.config.loader as loader_mod
 from squire.config import AppConfig, DatabaseConfig, GuardrailsConfig, HostConfig, LLMConfig, NotificationsConfig
 from squire.config.loader import (
@@ -72,6 +74,10 @@ class TestGuardrailsConfig:
 
 
 class TestNotificationsConfig:
+    @pytest.fixture(autouse=True)
+    def _clear_toml_cache(self, monkeypatch):
+        monkeypatch.setattr(loader_mod, "_cached", {})
+
     def test_disabled_by_default(self):
         config = NotificationsConfig()
         assert config.enabled is False

--- a/tests/test_monitoring/test_docker_state.py
+++ b/tests/test_monitoring/test_docker_state.py
@@ -1,0 +1,58 @@
+"""Unit tests for Docker container condition evaluation."""
+
+import pytest
+
+from squire.monitoring.docker_state import evaluate_container_condition
+
+
+@pytest.mark.parametrize(
+    ("state", "condition", "expected_outcome", "snippet"),
+    [
+        (
+            {"Running": True, "Status": "running", "ExitCode": 0},
+            "running",
+            "met",
+            "running",
+        ),
+        (
+            {"Running": False, "Status": "exited", "ExitCode": 0},
+            "exited",
+            "met",
+            "stopped",
+        ),
+        (
+            {"Running": False, "Status": "created", "ExitCode": 0},
+            "running",
+            "pending",
+            "Not running yet",
+        ),
+        (
+            {"Running": True, "Status": "running", "Health": {"Status": "healthy"}},
+            "healthy",
+            "met",
+            "healthy",
+        ),
+        (
+            {"Running": True, "Status": "starting", "Health": {"Status": "starting"}},
+            "healthy",
+            "pending",
+            "Health status",
+        ),
+        (
+            {"Running": True, "Status": "running"},
+            "healthy",
+            "failed",
+            "no health check",
+        ),
+        (
+            {"Running": True, "Status": "running", "Health": {"Status": "unhealthy"}},
+            "healthy",
+            "failed",
+            "unhealthy",
+        ),
+    ],
+)
+def test_evaluate_container_condition(state, condition, expected_outcome, snippet):
+    outcome, detail = evaluate_container_condition(state, condition)
+    assert outcome == expected_outcome
+    assert snippet.lower() in detail.lower()

--- a/tests/test_tools/test_run_command.py
+++ b/tests/test_tools/test_run_command.py
@@ -14,7 +14,7 @@ _mod = sys.modules["squire.tools.run_command"]
 @pytest.mark.asyncio
 async def test_allowed_command(mock_backend, mock_registry, monkeypatch):
     monkeypatch.setattr(_mod, "_guardrails_config", GuardrailsConfig())
-    mock_backend.set_response("ping", CommandResult(returncode=0, stdout="PING ok\n", stderr=""))
+    mock_backend.set_response("bash", CommandResult(returncode=0, stdout="PING ok\n", stderr=""))
 
     result = await run_command("ping -c 1 localhost")
     assert "PING ok" in result
@@ -39,20 +39,33 @@ async def test_unlisted_command(monkeypatch):
 @pytest.mark.asyncio
 async def test_empty_command():
     result = await run_command("")
-    assert "Empty" in result or "Invalid" in result
-
-
-@pytest.mark.asyncio
-async def test_invalid_syntax():
-    result = await run_command("echo 'unclosed")
-    assert "Invalid" in result or "syntax" in result.lower()
+    assert "Empty" in result
 
 
 @pytest.mark.asyncio
 async def test_run_command_with_host_param(mock_backend, mock_registry, monkeypatch):
     """The host parameter should be accepted."""
     monkeypatch.setattr(_mod, "_guardrails_config", GuardrailsConfig())
-    mock_backend.set_response("ping", CommandResult(returncode=0, stdout="PING ok\n", stderr=""))
+    mock_backend.set_response("bash", CommandResult(returncode=0, stdout="PING ok\n", stderr=""))
 
     result = await run_command("ping -c 1 localhost", host="local")
     assert "PING ok" in result
+
+
+@pytest.mark.asyncio
+async def test_shell_metacharacters(mock_backend, mock_registry, monkeypatch):
+    """Semicolons, pipes, and chained commands should work via bash -c."""
+    monkeypatch.setattr(_mod, "_guardrails_config", GuardrailsConfig())
+    mock_backend.set_response("bash", CommandResult(returncode=0, stdout="done\n", stderr=""))
+
+    result = await run_command("ls; sleep 1; echo done")
+    assert "done" in result
+
+
+@pytest.mark.asyncio
+async def test_denied_with_semicolon(monkeypatch):
+    """Blocklist still catches the base command even with shell syntax."""
+    config = GuardrailsConfig(commands_block=["rm"], commands_allow=[])
+    monkeypatch.setattr(_mod, "_guardrails_config", config)
+    result = await run_command("rm -rf /; echo hacked")
+    assert "DENIED" in result

--- a/tests/test_tools/test_wait_for_state.py
+++ b/tests/test_tools/test_wait_for_state.py
@@ -1,0 +1,103 @@
+"""Tests for wait_for_state tool."""
+
+import asyncio
+import json
+
+import pytest
+
+from squire.monitoring.sinks import register_monitor_session_sink, unregister_monitor_session_sink
+from squire.system.backend import CommandResult
+from squire.tools.wait_for_state import wait_for_state
+
+
+class _FakeSession:
+    id = "sess-test"
+
+
+class _FakeToolContext:
+    session = _FakeSession()
+
+
+@pytest.mark.asyncio
+async def test_wait_running_blocking(mock_registry, mock_backend):
+    """Without a session sink, polling runs inline until success."""
+    state = {"Running": True, "Status": "running", "ExitCode": 0}
+    mock_backend.set_response("docker", CommandResult(returncode=0, stdout=json.dumps(state), stderr=""))
+
+    out = await wait_for_state(
+        "docker_container",
+        "nginx",
+        "running",
+        host="local",
+        interval_seconds=1,
+        timeout_seconds=5,
+        tool_context=_FakeToolContext(),
+    )
+    assert "nginx" in out
+    assert "running" in out.lower() or "✓" in out
+
+
+@pytest.mark.asyncio
+async def test_healthy_fails_without_healthcheck(mock_registry, mock_backend):
+    state = {"Running": True, "Status": "running"}
+    mock_backend.set_response("docker", CommandResult(returncode=0, stdout=json.dumps(state), stderr=""))
+
+    out = await wait_for_state(
+        "docker_container",
+        "nginx",
+        "healthy",
+        interval_seconds=1,
+        timeout_seconds=5,
+        tool_context=_FakeToolContext(),
+    )
+    assert "no health check" in out.lower()
+
+
+@pytest.mark.asyncio
+async def test_background_registers_task(mock_registry, mock_backend):
+    """With a sink, the tool returns immediately and completes asynchronously."""
+    state = {"Running": True, "Status": "running", "ExitCode": 0}
+    mock_backend.set_response("docker", CommandResult(returncode=0, stdout=json.dumps(state), stderr=""))
+
+    delivered: list[tuple[str, str]] = []
+
+    class _Sink:
+        use_background = True
+
+        async def deliver_monitor_result(self, monitor_id: str, content: str) -> None:
+            delivered.append((monitor_id, content))
+
+    sid = _FakeToolContext.session.id
+    register_monitor_session_sink(sid, _Sink())
+    try:
+        out = await wait_for_state(
+            "docker_container",
+            "web",
+            "running",
+            interval_seconds=1,
+            timeout_seconds=5,
+            tool_context=_FakeToolContext(),
+        )
+        assert "Monitor" in out
+        assert "started" in out.lower()
+
+        for _ in range(50):
+            if delivered:
+                break
+            await asyncio.sleep(0.05)
+    finally:
+        unregister_monitor_session_sink(sid)
+
+    assert len(delivered) == 1
+    assert "web" in delivered[0][1].lower()
+
+
+@pytest.mark.asyncio
+async def test_invalid_kind(mock_registry):
+    out = await wait_for_state(
+        "not_a_kind",
+        "x",
+        "running",
+        tool_context=_FakeToolContext(),
+    )
+    assert "Unsupported" in out

--- a/tests/test_watch_config.py
+++ b/tests/test_watch_config.py
@@ -1,9 +1,16 @@
 """Tests for WatchConfig."""
 
+import pytest
+
+import squire.config.loader as loader_mod
 from squire.config.watch import WatchConfig
 
 
 class TestWatchConfigDefaults:
+    @pytest.fixture(autouse=True)
+    def _clear_toml_cache(self, monkeypatch):
+        monkeypatch.setattr(loader_mod, "_cached", {})
+
     def test_default_interval(self):
         c = WatchConfig()
         assert c.interval_minutes == 5

--- a/uv.lock
+++ b/uv.lock
@@ -3018,30 +3018,30 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-risk-engine", specifier = ">=0.2.0" },
-    { name = "aiosqlite", specifier = ">=0.19.0" },
-    { name = "asyncssh", specifier = ">=2.17.0" },
-    { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "google-adk", specifier = ">=1.23.0" },
-    { name = "httpx", specifier = ">=0.27.0" },
-    { name = "litellm", specifier = ">=1.81.1" },
-    { name = "pydantic", specifier = ">=2.12.0" },
-    { name = "pydantic-settings", specifier = ">=2.0.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
-    { name = "rich", specifier = ">=13.0.0" },
-    { name = "textual", specifier = ">=0.80.0" },
-    { name = "tomlkit", specifier = ">=0.13.0" },
-    { name = "typer", specifier = ">=0.12.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
+    { name = "agent-risk-engine", specifier = "==0.2.0" },
+    { name = "aiosqlite", specifier = "==0.22.1" },
+    { name = "asyncssh", specifier = "==2.22.0" },
+    { name = "fastapi", specifier = "==0.135.1" },
+    { name = "google-adk", specifier = "==1.27.1" },
+    { name = "httpx", specifier = "==0.28.1" },
+    { name = "litellm", specifier = "==1.82.2" },
+    { name = "pydantic", specifier = "==2.12.5" },
+    { name = "pydantic-settings", specifier = "==2.13.1" },
+    { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "pyyaml", specifier = "==6.0.3" },
+    { name = "rich", specifier = "==14.3.3" },
+    { name = "textual", specifier = "==8.1.1" },
+    { name = "tomlkit", specifier = "==0.14.0" },
+    { name = "typer", specifier = "==0.24.1" },
+    { name = "uvicorn", extras = ["standard"], specifier = "==0.41.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.10.0" },
-    { name = "pytest", specifier = ">=9.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.0.0" },
-    { name = "ruff", specifier = ">=0.14.0" },
+    { name = "mypy", specifier = "==1.19.1" },
+    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest-asyncio", specifier = "==1.3.0" },
+    { name = "ruff", specifier = "==0.15.6" },
 ]
 
 [[package]]

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -178,6 +178,19 @@ function ChatPageInner() {
           }
           break;
 
+        case "monitor_complete":
+          setAgentState(null);
+          setActiveToolName(undefined);
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: nextId(),
+              role: "assistant",
+              content: wsMsg.content,
+            },
+          ]);
+          break;
+
         case "message_complete":
           setAgentState(null);
           setActiveToolName(undefined);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -248,6 +248,11 @@ export interface WsMessageComplete {
   content: string;
   stopped?: boolean;
 }
+export interface WsMonitorComplete {
+  type: "monitor_complete";
+  content: string;
+  monitor_id: string;
+}
 export interface WsError {
   type: "error";
   message: string;
@@ -259,4 +264,5 @@ export type WsServerMessage =
   | WsToolResult
   | WsApprovalRequest
   | WsMessageComplete
+  | WsMonitorComplete
   | WsError;


### PR DESCRIPTION
## Problem

Squire had no way to execute an action (like restarting a container) and then actively monitor the resulting state until a condition was met. Users had to manually re-ask "is it healthy yet?" after every restart, deploy, or image pull. Additionally, `run_command` couldn't handle shell metacharacters (pipes, semicolons, `&&`), and the LLM consistently picked the wrong tool (`docker_compose ps` instead of `docker_ps`) for listing containers.

## Context

Closes #67

After a `docker restart`, Docker resets health status and the container transitions through intermediate states before becoming healthy. Squire needed a framework-level polling mechanism that works without LLM calls per tick, delivers results asynchronously to all three interfaces (Web, TUI, Watch), and keeps the LLM aware of completion for follow-up questions.

## Solution

**Core monitoring framework** (`src/squire/monitoring/`):
- `wait_for_state` tool — polls `docker inspect` for `healthy`/`running`/`exited` conditions with configurable interval and timeout
- Background task registry tracks active monitors per session; cleanup on disconnect/rotation
- `MonitorSessionSink` protocol with concrete implementations for Web (WebSocket `monitor_complete` messages), TUI (Textual message injection), and Watch (notifier dispatch)
- 2-second initial delay after state-changing actions so Docker has time to reset health status, preventing false-positive "healthy after 0s" results

**Race condition fix**: `WebChatMonitorSink` uses an `asyncio.Event` (`_turn_idle`) to gate monitor result delivery until the LLM turn completes, ensuring the agent's acknowledgment always appears before the monitor result.

**Session injection**: Monitor completion results are appended as ADK Events to the session, so the LLM knows the monitor finished and can answer follow-up questions accurately.

**`run_command` shell syntax fix**: Commands are now wrapped with `["bash", "-c", command]` instead of `shlex.split`, allowing full shell syntax while preserving guardrail checks on the base command.

**`docker_ps` vs `docker_compose ps` steering**: Agent instructions across all three agents (Squire, Container, Monitor) now explicitly state that `docker_ps` is the right tool for listing containers. `docker_compose` error output includes a fallback hint when the compose file is missing.

## Testing

### Unit tests
- `tests/test_monitoring/test_docker_state.py` — parametrized tests for `evaluate_container_condition` covering healthy, running, exited, unhealthy, no-healthcheck, and missing-container cases
- `tests/test_tools/test_wait_for_state.py` — blocking and background mode, healthcheck-required validation, task registration
- `tests/test_tools/test_run_command.py` — updated for `bash -c` wrapping; new tests for shell metacharacters and guardrail enforcement with semicolons
- `tests/test_agents/test_agent_tree.py` — updated tool counts for `wait_for_state` addition
- `tests/test_api/test_tools_endpoint.py` — updated tool catalog count

### Integration tests
Manual testing against a live homelab with `prod-apps-01`:
- Restarted containers and verified `wait_for_state` reports healthy after the initial delay
- Confirmed monitor result appears after the agent's acknowledgment in Web UI
- Verified the LLM correctly answers "what's the status?" after monitor completion
- Tested `run_command` with `ls; sleep 5; echo 'done'` and piped commands
- Verified "what containers are running" now routes to `docker_ps`

### Test results
```
388 passed, 3 warnings in 8.97s
```

## Reviewer Validation

1. Run `uv run pytest tests/ -q` — all 388 tests should pass
2. Inspect `src/squire/monitoring/loop.py` — verify the `initial_delay_seconds` sleep occurs before the first poll
3. Inspect `src/squire/monitoring/sinks.py` — verify `WebChatMonitorSink.deliver_monitor_result` awaits `_turn_idle.wait()` before sending
4. Inspect `src/squire/api/routers/chat.py` — verify `mark_streaming()`/`mark_idle()` bracket the LLM turn, and `_inject_monitor_event` appends to the session
5. Inspect `src/squire/instructions/squire_agent.py` and `container_agent.py` — verify `docker_ps` is recommended over `docker_compose ps` for general listing
6. Inspect `src/squire/tools/run_command.py` — verify commands are wrapped with `["bash", "-c", ...]` and `base_cmd` extraction strips trailing metacharacters

## TODOs / Follow-Ups

- Extend `wait_for_state` to support non-Docker targets (e.g. systemd service states, port reachability) — tracked by future issue
- Add progress callbacks for Web/TUI sinks (periodic "still waiting…" messages during long polls)
- Consider cancellation UI — currently monitors can only be cancelled by session disconnect/rotation