### PR TITLE
fix(watch): prevent memory exhaustion and fix stale stop in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Watch mode:** Fix "unable to stop" from the web UI when the watch process has crashed — `GET /api/watch/status` and `POST /api/watch/stop` now detect dead PIDs and clean up stale `running` state
+- **Watch mode:** Fix memory exhaustion caused by unbounded ADK session context growth — sessions now prune old events after each cycle via `max_context_events` (default 40)
+- **Watch mode:** Enforce `max_tool_calls_per_cycle` (default 15) which was previously defined but never wired into the watch loop
+- **Watch mode:** Free old sessions from `InMemorySessionService` on rotation to prevent abandoned sessions accumulating in memory
+- **Watch mode:** Replace the expensive LLM summary call at session rotation with a lightweight last-response carryover — the old approach sent the full bloated context to the model at peak size
+
+### Changed
+
+- **Watch mode:** Lower default `cycles_per_session` from 50 to 12 (rotates every ~1 hour instead of ~4 hours at default interval)
+- **Watch mode:** `_run_cycle` now returns `(response_text, tool_count)` tuple for accurate telemetry
+- **Watch mode:** Wire `notify_on_action` — dispatches `watch.action` notification when the agent executes tool calls during a cycle
+- **Watch mode:** Emit `session_rotated` watch event and report actual `tool_count` in `cycle_end` events (was hardcoded to 0)
+
+### Added
+
+- **Config:** `max_context_events` setting in `[watch]` to control how many ADK session events are kept in context
+
 ## [0.12.0] — 2026-04-10
 
 ### Added

--- a/src/squire/api/routers/watch.py
+++ b/src/squire/api/routers/watch.py
@@ -36,10 +36,27 @@ async def _decrement_supervisor_count(db) -> None:
 
 @router.get("/status", response_model=WatchStatusResponse)
 async def watch_status(db=Depends(get_db)):
-    """Current watch mode state."""
+    """Current watch mode state.
+
+    Detects stale ``running`` status when the process has exited and
+    corrects the DB so the UI stays accurate.
+    """
     state = await db.get_all_watch_state()
     if not state:
         return WatchStatusResponse()
+
+    pid = state.get("pid")
+    if pid and state.get("status") == "running":
+        try:
+            os.kill(int(pid), 0)
+        except (ProcessLookupError, ValueError):
+            from datetime import UTC, datetime
+
+            await db.set_watch_state("status", "stopped")
+            await db.set_watch_state("stopped_at", datetime.now(UTC).isoformat())
+            state["status"] = "stopped"
+            state["stopped_at"] = datetime.now(UTC).isoformat()
+
     return WatchStatusResponse(**state)
 
 
@@ -71,7 +88,26 @@ async def watch_start(db=Depends(get_db)):
 
 @router.post("/stop", response_model=WatchCommandResponse)
 async def watch_stop(db=Depends(get_db)):
-    """Stop watch mode."""
+    """Stop watch mode.
+
+    If the watch process is still alive, queues a stop command for it to
+    pick up on its next poll.  If the process has already exited (crash,
+    OOM, etc.) but the DB still says ``running``, cleans up the stale
+    state directly so the UI reflects the real status.
+    """
+    state = await db.get_all_watch_state()
+    pid = state.get("pid")
+
+    if pid and state.get("status") == "running":
+        try:
+            os.kill(int(pid), 0)
+        except (ProcessLookupError, ValueError):
+            from datetime import UTC, datetime
+
+            await db.set_watch_state("status", "stopped")
+            await db.set_watch_state("stopped_at", datetime.now(UTC).isoformat())
+            return WatchCommandResponse(status="ok", message="Watch process already exited; state cleaned up")
+
     await db.insert_watch_command("stop")
     return WatchCommandResponse(status="ok", message="Stop command sent")
 

--- a/src/squire/config/watch.py
+++ b/src/squire/config/watch.py
@@ -70,7 +70,12 @@ class WatchConfig(BaseSettings):
         description="Dispatch a notification when a tool call is blocked by the risk policy",
     )
     cycles_per_session: int = Field(
-        default=50,
+        default=12,
         ge=1,
         description="Rotate ADK session after this many cycles to bound memory",
+    )
+    max_context_events: int = Field(
+        default=40,
+        ge=10,
+        description="Maximum ADK session events kept in context; older events are pruned each cycle",
     )

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -313,9 +313,20 @@ async def start_watch() -> None:
             # Run the watch cycle
             cycle_start_time = datetime.now(UTC)
             await emitter.emit_cycle_start(cycle_count, session.id)
+            cycle_tool_count = 0
+            response_text = ""
             try:
