### PR TITLE
feat: web configuration API completeness and UI coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Web config:** `PATCH /api/config/notifications` now rebuilds `NotificationRouter` (webhook + email) instead of replacing it with a webhook-only dispatcher, so email delivery keeps working after saving notification settings from the UI
+- **Watch live config:** `PUT /api/watch/config` now applies all documented watch fields via the `update_config` queue, including numeric risk threshold (updates the running evaluator and session state)
+- **Watch API:** `GET /api/watch/config` returns a numeric `risk_tolerance` consistent with effective guardrails/app policy (fixes response validation when watch tolerance was set)
+
+### Added
+
+- **Web config:** `GET/PATCH /api/config/skills` for the skills directory; skills section on the Configuration page; notifications channels editor embedded as a Configuration tab
+- **Web config:** Extended PATCH schemas and forms for app name/user id, LLM `api_base`, remaining watch and guardrails fields; watch form pushes changes to a running watch process when status is `running`
+- **Web config:** Database tab explains that DB path, snapshot interval, and LLM provider secrets require env/TOML plus process restart
+
 ## [0.13.0] — 2026-04-11
 
 ### Fixed

--- a/src/squire/api/app.py
+++ b/src/squire/api/app.py
@@ -24,7 +24,7 @@ from ..config import (
 from ..database.service import DatabaseService
 from ..hosts.store import HostStore
 from ..main import _collect_all_snapshots
-from ..notifications.webhook import WebhookDispatcher
+from ..notifications.factory import build_notification_router
 from ..skills import SkillService
 from ..system.registry import BackendRegistry
 from ..tools import set_db as tools_set_db
@@ -75,20 +75,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     deps.notif_config = NotificationsConfig()
     deps.watch_config = WatchConfig()
     deps.guardrails = GuardrailsConfig()
-    skills_config = SkillsConfig()
+    deps.skills_config = SkillsConfig()
 
     # Create service singletons
     deps.registry = BackendRegistry()
     deps.db = DatabaseService(deps.db_config.path)
-    from ..notifications.email import EmailNotifier
-    from ..notifications.router import NotificationRouter
-
-    webhook_dispatcher = WebhookDispatcher(deps.notif_config)
-    email_notifier = None
-    if deps.notif_config.email and deps.notif_config.email.enabled:
-        email_notifier = EmailNotifier(deps.notif_config.email)
-    deps.notifier = NotificationRouter(webhook=webhook_dispatcher, email=email_notifier)
-    deps.skills_service = SkillService(skills_config.path)
+    deps.notifier = build_notification_router(deps.notif_config)
+    deps.skills_service = SkillService(deps.skills_config.path)
 
     # Load managed hosts from DB into the registry
     deps.host_store = HostStore(deps.db, deps.registry)

--- a/src/squire/api/dependencies.py
+++ b/src/squire/api/dependencies.py
@@ -5,6 +5,7 @@ injection. Tools also receive these via the global tool registry.
 """
 
 from squire.config import AppConfig, DatabaseConfig, GuardrailsConfig, LLMConfig, NotificationsConfig, WatchConfig
+from squire.config.skills import SkillsConfig
 from squire.database.service import DatabaseService
 from squire.hosts.store import HostStore
 from squire.notifications.router import NotificationRouter
@@ -24,6 +25,7 @@ db_config: DatabaseConfig | None = None
 notif_config: NotificationsConfig | None = None
 watch_config: WatchConfig | None = None
 guardrails: GuardrailsConfig | None = None
+skills_config: SkillsConfig | None = None
 host_store: HostStore | None = None
 
 

--- a/src/squire/api/routers/config.py
+++ b/src/squire/api/routers/config.py
@@ -2,14 +2,18 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from squire.config import AppConfig, GuardrailsConfig, LLMConfig, NotificationsConfig, WatchConfig
 from squire.config.loader import get_env_overrides, get_toml_path, write_toml_section
-from squire.config.notifications import WebhookConfig
-from squire.notifications.webhook import WebhookDispatcher
+from squire.config.notifications import EmailConfig, WebhookConfig
+from squire.config.skills import SkillsConfig
+from squire.notifications.factory import build_notification_router
+from squire.skills import SkillService
+from squire.tools import set_notifier as tools_set_notifier
 
 from .. import dependencies as deps
 from ..dependencies import get_app_config, get_llm_config
@@ -20,6 +24,7 @@ from ..schemas import (
     GuardrailsConfigUpdate,
     LLMConfigUpdate,
     NotificationsConfigUpdate,
+    SkillsConfigUpdate,
     WatchConfigPatch,
 )
 
@@ -82,9 +87,10 @@ _SECTIONS: dict[str, _SectionInfo] = {
         "notifications",
         _redact_notifications,
     ),
+    "skills": _SectionInfo("skills_config", SkillsConfig, SkillsConfigUpdate, "SQUIRE_SKILLS_", "skills"),
 }
 
-_IMMUTABLE_SECTIONS = {"database", "hosts", "skills"}
+_IMMUTABLE_SECTIONS = {"database", "hosts"}
 
 
 def _section_meta(attr: str, info: _SectionInfo) -> ConfigSectionMeta:
@@ -127,6 +133,7 @@ async def get_config(
         notifications=_section_meta("notif_config", _SECTIONS["notifications"]),
         guardrails=_section_meta("guardrails", _SECTIONS["guardrails"]),
         watch=_section_meta("watch_config", _SECTIONS["watch"]),
+        skills=_section_meta("skills_config", _SECTIONS["skills"]),
         hosts=host_configs,
         toml_path=str(toml_path) if toml_path else None,
     )
@@ -154,6 +161,37 @@ def _merge_webhooks(existing: list[WebhookConfig], incoming: list[dict]) -> list
                 wh_dict["headers"] = headers
         result.append(WebhookConfig(**wh_dict))
     return result
+
+
+def _normalize_email_dict(data: dict) -> dict:
+    """Map UI field names to EmailConfig (e.g. ``tls`` -> ``use_tls``)."""
+    out = dict(data)
+    if "tls" in out and "use_tls" not in out:
+        out["use_tls"] = bool(out.pop("tls"))
+    return out
+
+
+def _merge_email(existing: EmailConfig | None, incoming: dict) -> EmailConfig:
+    """Merge PATCH email payload with existing config; preserve redacted password."""
+    inc = _normalize_email_dict(dict(incoming))
+    base = existing.model_dump() if existing else {}
+    for k, v in inc.items():
+        if k == "smtp_password" and v == _REDACTED and existing:
+            base[k] = existing.smtp_password
+            continue
+        base[k] = v
+    return EmailConfig.model_validate(base)
+
+
+def _persist_value(v):
+    """JSON/TOML-friendly value for ``write_toml_section``."""
+    if hasattr(v, "model_dump"):
+        return v.model_dump()
+    if isinstance(v, Path):
+        return str(v)
+    if isinstance(v, list) and v and hasattr(v[0], "model_dump"):
+        return [x.model_dump() for x in v]
+    return v
 
 
 @router.patch("/{section}")
@@ -192,9 +230,15 @@ async def patch_config(
             detail=f"Cannot update env-var-overridden fields: {', '.join(env_vars)}",
         )
 
-    # Special handling for notifications webhooks
+    # Special handling for notifications webhooks + email
     if section == "notifications" and "webhooks" in fields:
         fields["webhooks"] = _merge_webhooks(current.webhooks, fields["webhooks"])
+    if section == "notifications" and "email" in cleaned:
+        em = cleaned["email"]
+        fields["email"] = None if em is None else _merge_email(current.email, em)
+
+    if section == "skills" and "path" in fields:
+        fields["path"] = Path(fields["path"])
 
     # Create new config instance with updated fields
     new_config = current.model_copy(update=fields)
@@ -202,20 +246,21 @@ async def patch_config(
     # Replace the singleton
     setattr(deps, info.attr, new_config)
 
-    # Recreate notifier if notifications changed
-    if section == "notifications" and deps.notifier is not None:
-        deps.notifier = WebhookDispatcher(new_config)
+    # Recreate notifier if notifications changed (webhook + email, same as lifespan)
+    if section == "notifications":
+        old_notifier = deps.notifier
+        deps.notifier = build_notification_router(new_config)
+        tools_set_notifier(deps.notifier)
+        if old_notifier is not None:
+            await old_notifier.close()
+
+    if section == "skills":
+        deps.skills_service = SkillService(new_config.path)
 
     # Persist to TOML if requested
     persist_path = None
     if persist:
-        # For notifications webhooks, serialize back to dicts
-        persist_data = {}
-        for k, v in fields.items():
-            if k == "webhooks":
-                persist_data[k] = [wh.model_dump() if hasattr(wh, "model_dump") else wh for wh in v]
-            else:
-                persist_data[k] = v
+        persist_data = {k: _persist_value(getattr(new_config, k)) for k in fields}
         persist_path = write_toml_section(info.toml_section, persist_data)
 
     values = new_config.model_dump(mode="json")

--- a/src/squire/api/routers/watch.py
+++ b/src/squire/api/routers/watch.py
@@ -4,9 +4,10 @@ import asyncio
 import json
 import os
 
+from agent_risk_engine import RuleGate
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
 
-from ..dependencies import get_db, get_guardrails, get_watch_config
+from ..dependencies import get_app_config, get_db, get_guardrails, get_watch_config
 from ..schemas import (
     WatchApprovalAction,
     WatchCommandResponse,
@@ -16,6 +17,12 @@ from ..schemas import (
 )
 
 router = APIRouter()
+
+
+def _effective_watch_risk_level(guardrails, app_config) -> int:
+    """Numeric risk threshold (1–5) used in watch mode UI and live updates."""
+    wt = guardrails.watch_tolerance or app_config.risk_tolerance
+    return RuleGate(threshold=wt, strict=True, allowed=set(), denied=set()).threshold
 
 
 async def _increment_supervisor_count(db) -> None:
@@ -116,16 +123,19 @@ async def watch_stop(db=Depends(get_db)):
 async def watch_config_get(
     watch_config=Depends(get_watch_config),
     guardrails=Depends(get_guardrails),
+    app_config=Depends(get_app_config),
 ):
     """Get current watch configuration."""
     return WatchConfigResponse(
         interval_minutes=watch_config.interval_minutes,
+        max_tool_calls_per_cycle=watch_config.max_tool_calls_per_cycle,
         cycle_timeout_seconds=watch_config.cycle_timeout_seconds,
         checkin_prompt=watch_config.checkin_prompt,
         notify_on_action=watch_config.notify_on_action,
         notify_on_blocked=watch_config.notify_on_blocked,
         cycles_per_session=watch_config.cycles_per_session,
-        risk_tolerance=guardrails.watch_tolerance,
+        max_context_events=watch_config.max_context_events,
+        risk_tolerance=_effective_watch_risk_level(guardrails, app_config),
     )
 
 

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -220,11 +220,14 @@ class ConfigDetailResponse(BaseModel):
     notifications: ConfigSectionMeta
     guardrails: ConfigSectionMeta
     watch: ConfigSectionMeta
+    skills: ConfigSectionMeta
     hosts: list[dict]
     toml_path: str | None = None
 
 
 class AppConfigUpdate(BaseModel):
+    app_name: str | None = None
+    user_id: str | None = None
     risk_tolerance: str | None = None
     risk_strict: bool | None = None
     history_limit: int | None = None
@@ -234,16 +237,20 @@ class AppConfigUpdate(BaseModel):
 
 class LLMConfigUpdate(BaseModel):
     model: str | None = None
+    api_base: str | None = None
     temperature: float | None = None
     max_tokens: int | None = None
 
 
 class WatchConfigPatch(BaseModel):
     interval_minutes: int | None = None
+    max_tool_calls_per_cycle: int | None = None
     cycle_timeout_seconds: int | None = None
     checkin_prompt: str | None = None
     notify_on_action: bool | None = None
     notify_on_blocked: bool | None = None
+    cycles_per_session: int | None = None
+    max_context_events: int | None = None
 
 
 class GuardrailsConfigUpdate(BaseModel):
@@ -258,11 +265,19 @@ class GuardrailsConfigUpdate(BaseModel):
     watch_tolerance: str | None = None
     watch_tools_allow: list[str] | None = None
     watch_tools_deny: list[str] | None = None
+    commands_allow: list[str] | None = None
+    commands_block: list[str] | None = None
+    config_paths: list[str] | None = None
 
 
 class NotificationsConfigUpdate(BaseModel):
     enabled: bool | None = None
     webhooks: list[dict] | None = None
+    email: dict | None = None
+
+
+class SkillsConfigUpdate(BaseModel):
+    path: str | None = None
 
 
 # --- Watch ---
@@ -283,17 +298,25 @@ class WatchStatusResponse(BaseModel):
 
 class WatchConfigUpdate(BaseModel):
     interval_minutes: int | None = None
-    risk_tolerance: int | None = None
+    max_tool_calls_per_cycle: int | None = None
+    cycle_timeout_seconds: int | None = None
     checkin_prompt: str | None = None
+    notify_on_action: bool | None = None
+    notify_on_blocked: bool | None = None
+    cycles_per_session: int | None = None
+    max_context_events: int | None = None
+    risk_tolerance: int | None = None
 
 
 class WatchConfigResponse(BaseModel):
     interval_minutes: int
+    max_tool_calls_per_cycle: int
     cycle_timeout_seconds: int
     checkin_prompt: str
     notify_on_action: bool
     notify_on_blocked: bool
     cycles_per_session: int
+    max_context_events: int
     risk_tolerance: int | None
 
 

--- a/src/squire/notifications/factory.py
+++ b/src/squire/notifications/factory.py
@@ -1,0 +1,17 @@
+"""Build NotificationRouter from NotificationsConfig (shared by web lifespan and config PATCH)."""
+
+from __future__ import annotations
+
+from ..config.notifications import NotificationsConfig
+from .email import EmailNotifier
+from .router import NotificationRouter
+from .webhook import WebhookDispatcher
+
+
+def build_notification_router(cfg: NotificationsConfig) -> NotificationRouter:
+    """Create webhook + optional email channels wrapped in NotificationRouter."""
+    webhook = WebhookDispatcher(cfg)
+    email_notifier = None
+    if cfg.email and cfg.email.enabled:
+        email_notifier = EmailNotifier(cfg.email)
+    return NotificationRouter(webhook=webhook, email=email_notifier)

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -46,11 +46,29 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+# Keys allowed on WatchConfig from a live ``update_config`` command (JSON payload).
+_WATCH_LIVE_KEYS = frozenset(
+    {
+        "interval_minutes",
+        "max_tool_calls_per_cycle",
+        "cycle_timeout_seconds",
+        "checkin_prompt",
+        "notify_on_action",
+        "notify_on_blocked",
+        "cycles_per_session",
+        "max_context_events",
+    }
+)
+
 
 async def _poll_commands(
     db: DatabaseService,
     shutdown: asyncio.Event,
     watch_config: WatchConfig | None,
+    *,
+    session_ref: list | None = None,
+    session_state_template: dict | None = None,
+    risk_evaluator: RiskEvaluator | None = None,
 ) -> None:
     """Process any pending watch commands from the database."""
     commands = await db.get_pending_watch_commands()
@@ -63,9 +81,20 @@ async def _poll_commands(
                 await db.update_watch_command_status(cmd_id, "completed")
             elif command == "update_config" and watch_config is not None:
                 payload = json.loads(cmd["payload"] or "{}")
-                for key in ("interval_minutes", "checkin_prompt"):
+                for key in _WATCH_LIVE_KEYS:
                     if key in payload:
                         setattr(watch_config, key, payload[key])
+                if "interval_minutes" in payload:
+                    await db.set_watch_state("interval_minutes", str(payload["interval_minutes"]))
+                if "risk_tolerance" in payload and risk_evaluator is not None:
+                    threshold = int(payload["risk_tolerance"])
+                    risk_evaluator.rule_gate.threshold = threshold
+                    if session_state_template is not None:
+                        session_state_template["risk_tolerance"] = threshold
+                    sess = session_ref[0] if session_ref and session_ref[0] is not None else None
+                    if sess is not None:
+                        sess.state["risk_tolerance"] = threshold
+                    await db.set_watch_state("risk_tolerance", str(threshold))
                 await db.update_watch_command_status(cmd_id, "completed")
                 logger.info("Applied config update: %s", payload)
             elif command == "start":
@@ -82,6 +111,10 @@ async def _interruptible_sleep(
     interval_seconds: float,
     poll_seconds: float = 5.0,
     watch_config: WatchConfig | None = None,
+    *,
+    session_ref: list | None = None,
+    session_state_template: dict | None = None,
+    risk_evaluator: RiskEvaluator | None = None,
 ) -> None:
     """Sleep in short increments, polling for commands between sleeps."""
     elapsed = 0.0
@@ -92,7 +125,14 @@ async def _interruptible_sleep(
             pass
         elapsed += poll_seconds
         if not shutdown.is_set():
-            await _poll_commands(db, shutdown, watch_config)
+            await _poll_commands(
+                db,
+                shutdown,
+                watch_config,
+                session_ref=session_ref,
+                session_state_template=session_state_template,
+                risk_evaluator=risk_evaluator,
+            )
 
 
 def _configure_logging() -> None:
@@ -206,6 +246,7 @@ async def start_watch() -> None:
         state=session_state,
     )
     await db.create_session(session.id)
+    session_ref = [session]
 
     # Signal handling for graceful shutdown
     shutdown = asyncio.Event()
@@ -245,7 +286,14 @@ async def start_watch() -> None:
 
     # Cleanup stale data and process any pending start commands
     await db.cleanup_watch_data()
-    await _poll_commands(db, shutdown, watch_config)
+    await _poll_commands(
+        db,
+        shutdown,
+        watch_config,
+        session_ref=session_ref,
+        session_state_template=session_state,
+        risk_evaluator=risk_evaluator,
+    )
 
     cycle_count = 0
     last_cycle_error: str | None = None
@@ -259,7 +307,14 @@ async def start_watch() -> None:
             await db.set_watch_state("last_cycle_at", cycle_start)
 
             # Poll for commands (e.g. stop or config update) before running cycle
-            await _poll_commands(db, shutdown, watch_config)
+            await _poll_commands(
+                db,
+                shutdown,
+                watch_config,
+                session_ref=session_ref,
+                session_state_template=session_state,
+                risk_evaluator=risk_evaluator,
+            )
             if shutdown.is_set():
                 break
 
@@ -398,9 +453,18 @@ async def start_watch() -> None:
 
                 await emitter.emit_session_rotated(cycle_count, old_session_id, session.id)
                 cycle_count = 0
+                session_ref[0] = session
 
             # Sleep until next cycle (interruptible by shutdown signal or commands)
-            await _interruptible_sleep(db, shutdown, watch_config.interval_minutes * 60, watch_config=watch_config)
+            await _interruptible_sleep(
+                db,
+                shutdown,
+                watch_config.interval_minutes * 60,
+                watch_config=watch_config,
+                session_ref=session_ref,
+                session_state_template=session_state,
+                risk_evaluator=risk_evaluator,
+            )
 
     finally:
         await db.set_watch_state("status", "stopped")

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -17,11 +17,16 @@ def _empty_toml(monkeypatch):
 @pytest.fixture
 def _setup_deps(monkeypatch):
     """Populate deps singletons with default configs."""
+    from squire.config.skills import SkillsConfig
+    from squire.skills import SkillService
+
     monkeypatch.setattr(deps, "app_config", AppConfig())
     monkeypatch.setattr(deps, "llm_config", LLMConfig())
     monkeypatch.setattr(deps, "watch_config", WatchConfig())
     monkeypatch.setattr(deps, "guardrails", GuardrailsConfig())
     monkeypatch.setattr(deps, "notif_config", NotificationsConfig())
+    monkeypatch.setattr(deps, "skills_config", SkillsConfig())
+    monkeypatch.setattr(deps, "skills_service", SkillService(deps.skills_config.path))
     monkeypatch.setattr(deps, "db_config", None)
     monkeypatch.setattr(deps, "host_store", None)
     monkeypatch.setattr(deps, "notifier", None)
@@ -48,6 +53,7 @@ class TestGetConfig:
         result = await get_config(app_config=deps.app_config, llm_config=deps.llm_config)
         assert result.app.values["app_name"] == "Squire"
         assert "model" in result.llm.values
+        assert "path" in result.skills.values
 
     async def test_returns_toml_path(self, tmp_path, monkeypatch):
         from squire.api.routers.config import get_config
@@ -130,6 +136,15 @@ class TestPatchConfig:
             await patch_config("database", {"path": "/tmp/db"}, persist=False)
         assert exc_info.value.status_code == 404
 
+    async def test_patch_skills_updates_service(self, monkeypatch, tmp_path):
+        from squire.api.routers.config import patch_config
+
+        new_dir = tmp_path / "skills2"
+        new_dir.mkdir()
+        await patch_config("skills", {"path": str(new_dir)}, persist=False)
+        assert deps.skills_config.path == new_dir
+        assert deps.skills_service._dir == new_dir
+
     async def test_empty_body_400(self):
         from fastapi import HTTPException
 
@@ -189,6 +204,41 @@ class TestNotificationsWebhookMerge:
             persist=False,
         )
         assert deps.notif_config.webhooks[0].headers["Authorization"] == "Bearer secret"
+
+    async def test_merge_preserves_redacted_email_password(self, monkeypatch):
+        from squire.api.routers.config import patch_config
+        from squire.config.notifications import EmailConfig
+
+        existing = NotificationsConfig(
+            enabled=True,
+            email=EmailConfig(
+                enabled=True,
+                smtp_host="smtp.example.com",
+                smtp_password="secret-pass",
+                from_address="a@b.c",
+                to_addresses=["u@x.y"],
+            ),
+        )
+        monkeypatch.setattr(deps, "notif_config", existing)
+        monkeypatch.setattr(deps, "notifier", None)
+
+        await patch_config(
+            "notifications",
+            {
+                "email": {
+                    "enabled": True,
+                    "smtp_host": "smtp.example.com",
+                    "smtp_password": "••••••",
+                    "from_address": "a@b.c",
+                    "to_addresses": ["u@x.y"],
+                    "tls": True,
+                }
+            },
+            persist=False,
+        )
+        assert deps.notif_config.email is not None
+        assert deps.notif_config.email.smtp_password == "secret-pass"
+        assert deps.notif_config.email.use_tls is True
 
 
 # --- Persist to TOML ---

--- a/tests/test_watch_loop.py
+++ b/tests/test_watch_loop.py
@@ -24,16 +24,50 @@ async def test_poll_commands_stop(db):
 @pytest.mark.asyncio
 async def test_poll_commands_update_config(db):
     """An 'update_config' command should apply overrides."""
+    from agent_risk_engine import RiskEvaluator, RuleGate
+
+    from squire.callbacks.risk_gate import build_pattern_analyzer
     from squire.config import WatchConfig
     from squire.watch import _poll_commands
 
     shutdown = asyncio.Event()
     config = WatchConfig()
+    rule_gate = RuleGate(threshold=2, strict=True, allowed=set(), denied=set())
+    risk_evaluator = RiskEvaluator(rule_gate=rule_gate, analyzer=build_pattern_analyzer())
+    session_state = {"risk_tolerance": 2}
 
-    await db.insert_watch_command("update_config", payload=json.dumps({"interval_minutes": 1}))
-    await _poll_commands(db, shutdown, watch_config=config)
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.state: dict = {"risk_tolerance": 2}
+
+    session_ref = [_FakeSession()]
+
+    await db.insert_watch_command(
+        "update_config",
+        payload=json.dumps(
+            {
+                "interval_minutes": 1,
+                "cycle_timeout_seconds": 120,
+                "notify_on_action": False,
+                "risk_tolerance": 5,
+            }
+        ),
+    )
+    await _poll_commands(
+        db,
+        shutdown,
+        watch_config=config,
+        session_ref=session_ref,
+        session_state_template=session_state,
+        risk_evaluator=risk_evaluator,
+    )
 
     assert config.interval_minutes == 1
+    assert config.cycle_timeout_seconds == 120
+    assert config.notify_on_action is False
+    assert risk_evaluator.rule_gate.threshold == 5
+    assert session_ref[0].state["risk_tolerance"] == 5
+    assert session_state["risk_tolerance"] == 5
     assert not shutdown.is_set()
 
     pending = await db.get_pending_watch_commands()

--- a/web/src/components/config/app-config-form.tsx
+++ b/web/src/components/config/app-config-form.tsx
@@ -52,6 +52,8 @@ function EnvLock({ field, prefix }: { field: string; prefix: string }) {
 }
 
 export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppConfigFormProps) {
+  const [appName, setAppName] = useState(String(values.app_name ?? "Squire"));
+  const [userId, setUserId] = useState(String(values.user_id ?? "squire-user"));
   const [riskTolerance, setRiskTolerance] = useState(String(values.risk_tolerance ?? "cautious"));
   const [riskStrict, setRiskStrict] = useState(Boolean(values.risk_strict));
   const [historyLimit, setHistoryLimit] = useState(Number(values.history_limit ?? 50));
@@ -64,6 +66,8 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
   const isLocked = (field: string) => envOverrides.includes(field);
 
   const isDirty =
+    appName !== String(values.app_name ?? "Squire") ||
+    userId !== String(values.user_id ?? "squire-user") ||
     riskTolerance !== String(values.risk_tolerance ?? "cautious") ||
     riskStrict !== Boolean(values.risk_strict) ||
     historyLimit !== Number(values.history_limit ?? 50) ||
@@ -71,6 +75,8 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
     multiAgent !== Boolean(values.multi_agent);
 
   const revert = () => {
+    setAppName(String(values.app_name ?? "Squire"));
+    setUserId(String(values.user_id ?? "squire-user"));
     setRiskTolerance(String(values.risk_tolerance ?? "cautious"));
     setRiskStrict(Boolean(values.risk_strict));
     setHistoryLimit(Number(values.history_limit ?? 50));
@@ -84,6 +90,8 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
     setError(null);
     try {
       const changed: Record<string, unknown> = {};
+      if (appName !== String(values.app_name ?? "Squire")) changed.app_name = appName;
+      if (userId !== String(values.user_id ?? "squire-user")) changed.user_id = userId;
       if (riskTolerance !== String(values.risk_tolerance ?? "cautious")) changed.risk_tolerance = riskTolerance;
       if (riskStrict !== Boolean(values.risk_strict)) changed.risk_strict = riskStrict;
       if (historyLimit !== Number(values.history_limit ?? 50)) changed.history_limit = historyLimit;
@@ -106,6 +114,32 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
         <CardTitle className="text-base">App</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>App name</Label>
+            {isLocked("app_name") && <EnvLock field="app_name" prefix="SQUIRE_" />}
+          </div>
+          <Input
+            value={appName}
+            onChange={(e) => setAppName(e.target.value)}
+            disabled={isLocked("app_name")}
+            className="text-sm"
+          />
+          <p className="text-xs text-muted-foreground">Passed to the ADK runner as the application name.</p>
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>User ID</Label>
+            {isLocked("user_id") && <EnvLock field="user_id" prefix="SQUIRE_" />}
+          </div>
+          <Input
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            disabled={isLocked("user_id")}
+            className="text-sm font-mono"
+          />
+          <p className="text-xs text-muted-foreground">ADK session scope for this Squire instance.</p>
+        </div>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>Risk Tolerance</Label>

--- a/web/src/components/config/config-editor.tsx
+++ b/web/src/components/config/config-editor.tsx
@@ -6,10 +6,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import type { ConfigDetailResponse } from "@/lib/types";
+import { ChannelsTab } from "@/components/notifications/channels-tab";
 import { AppConfigForm } from "./app-config-form";
 import { LLMConfigForm } from "./llm-config-form";
 import { WatchConfigForm } from "./watch-config-form";
 import { GuardrailsConfigForm } from "./guardrails-config-form";
+import { SkillsConfigForm } from "./skills-config-form";
 
 interface ConfigEditorProps {
   config: ConfigDetailResponse;
@@ -95,8 +97,10 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
         <TabsTrigger value="app">App</TabsTrigger>
         <TabsTrigger value="llm">LLM</TabsTrigger>
         <TabsTrigger value="database">Database</TabsTrigger>
+        <TabsTrigger value="notifications">Notifications</TabsTrigger>
         <TabsTrigger value="guardrails">Guardrails</TabsTrigger>
         <TabsTrigger value="watch">Watch</TabsTrigger>
+        <TabsTrigger value="skills">Skills</TabsTrigger>
         <TabsTrigger value="hosts">Hosts</TabsTrigger>
       </TabsList>
 
@@ -119,7 +123,23 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
       </TabsContent>
 
       <TabsContent value="database">
-        <ReadOnlySection title="Database" data={config.database.values} />
+        <div className="space-y-4">
+          <div className="rounded-md border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">Database settings are read-only here</p>
+            <p className="mt-1 text-xs leading-relaxed">
+              The SQLite path (<code className="font-mono">SQUIRE_DB_PATH</code> /{" "}
+              <code className="font-mono">[db].path</code>) and snapshot interval are fixed when the web process
+              starts. Changing them requires updating <code className="font-mono">squire.toml</code> or environment
+              variables and restarting Squire. Provider API keys for LLMs are configured through LiteLLM environment
+              variables, not through this UI.
+            </p>
+          </div>
+          <ReadOnlySection title="Database" data={config.database.values} />
+        </div>
+      </TabsContent>
+
+      <TabsContent value="notifications">
+        <ChannelsTab />
       </TabsContent>
 
       <TabsContent value="guardrails">
@@ -135,6 +155,15 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
         <WatchConfigForm
           values={config.watch.values}
           envOverrides={config.watch.env_overrides}
+          tomlPath={config.toml_path}
+          onSaved={onSaved}
+        />
+      </TabsContent>
+
+      <TabsContent value="skills">
+        <SkillsConfigForm
+          values={config.skills.values}
+          envOverrides={config.skills.env_overrides}
           tomlPath={config.toml_path}
           onSaved={onSaved}
         />

--- a/web/src/components/config/guardrails-config-form.tsx
+++ b/web/src/components/config/guardrails-config-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Lock, Loader2, RotateCcw, Save, X } from "lucide-react";
 import { apiPatch } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
@@ -20,6 +20,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface GuardrailsConfigFormProps {
@@ -130,9 +131,45 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
   const [watchTolerance, setWatchTolerance] = useState(toStr(values.watch_tolerance));
   const [watchToolsAllow, setWatchToolsAllow] = useState(toArr(values.watch_tools_allow));
   const [watchToolsDeny, setWatchToolsDeny] = useState(toArr(values.watch_tools_deny));
+  const [commandsAllow, setCommandsAllow] = useState(toArr(values.commands_allow));
+  const [commandsBlock, setCommandsBlock] = useState(toArr(values.commands_block));
+  const [configPaths, setConfigPaths] = useState(toArr(values.config_paths));
+  const riskOrigJson = JSON.stringify(
+    values.tools_risk_overrides && typeof values.tools_risk_overrides === "object"
+      ? (values.tools_risk_overrides as Record<string, unknown>)
+      : {},
+    null,
+    2
+  );
+  const [toolsRiskJson, setToolsRiskJson] = useState(riskOrigJson);
   const [persist, setPersist] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setToolsAllow(toArr(values.tools_allow));
+    setToolsRequireApproval(toArr(values.tools_require_approval));
+    setToolsDeny(toArr(values.tools_deny));
+    setMonitorTolerance(toStr(values.monitor_tolerance));
+    setContainerTolerance(toStr(values.container_tolerance));
+    setAdminTolerance(toStr(values.admin_tolerance));
+    setNotifierTolerance(toStr(values.notifier_tolerance));
+    setWatchTolerance(toStr(values.watch_tolerance));
+    setWatchToolsAllow(toArr(values.watch_tools_allow));
+    setWatchToolsDeny(toArr(values.watch_tools_deny));
+    setCommandsAllow(toArr(values.commands_allow));
+    setCommandsBlock(toArr(values.commands_block));
+    setConfigPaths(toArr(values.config_paths));
+    setToolsRiskJson(
+      JSON.stringify(
+        values.tools_risk_overrides && typeof values.tools_risk_overrides === "object"
+          ? (values.tools_risk_overrides as Record<string, unknown>)
+          : {},
+        null,
+        2
+      )
+    );
+  }, [values]);
 
   const isLocked = (field: string) => envOverrides.includes(field);
 
@@ -146,7 +183,11 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
     notifierTolerance !== toStr(values.notifier_tolerance) ||
     watchTolerance !== toStr(values.watch_tolerance) ||
     !arraysEqual(values.watch_tools_allow, watchToolsAllow) ||
-    !arraysEqual(values.watch_tools_deny, watchToolsDeny);
+    !arraysEqual(values.watch_tools_deny, watchToolsDeny) ||
+    !arraysEqual(values.commands_allow, commandsAllow) ||
+    !arraysEqual(values.commands_block, commandsBlock) ||
+    !arraysEqual(values.config_paths, configPaths) ||
+    toolsRiskJson.trim() !== riskOrigJson.trim();
 
   const revert = () => {
     setToolsAllow(toArr(values.tools_allow));
@@ -159,6 +200,10 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
     setWatchTolerance(toStr(values.watch_tolerance));
     setWatchToolsAllow(toArr(values.watch_tools_allow));
     setWatchToolsDeny(toArr(values.watch_tools_deny));
+    setCommandsAllow(toArr(values.commands_allow));
+    setCommandsBlock(toArr(values.commands_block));
+    setConfigPaths(toArr(values.config_paths));
+    setToolsRiskJson(riskOrigJson);
     setError(null);
   };
 
@@ -166,6 +211,21 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
     setSaving(true);
     setError(null);
     try {
+      let parsedOverrides: Record<string, number> | undefined;
+      if (toolsRiskJson.trim() !== riskOrigJson.trim()) {
+        try {
+          const p = JSON.parse(toolsRiskJson) as unknown;
+          if (p === null || typeof p !== "object" || Array.isArray(p)) {
+            throw new Error("Must be a JSON object");
+          }
+          parsedOverrides = p as Record<string, number>;
+        } catch {
+          setError("Tool risk overrides must be valid JSON object (tool name → number).");
+          setSaving(false);
+          return;
+        }
+      }
+
       const changed: Record<string, unknown> = {};
       if (!arraysEqual(values.tools_allow, toolsAllow)) changed.tools_allow = toolsAllow;
       if (!arraysEqual(values.tools_require_approval, toolsRequireApproval))
@@ -183,6 +243,10 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
       }
       if (!arraysEqual(values.watch_tools_allow, watchToolsAllow)) changed.watch_tools_allow = watchToolsAllow;
       if (!arraysEqual(values.watch_tools_deny, watchToolsDeny)) changed.watch_tools_deny = watchToolsDeny;
+      if (!arraysEqual(values.commands_allow, commandsAllow)) changed.commands_allow = commandsAllow;
+      if (!arraysEqual(values.commands_block, commandsBlock)) changed.commands_block = commandsBlock;
+      if (!arraysEqual(values.config_paths, configPaths)) changed.config_paths = configPaths;
+      if (parsedOverrides !== undefined) changed.tools_risk_overrides = parsedOverrides;
 
       const url = persist ? "/api/config/guardrails?persist=true" : "/api/config/guardrails";
       await apiPatch(url, changed);
@@ -303,6 +367,65 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
             <Label className="text-xs">Watch Tools Deny</Label>
             <TagInput value={watchToolsDeny} onChange={setWatchToolsDeny} disabled={isLocked("watch_tools_deny")} />
           </div>
+        </div>
+
+        <div className="border-t pt-4 space-y-3">
+          <Label className="text-sm font-medium">run_command and read_config</Label>
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5">
+              <Label className="text-xs">Commands Allow</Label>
+              {isLocked("commands_allow") && <EnvLock field="commands_allow" prefix="SQUIRE_GUARDRAILS_" />}
+            </div>
+            <TagInput
+              value={commandsAllow}
+              onChange={setCommandsAllow}
+              disabled={isLocked("commands_allow")}
+              placeholder="Command basename, press Enter"
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5">
+              <Label className="text-xs">Commands Block</Label>
+              {isLocked("commands_block") && <EnvLock field="commands_block" prefix="SQUIRE_GUARDRAILS_" />}
+            </div>
+            <TagInput
+              value={commandsBlock}
+              onChange={setCommandsBlock}
+              disabled={isLocked("commands_block")}
+              placeholder="Command basename, press Enter"
+            />
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5">
+              <Label className="text-xs">read_config allowed paths</Label>
+              {isLocked("config_paths") && <EnvLock field="config_paths" prefix="SQUIRE_GUARDRAILS_" />}
+            </div>
+            <TagInput
+              value={configPaths}
+              onChange={setConfigPaths}
+              disabled={isLocked("config_paths")}
+              placeholder="Directory path, press Enter"
+            />
+          </div>
+        </div>
+
+        <div className="border-t pt-4 space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label className="text-sm font-medium">Tool risk overrides</Label>
+            {isLocked("tools_risk_overrides") && (
+              <EnvLock field="tools_risk_overrides" prefix="SQUIRE_GUARDRAILS_" />
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            JSON object mapping tool names (or tool:action) to risk level integers 1–5.
+          </p>
+          <Textarea
+            value={toolsRiskJson}
+            onChange={(e) => setToolsRiskJson(e.target.value)}
+            disabled={isLocked("tools_risk_overrides")}
+            rows={6}
+            className="font-mono text-xs"
+          />
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}

--- a/web/src/components/config/llm-config-form.tsx
+++ b/web/src/components/config/llm-config-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Lock, Loader2, RotateCcw, Save } from "lucide-react";
 import { apiPatch } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -36,25 +36,45 @@ function EnvLock({ field, prefix }: { field: string; prefix: string }) {
   );
 }
 
+const REDACTED = "\u2022\u2022\u2022\u2022\u2022\u2022";
+
+function apiBaseFromValues(v: unknown): string {
+  if (v == null) return "";
+  const s = String(v);
+  return s === REDACTED ? "" : s;
+}
+
 export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMConfigFormProps) {
   const [model, setModel] = useState(String(values.model ?? ""));
   const [temperature, setTemperature] = useState(Number(values.temperature ?? 0.2));
   const [maxTokens, setMaxTokens] = useState(Number(values.max_tokens ?? 4096));
+  const [apiBase, setApiBase] = useState(() => apiBaseFromValues(values.api_base));
   const [persist, setPersist] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    setModel(String(values.model ?? ""));
+    setTemperature(Number(values.temperature ?? 0.2));
+    setMaxTokens(Number(values.max_tokens ?? 4096));
+    setApiBase(apiBaseFromValues(values.api_base));
+  }, [values]);
+
   const isLocked = (field: string) => envOverrides.includes(field);
+
+  const origApiBase = apiBaseFromValues(values.api_base);
 
   const isDirty =
     model !== String(values.model ?? "") ||
     temperature !== Number(values.temperature ?? 0.2) ||
-    maxTokens !== Number(values.max_tokens ?? 4096);
+    maxTokens !== Number(values.max_tokens ?? 4096) ||
+    apiBase !== origApiBase;
 
   const revert = () => {
     setModel(String(values.model ?? ""));
     setTemperature(Number(values.temperature ?? 0.2));
     setMaxTokens(Number(values.max_tokens ?? 4096));
+    setApiBase(origApiBase);
     setError(null);
   };
 
@@ -66,6 +86,7 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
       if (model !== String(values.model ?? "")) changed.model = model;
       if (temperature !== Number(values.temperature ?? 0.2)) changed.temperature = temperature;
       if (maxTokens !== Number(values.max_tokens ?? 4096)) changed.max_tokens = maxTokens;
+      if (apiBase !== origApiBase) changed.api_base = apiBase.trim() === "" ? null : apiBase.trim();
 
       const url = persist ? "/api/config/llm?persist=true" : "/api/config/llm";
       await apiPatch(url, changed);
@@ -126,16 +147,23 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
           />
         </div>
 
-        {values.api_base != null && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-1.5">
-              <Label>API Base</Label>
-              <Lock className="h-3.5 w-3.5 text-muted-foreground" />
-            </div>
-            <Input value={String(values.api_base)} disabled className="font-mono text-xs" />
-            <p className="text-xs text-muted-foreground">Sensitive — change via env var or squire.toml</p>
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>API Base URL</Label>
+            {isLocked("api_base") && <EnvLock field="api_base" prefix="SQUIRE_LLM_" />}
           </div>
-        )}
+          <Input
+            value={apiBase}
+            onChange={(e) => setApiBase(e.target.value)}
+            disabled={isLocked("api_base")}
+            placeholder="e.g. http://localhost:11434 (Ollama)"
+            className="font-mono text-xs"
+          />
+          <p className="text-xs text-muted-foreground">
+            Optional LiteLLM API base. Provider API keys are usually set via environment variables (see LiteLLM docs).
+            Redacted values in the API response are omitted here; enter a new URL to replace the stored one.
+          </p>
+        </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}
 

--- a/web/src/components/config/skills-config-form.tsx
+++ b/web/src/components/config/skills-config-form.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { Lock, Loader2, RotateCcw, Save } from "lucide-react";
+import { apiPatch } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface SkillsConfigFormProps {
+  values: Record<string, unknown>;
+  envOverrides: string[];
+  tomlPath: string | null;
+  onSaved: () => void;
+}
+
+function EnvLock({ field, prefix }: { field: string; prefix: string }) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Lock className="h-3.5 w-3.5 text-muted-foreground" />
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            Set by {prefix}
+            {field.toUpperCase()}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export function SkillsConfigForm({ values, envOverrides, tomlPath, onSaved }: SkillsConfigFormProps) {
+  const [path, setPath] = useState(String(values.path ?? ""));
+  const [persist, setPersist] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isLocked = (field: string) => envOverrides.includes(field);
+  const isDirty = path !== String(values.path ?? "");
+
+  const revert = () => {
+    setPath(String(values.path ?? ""));
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const url = persist ? "/api/config/skills?persist=true" : "/api/config/skills";
+      await apiPatch(url, { path });
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Skills</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-xs text-muted-foreground">
+          Directory for Open Agent Skills (each skill in a <code className="font-mono">NAME/SKILL.md</code>{" "}
+          folder). Changes apply immediately to the API; the autonomous watch process reloads skills from disk each
+          cycle.
+        </p>
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Skills directory</Label>
+            {isLocked("path") && <EnvLock field="path" prefix="SQUIRE_SKILLS_" />}
+          </div>
+          <Input
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            disabled={isLocked("path")}
+            className="font-mono text-xs"
+          />
+        </div>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <div className="flex items-center justify-between pt-2 border-t">
+          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={persist}
+              onChange={(e) => setPersist(e.target.checked)}
+              disabled={!tomlPath}
+              className="rounded"
+            />
+            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+          </label>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
+              <RotateCcw className="h-3.5 w-3.5 mr-1" />
+              Revert
+            </Button>
+            <Button size="sm" onClick={handleSave} disabled={!isDirty || saving}>
+              {saving ? (
+                <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+              ) : (
+                <Save className="h-3.5 w-3.5 mr-1" />
+              )}
+              Save
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/components/config/watch-config-form.tsx
+++ b/web/src/components/config/watch-config-form.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react";
 import { Lock, Loader2, RotateCcw, Save } from "lucide-react";
-import { apiPatch } from "@/lib/api";
+import type { WatchStatus } from "@/lib/types";
+import { apiGet, apiPatch, apiPut } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -44,6 +45,11 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
   const [checkinPrompt, setCheckinPrompt] = useState(String(values.checkin_prompt ?? ""));
   const [notifyOnAction, setNotifyOnAction] = useState(Boolean(values.notify_on_action ?? true));
   const [notifyOnBlocked, setNotifyOnBlocked] = useState(Boolean(values.notify_on_blocked ?? true));
+  const [maxToolCallsPerCycle, setMaxToolCallsPerCycle] = useState(
+    Number(values.max_tool_calls_per_cycle ?? 15)
+  );
+  const [cyclesPerSession, setCyclesPerSession] = useState(Number(values.cycles_per_session ?? 12));
+  const [maxContextEvents, setMaxContextEvents] = useState(Number(values.max_context_events ?? 40));
   const [persist, setPersist] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -55,7 +61,10 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
     cycleTimeout !== Number(values.cycle_timeout_seconds ?? 300) ||
     checkinPrompt !== String(values.checkin_prompt ?? "") ||
     notifyOnAction !== Boolean(values.notify_on_action ?? true) ||
-    notifyOnBlocked !== Boolean(values.notify_on_blocked ?? true);
+    notifyOnBlocked !== Boolean(values.notify_on_blocked ?? true) ||
+    maxToolCallsPerCycle !== Number(values.max_tool_calls_per_cycle ?? 15) ||
+    cyclesPerSession !== Number(values.cycles_per_session ?? 12) ||
+    maxContextEvents !== Number(values.max_context_events ?? 40);
 
   const revert = () => {
     setIntervalMinutes(Number(values.interval_minutes ?? 5));
@@ -63,6 +72,9 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
     setCheckinPrompt(String(values.checkin_prompt ?? ""));
     setNotifyOnAction(Boolean(values.notify_on_action ?? true));
     setNotifyOnBlocked(Boolean(values.notify_on_blocked ?? true));
+    setMaxToolCallsPerCycle(Number(values.max_tool_calls_per_cycle ?? 15));
+    setCyclesPerSession(Number(values.cycles_per_session ?? 12));
+    setMaxContextEvents(Number(values.max_context_events ?? 40));
     setError(null);
   };
 
@@ -76,9 +88,28 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
       if (checkinPrompt !== String(values.checkin_prompt ?? "")) changed.checkin_prompt = checkinPrompt;
       if (notifyOnAction !== Boolean(values.notify_on_action ?? true)) changed.notify_on_action = notifyOnAction;
       if (notifyOnBlocked !== Boolean(values.notify_on_blocked ?? true)) changed.notify_on_blocked = notifyOnBlocked;
+      if (maxToolCallsPerCycle !== Number(values.max_tool_calls_per_cycle ?? 15)) {
+        changed.max_tool_calls_per_cycle = maxToolCallsPerCycle;
+      }
+      if (cyclesPerSession !== Number(values.cycles_per_session ?? 12)) {
+        changed.cycles_per_session = cyclesPerSession;
+      }
+      if (maxContextEvents !== Number(values.max_context_events ?? 40)) {
+        changed.max_context_events = maxContextEvents;
+      }
 
       const url = persist ? "/api/config/watch?persist=true" : "/api/config/watch";
       await apiPatch(url, changed);
+
+      try {
+        const status = await apiGet<WatchStatus>("/api/watch/status");
+        if (status.status === "running" && Object.keys(changed).length > 0) {
+          await apiPut("/api/watch/config", changed);
+        }
+      } catch {
+        /* watch API unavailable — server-side config still updated */
+      }
+
       onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
@@ -93,6 +124,11 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
         <CardTitle className="text-base">Watch</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
+        <p className="text-xs text-muted-foreground">
+          These settings apply to the web API immediately. If autonomous watch mode is running, compatible fields are
+          also pushed to the watch process so they take effect on the next poll (typically within a few seconds).
+          Risk tolerance for watch is controlled under Guardrails (watch tolerance); restart watch after changing it.
+        </p>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>Interval (minutes)</Label>
@@ -155,6 +191,50 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
             checked={notifyOnBlocked}
             onCheckedChange={setNotifyOnBlocked}
             disabled={isLocked("notify_on_blocked")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Max tool calls per cycle</Label>
+            {isLocked("max_tool_calls_per_cycle") && (
+              <EnvLock field="max_tool_calls_per_cycle" prefix="SQUIRE_WATCH_" />
+            )}
+          </div>
+          <Input
+            type="number"
+            min={1}
+            value={maxToolCallsPerCycle}
+            onChange={(e) => setMaxToolCallsPerCycle(parseInt(e.target.value) || 1)}
+            disabled={isLocked("max_tool_calls_per_cycle")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Cycles per session</Label>
+            {isLocked("cycles_per_session") && <EnvLock field="cycles_per_session" prefix="SQUIRE_WATCH_" />}
+          </div>
+          <Input
+            type="number"
+            min={1}
+            value={cyclesPerSession}
+            onChange={(e) => setCyclesPerSession(parseInt(e.target.value) || 1)}
+            disabled={isLocked("cycles_per_session")}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Max context events</Label>
+            {isLocked("max_context_events") && <EnvLock field="max_context_events" prefix="SQUIRE_WATCH_" />}
+          </div>
+          <Input
+            type="number"
+            min={10}
+            value={maxContextEvents}
+            onChange={(e) => setMaxContextEvents(parseInt(e.target.value) || 10)}
+            disabled={isLocked("max_context_events")}
           />
         </div>
 

--- a/web/src/components/notifications/channels-tab.tsx
+++ b/web/src/components/notifications/channels-tab.tsx
@@ -174,7 +174,11 @@ export function ChannelsTab() {
       if (enabled !== origEnabled) changed.enabled = enabled;
 
       if (JSON.stringify(webhooks) !== JSON.stringify(origWebhooks)) {
-        changed.webhooks = webhooks.map(({ isNew: _, ...wh }) => wh);
+        changed.webhooks = webhooks.map((wh) => {
+          const { isNew, ...rest } = wh;
+          void isNew;
+          return rest;
+        });
       }
 
       if (JSON.stringify(email) !== JSON.stringify(origEmail)) {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -151,19 +151,27 @@ export interface WatchCycle {
 // Watch config from API
 export interface WatchConfigResponse {
   interval_minutes: number;
+  max_tool_calls_per_cycle: number;
   cycle_timeout_seconds: number;
   checkin_prompt: string;
   notify_on_action: boolean;
   notify_on_blocked: boolean;
   cycles_per_session: number;
+  max_context_events: number;
   risk_tolerance: number | null;
 }
 
 // Watch config update payload
 export interface WatchConfigUpdate {
   interval_minutes?: number;
-  risk_tolerance?: number;
+  max_tool_calls_per_cycle?: number;
+  cycle_timeout_seconds?: number;
   checkin_prompt?: string;
+  notify_on_action?: boolean;
+  notify_on_blocked?: boolean;
+  cycles_per_session?: number;
+  max_context_events?: number;
+  risk_tolerance?: number;
 }
 
 // --- Tools ---
@@ -215,6 +223,7 @@ export interface ConfigDetailResponse {
   notifications: ConfigSectionMeta;
   guardrails: ConfigSectionMeta;
   watch: ConfigSectionMeta;
+  skills: ConfigSectionMeta;
   hosts: Record<string, unknown>[];
   toml_path: string | null;
 }


### PR DESCRIPTION
## Problem

Saving notification settings from the API could replace the global notifier with a webhook-only implementation, dropping email delivery. Watch live configuration (`update_config`) only applied a subset of fields, so the watch drawer’s risk tolerance and other settings never reached the running process. The Configuration page exposed only part of Squire’s settings (no skills path, no notifications tab, incomplete guardrails/watch/app/LLM fields), and changing watch settings on the Config page did not update a running `squire watch` process.

## Context

Homelab operators expect the web UI to reflect and adjust effective configuration where safe, while autonomous watch remains a separate process fed by queued DB commands. Env vars and TOML still override file-based values; database path and snapshot interval remain lifecycle-bound.

## Solution

- Introduce `build_notification_router()` and use it from app lifespan and `PATCH /api/config/notifications`, closing the old notifier before swap; merge email PATCH payloads (including UI `tls` → `use_tls` and redacted password preservation).
- Extend `_poll_commands` to apply all live watch fields and to update `risk_evaluator.rule_gate.threshold`, session state, and the session template used on rotation; thread `session_ref` / `session_state` / `risk_evaluator` through the watch loop and interruptible sleep.
- Align `WatchConfigUpdate` / `WatchConfigResponse` with the watch API; compute numeric `risk_tolerance` for `GET /api/watch/config` via `RuleGate`.
- Add `skills` to `GET/PATCH /api/config` with `deps.skills_config` and `SkillService` reload; broaden `*Update` schemas; persist helper for nested TOML values.
- Frontend: new Notifications and Skills tabs, database guidance copy, expanded App/LLM/Guardrails/Watch forms; after saving watch settings, `PUT /api/watch/config` when watch status is `running`.

## Testing

### Unit tests

- `tests/test_config_api.py` — skills PATCH, email password redaction merge, existing PATCH/GET/persist coverage.
- `tests/test_watch_loop.py` — `update_config` applies interval, timeout, notify flag, and `risk_tolerance` with fake session + evaluator.

### Integration tests

- None beyond existing API/watch test modules; `make ci` runs the full suite.

### Test results

- `make ci`: **392** pytest tests passed; `ruff check` / `ruff format --check` passed; `web` ESLint and `next build` passed (run before PR).

## Reviewer Validation

1. `git fetch && git checkout feat/web-config-ui && make ci` — expect all green.
2. Run `squire web`, open **Configuration**: confirm **Notifications**, **Skills**, expanded **Watch** / **Guardrails** / **App** / **LLM** fields and database notice.
3. With watch running (`squire watch`), change interval or check-in prompt on the Config **Watch** tab and save; confirm the running process picks up changes within a poll interval (or inspect DB `watch_commands` / logs).

## TODOs / Follow-Ups

- Optional: top-of-page summary of all `env_overrides` across sections for clearer 409 explanations.
- Database `path` / `snapshot_interval_minutes` still require process restart to fully take effect; only documented in UI, not PATCHable.
- LiteLLM provider API keys remain environment-based; no secrets editor in this PR.


Made with [Cursor](https://cursor.com)