-                response_text = await asyncio.wait_for(
-                    _run_cycle(runner, session, agent, prompt, app_config, emitter=emitter, cycle=cycle_count),
+                response_text, cycle_tool_count = await asyncio.wait_for(
+                    _run_cycle(
+                        runner,
+                        session,
+                        agent,
+                        prompt,
+                        app_config,
+                        emitter=emitter,
+                        cycle=cycle_count,
+                        max_tool_calls=watch_config.max_tool_calls_per_cycle,
+                    ),
                     timeout=watch_config.cycle_timeout_seconds,
                 )
                 last_cycle_error = None
@@ -336,24 +347,26 @@ async def start_watch() -> None:
 
             cycle_duration = (datetime.now(UTC) - cycle_start_time).total_seconds()
             cycle_status = "ok" if last_cycle_error is None else "error"
-            await emitter.emit_cycle_end(cycle_count, cycle_status, cycle_duration, tool_count=0)
+            await emitter.emit_cycle_end(cycle_count, cycle_status, cycle_duration, tool_count=cycle_tool_count)
+
+            if watch_config.notify_on_action and cycle_tool_count > 0 and last_cycle_error is None:
+                await _dispatch(
+                    notifier,
+                    "watch.action",
+                    f"Watch cycle {cycle_count} executed {cycle_tool_count} tool call(s).",
+                )
+
+            # Prune session history to bound context size
+            pruned = _prune_session_history(runner, session, watch_config.max_context_events)
+            if pruned > 0:
+                logger.debug("Pruned %d old events from session history", pruned)
 
             # Session rotation
             if cycle_count >= watch_config.cycles_per_session:
+                old_session_id = session.id
                 logger.info("Rotating session after %d cycles", cycle_count)
-                try:
-                    summary = await asyncio.wait_for(
-                        _run_cycle(
-                            runner,
-                            session,
-                            agent,
-                            "Summarize your observations and actions from this session in a few sentences.",
-                            app_config,
-                        ),
-                        timeout=60,
-                    )
-                except (TimeoutError, Exception):
-                    summary = "(session summary unavailable)"
+
+                carryover = response_text[:500] if response_text else "(no prior context)"
 
                 session = await runner.session_service.create_session(
                     app_name=app_config.app_name,
@@ -363,17 +376,27 @@ async def start_watch() -> None:
                 await db.create_session(session.id)
                 await db.set_watch_state("session_id", session.id)
 
-                if summary:
-                    event = Event(
-                        author="user",
-                        invocation_id=Event.new_id(),
-                        content=types.Content(
-                            role="user",
-                            parts=[types.Part(text=f"Context from previous session: {summary}")],
-                        ),
-                    )
-                    await runner.session_service.append_event(session, event)
+                carryover_event = Event(
+                    author="user",
+                    invocation_id=Event.new_id(),
+                    content=types.Content(
+                        role="user",
+                        parts=[types.Part(text=f"Context from previous session: {carryover}")],
+                    ),
+                )
+                await runner.session_service.append_event(session, carryover_event)
 
+                # Free old session from in-memory storage
+                try:
+                    await runner.session_service.delete_session(
+                        app_name=app_config.app_name,
+                        user_id=app_config.user_id,
+                        session_id=old_session_id,
+                    )
+                except Exception:
+                    logger.debug("Failed to delete old session %s", old_session_id, exc_info=True)
+
+                await emitter.emit_session_rotated(cycle_count, old_session_id, session.id)
                 cycle_count = 0
 
             # Sleep until next cycle (interruptible by shutdown signal or commands)
@@ -397,10 +420,16 @@ async def _run_cycle(
     app_config: AppConfig,
     emitter: WatchEventEmitter | None = None,
     cycle: int = 0,
-) -> str:
-    """Inject a prompt and collect the agent's response."""
+    max_tool_calls: int = 0,
+) -> tuple[str, int]:
+    """Inject a prompt and collect the agent's response.
+
+    Returns:
+        A tuple of (response_text, tool_call_count).
+    """
     message = types.Content(parts=[types.Part(text=prompt)])
-    response_parts = []
+    response_parts: list[str] = []
+    tool_count = 0
 
     async for event in runner.run_async(
         user_id=app_config.user_id,
@@ -412,8 +441,14 @@ async def _run_cycle(
         for part in event.content.parts:
             if getattr(part, "thought", False):
                 continue
-            if part.function_call and emitter:
-                await emitter.emit_tool_call(cycle, part.function_call.name, dict(part.function_call.args or {}))
+            if part.function_call:
+                tool_count += 1
+                if emitter:
+                    await emitter.emit_tool_call(cycle, part.function_call.name, dict(part.function_call.args or {}))
+                if max_tool_calls and tool_count >= max_tool_calls:
+                    logger.warning("Cycle %d hit tool call limit (%d)", cycle, max_tool_calls)
+                    response_parts.append(f"\n[Cycle stopped: reached {max_tool_calls} tool call limit]")
+                    return "".join(response_parts), tool_count
             elif part.function_response and emitter:
                 output = str(part.function_response.response) if part.function_response.response else ""
                 await emitter.emit_tool_result(cycle, part.function_response.name or "", output)
@@ -422,7 +457,30 @@ async def _run_cycle(
                 if emitter:
                     await emitter.emit_token(cycle, part.text)
 
-    return "".join(response_parts)
+    return "".join(response_parts), tool_count
+
+
+def _prune_session_history(runner: InMemoryRunner, session, max_events: int) -> int:
+    """Trim old events from the ADK session to bound context size.
+
+    Directly accesses the InMemorySessionService storage to truncate
+    the event list in-place, keeping only the most recent ``max_events``.
+
+    Returns the number of events pruned.
+    """
+    try:
+        storage = runner.session_service.sessions
+        stored = storage.get(session.app_name, {}).get(session.user_id, {}).get(session.id)
+        if stored is None or len(stored.events) <= max_events:
+            return 0
+
+        pruned = len(stored.events) - max_events
+        stored.events = stored.events[-max_events:]
+        session.events = session.events[-max_events:]
+        return pruned
+    except Exception:
+        logger.debug("Failed to prune session history", exc_info=True)
+        return 0
 
 
 async def _update_watch_state(db: DatabaseService, state: dict[str, str]) -> None:

--- a/tests/test_watch_config.py
+++ b/tests/test_watch_config.py
@@ -25,7 +25,11 @@ class TestWatchConfigDefaults:
 
     def test_default_cycles_per_session(self):
         c = WatchConfig()
-        assert c.cycles_per_session == 50
+        assert c.cycles_per_session == 12
+
+    def test_default_max_context_events(self):
+        c = WatchConfig()
+        assert c.max_context_events == 40
 
     def test_override_interval(self):
         c = WatchConfig(interval_minutes=10)


### PR DESCRIPTION
## Problem

Watch mode running overnight causes memory exhaustion in both the Squire container and the Ollama container hosting the LLM. Additionally, after the watch process crashes (from OOM), the web UI shows the watch as "Running" and the Stop button has no effect — there is no way to recover without restarting the entire application.

## Context

The ADK `InMemorySessionService` appends every turn (user prompt, tool calls, tool results, model response) to the session's event list. With the default `cycles_per_session=50` and `interval_minutes=5`, the session accumulated ~4 hours of conversation history before rotating. Each cycle produces 5–15KB of context, meaning by cycle 50 the session carried 250–750KB of history — all sent to Ollama on every subsequent LLM call, eventually exhausting its KV-cache memory.

Several config guardrails (`max_tool_calls_per_cycle`, `history_limit`, `notify_on_action`) were defined but never wired into runtime code.

## Solution

**Memory fixes (layered defense):**
1. **Context pruning** — after each cycle, trim the ADK session's event list to keep only the most recent `max_context_events` (default 40). This directly accesses `InMemorySessionService.sessions` storage to truncate in-place.
2. **Tool call limit enforcement** — `_run_cycle` now tracks tool calls and aborts the cycle when `max_tool_calls_per_cycle` is reached, preventing runaway tool loops from ballooning context within a single cycle.
3. **Old session cleanup** — `delete_session()` is called on the old session after rotation, freeing it from the in-memory store.
4. **Lightweight rotation handoff** — replaced the LLM summary call (which sent the full bloated context at peak size) with a simple truncation of the last response text as carryover.
5. **Lower default `cycles_per_session`** from 50 to 12 (~1 hour rotation at default interval).

**Stale state fix:**
Both `GET /api/watch/status` and `POST /api/watch/stop` now check if the recorded PID is alive via `os.kill(pid, 0)`. If the process has exited (crash, OOM, kill), the DB state is immediately corrected to `stopped` so the UI reflects reality.

**Observability wiring:**
`_run_cycle` returns `(response_text, tool_count)`. Actual tool count flows into `cycle_end` events (was hardcoded 0). `emit_session_rotated` is now called. `notify_on_action` dispatches `watch.action` notifications.

## Testing

### Unit tests
- Updated `test_watch_config.py::test_default_cycles_per_session` for the new default (12).
- Added `test_watch_config.py::test_default_max_context_events` for the new config field.

### Integration tests
No integration tests for the watch loop itself — it requires a live LLM and system backend. The watch loop is inherently end-to-end; the fixes are structural changes to session management and API endpoints that are best verified by running watch mode.

### Test results
```
390 passed, 3 warnings in 2.83s
```
Lint and format checks clean.

## Reviewer Validation

1. Run `uv run pytest tests/ -x -q` — all 390 tests should pass.
2. Review `src/squire/watch.py`:
   - `_prune_session_history` (line ~463) — verify it correctly trims both `stored.events` and `session.events`.
   - `_run_cycle` — verify `max_tool_calls` parameter and early return on limit.
   - Session rotation block — verify old session deletion and `emit_session_rotated` call.
3. Review `src/squire/api/routers/watch.py` — verify `watch_status` and `watch_stop` both check PID liveness with `os.kill(int(pid), 0)` and clean up stale state on `ProcessLookupError`.
4. To manually verify the stale-state fix: start watch, kill the process (`kill <pid>`), then `GET /api/watch/status` — should return `stopped`.

## TODOs / Follow-Ups

- `AppConfig.history_limit` and `AppConfig.max_tool_rounds` are still dead config for the **chat** (web UI) path — they only affect watch mode indirectly now. Wiring them for chat sessions is a separate concern.
- The `_prune_session_history` function accesses `InMemorySessionService` internals (`runner.session_service.sessions`). If ADK changes its internal storage structure, this will need updating. A proper upstream API for session event trimming would be preferable.

Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)