### PR TITLE
fix: guardrails bug fixes, risk tolerance move, config help, and Makefile polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Guardrails:** `run_command` and `read_config` tools now use the live guardrails config instead of a stale module-level cache — runtime changes via the config UI take effect immediately
+- **Guardrails:** Chat sessions now use the `deps.guardrails` singleton instead of loading a fresh `GuardrailsConfig()` from disk — non-persisted PATCH changes are respected by new sessions
+- **Guardrails:** Per-agent tolerances (`monitor_tolerance`, etc.) are now wired into the risk gate callback via `default_threshold` — previously declared but never consumed
+- **Guardrails:** Default `commands_allow` now includes `ls`, `stat`, `file`, `du`, `find`, `grep`, `hostname`, `date`, `whoami`, `id`, `uname`, `mount`, `lsblk`, `top`, `ps`, `which`, `netstat`, `docker`, `systemctl`, `journalctl`, `lsof`, `wc` — fixes `run_command` blocking common read-only commands even at `full-trust` tolerance
 - **Web config:** `PATCH /api/config/notifications` now rebuilds `NotificationRouter` (webhook + email) instead of replacing it with a webhook-only dispatcher, so email delivery keeps working after saving notification settings from the UI
 - **Watch live config:** `PUT /api/watch/config` now applies all documented watch fields via the `update_config` queue, including numeric risk threshold (updates the running evaluator and session state)
 - **Watch API:** `GET /api/watch/config` returns a numeric `risk_tolerance` consistent with effective guardrails/app policy (fixes response validation when watch tolerance was set)
+- **Makefile:** `make clean-web` removes `web/out` under `REPO_ROOT` (same as other web targets)
+
+### Changed
+
+- **BREAKING:** `risk_tolerance` and `risk_strict` moved from top-level app config to `[guardrails]` section — env vars change from `SQUIRE_RISK_TOLERANCE` / `SQUIRE_RISK_STRICT` to `SQUIRE_GUARDRAILS_RISK_TOLERANCE` / `SQUIRE_GUARDRAILS_RISK_STRICT`; TOML keys move from top-level to `[guardrails]`
 
 ### Added
 
+- **Web config:** Inline help on the Configuration page — section intros, per-field hints, env-override banner, and a page blurb explaining save vs disk vs env vs watch/restart behavior
 - **Web config:** `GET/PATCH /api/config/skills` for the skills directory; skills section on the Configuration page; notifications channels editor embedded as a Configuration tab
 - **Web config:** Extended PATCH schemas and forms for app name/user id, LLM `api_base`, remaining watch and guardrails fields; watch form pushes changes to a running watch process when status is `running`
 - **Web config:** Database tab explains that DB path, snapshot interval, and LLM provider secrets require env/TOML plus process restart
+- **Makefile:** `REPO_ROOT`-anchored recipes (`make web`, `web-build`, `ci` targets, etc.) so build and server use this checkout even when Make's working directory differs
+- **Web:** `make web` sets `SQUIRE_WEB_STATIC_DIR` to `<repo>/web/out` so the API always serves the bundle that was just built; `_find_static_dir()` falls back to cwd vs package root and picks the newer `index.html` if both exist
 
 ## [0.13.0] — 2026-04-11
 
@@ -191,7 +203,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `docker_image` — manage images (list, inspect, pull, remove)
   - `docker_cleanup` — prune resources and check disk usage (df, prune_containers, prune_images, prune_volumes, prune_all)
 - **Compound action risk evaluation** — risk gate now constructs `tool:action` names for per-action risk levels, enabling fine-grained guardrails configuration (e.g., `tools_deny = ["docker_cleanup:prune_volumes"]`). Also adds `force` flag risk escalation (+1 when `force=True`).
-
 - **Watch mode web integration** — manage and observe watch mode through the web UI at `/watch`.
   - Start/stop watch mode from the browser, with PID-based liveness detection
   - Live streaming of watch cycle activity via WebSocket (tokens, tool calls, tool results, cycle boundaries)
@@ -201,7 +212,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Three new SQLite tables (`watch_events`, `watch_commands`, `watch_approvals`) for process-independent IPC
   - Watch process emits granular events and polls for commands between cycles (responsive to stop/config changes)
   - Supervisor connection tracking (`supervisor_count` / `supervisor_connected` in `watch_state`)
-
 - **Skills** (replaces Runbooks) — file-based skill definitions aligned with the [Open Agent Skills spec](https://agentskills.io/specification). Each skill is a `SKILL.md` file with YAML frontmatter + freeform Markdown instructions, stored in a configurable directory (default `~/.local/share/squire/skills`). No database required — skills are version-controllable and editable with any text editor.
   - **SkillService** (`src/squire/skills/`) — file-based CRUD: `list_skills`, `get_skill`, `save_skill`, `delete_skill`. Parses YAML frontmatter with `yaml.safe_load()` and renders back to spec-compliant SKILL.md format (`name`/`description` at top level, Squire-specific fields under `metadata`). Names are validated per the spec (lowercase alphanumeric + hyphens, max 64 chars).
   - **SkillsConfig** (`src/squire/config/skills.py`) — configurable via `[skills]` in `squire.toml` or `SQUIRE_SKILLS_` env vars. Default path: `~/.local/share/squire/skills`.
@@ -220,26 +230,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **Persona customization** — removed `house`, `squire_name`, and `squire_profile` config fields and the three built-in personality profiles (Rook, Cedric, Wynn). Squire now uses a single fixed identity across all interfaces. The `profiles.py` module has been deleted. System prompts, session state, TUI, config files, and documentation have been updated accordingly.
-- **`agent-risk-engine` v0.2.0: tool-centric models and state layer** — `ToolDef`, `ToolRegistry`, `ToolAnalyzer`, `SystemState`, `StateMonitor`, `NullStateMonitor`, and `RiskScore.alternative` removed from public API.
+- `**agent-risk-engine` v0.2.0: tool-centric models and state layer** — `ToolDef`, `ToolRegistry`, `ToolAnalyzer`, `SystemState`, `StateMonitor`, `NullStateMonitor`, and `RiskScore.alternative` removed from public API.
 
 ### Changed
 
-- **`agent-risk-engine` migrated to PyPI** — replaced local path dependency (`packages/agent-risk-engine/`) with standard PyPI dependency (`agent-risk-engine>=0.2.0`). The `packages/` directory is removed.
-
+- `**agent-risk-engine` migrated to PyPI** — replaced local path dependency (`packages/agent-risk-engine/`) with standard PyPI dependency (`agent-risk-engine>=0.2.0`). The `packages/` directory is removed.
 - **CI/CD improvements** — split CI into parallel jobs (lint, test, frontend, docker) with dependency caching. Fixed broken Dockerfile (missing `packages/` copy for `agent-risk-engine`). Added `.dockerignore`. Added Dependabot for Python, npm, and GitHub Actions. `make ci` now includes frontend lint and build checks.
 - **Release workflow** — pushing a `v*` tag now builds and publishes the Docker image to `ghcr.io/willdah/squire` and creates a GitHub Release with changelog notes.
-
-- **`agent-risk-engine` v0.2.0: action-centric protocol** — breaking refactor repositioning the package as an open protocol with Python reference implementation.
-  - **`Action` envelope** — new `Action(kind, name, parameters, risk, metadata)` dataclass replaces the `(tool_name, args, tool_risk)` tuple. `kind` enables per-category routing; `metadata` carries framework-provided context.
+- `**agent-risk-engine` v0.2.0: action-centric protocol** — breaking refactor repositioning the package as an open protocol with Python reference implementation.
+  - `**Action` envelope** — new `Action(kind, name, parameters, risk, metadata)` dataclass replaces the `(tool_name, args, tool_risk)` tuple. `kind` enables per-category routing; `metadata` carries framework-provided context.
   - **3-layer stateless pipeline** — `RuleGate` → `ActionAnalyzer` → `ActionGate`. The `StateMonitor` layer is removed; the engine no longer tracks call history internally. Temporal context (loop detection, session state) is the framework's responsibility and flows in via `Action.metadata`.
   - **Kind-aware routing** — `RuleGate` gains `kind_thresholds` for per-kind threshold overrides. `allowed_tools`/`approve_tools`/`denied_tools` renamed to `allowed`/`approve`/`denied`.
   - **Kind-scoped patterns** — `RiskPattern.kinds` enables patterns that only fire for specific action categories.
-  - **`CallTracker` standalone** — extracted from pipeline to standalone utility. `check()` returns `dict` instead of `SystemState`. New configurable `repetition_ratio` parameter.
+  - `**CallTracker` standalone** — extracted from pipeline to standalone utility. `check()` returns `dict` instead of `SystemState`. New configurable `repetition_ratio` parameter.
   - **Renames** — `ToolDef` → `ActionDef`, `ToolRegistry` → `ActionRegistry`, `ToolAnalyzer` → `ActionAnalyzer`.
-  - **`PROTOCOL.md`** — new language-agnostic protocol specification defining risk levels, gate results, action envelope, and evaluation semantics.
-
+  - `**PROTOCOL.md`** — new language-agnostic protocol specification defining risk levels, gate results, action envelope, and evaluation semantics.
 - **README restructure** — rewrote README with new Interfaces section (Web UI, TUI, CLI), Docker deployment section, Notifications config section, badges, expanded Quickstart and Development sections. Removed stale Personalization TOC entry. Trimmed config duplication in favor of linking to `docs/configuration.md`. Updated `docs/cli.md` with `squire web` command, fixed watch config table to reflect `[guardrails.watch]` restructure, added `Ctrl+X` keyboard shortcut.
-
 - **Runbooks replaced by Skills** — the database-backed runbook system (ordered steps in `runbooks` + `runbook_steps` tables) has been replaced by file-based skills. This simplifies the data model (no numbered steps, no per-step tracking), makes skills version-controllable, and aligns with the Open Agent Skills spec. The `[STEP N COMPLETE]` / `[RUNBOOK COMPLETE]` markers are replaced by a single `[SKILL COMPLETE]` marker. Existing runbook tables in the database are left in place but no longer queried. The WebSocket `?runbook=` query param is now `?skill=`. CLI commands changed from `squire runbooks` to `squire skills`. Added `pyyaml>=6.0` as an explicit dependency (was already a transitive dep).
 
 ### Fixed
@@ -261,7 +267,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Consolidated guardrails config** — merged `[security]`, `[risk]`, and watch-mode risk fields into a single `[guardrails]` section. All safety policy (tool overrides, command/path guards, per-agent tolerances, watch-mode risk) now lives in one place. The old `[security]` and `[risk]` TOML sections are removed. Watch-mode risk overrides moved to `[guardrails.watch]` sub-table; `[watch]` now contains only operational settings (interval, timeout, prompt, notifications). Renamed fields: `command_allowlist` → `commands_allow`, `command_denylist` → `commands_block`, `config_allowlist` → `config_paths`, `allow`/`approve`/`deny` → `tools_allow`/`tools_require_approval`/`tools_deny`. Per-agent tolerances moved from top-level to `[guardrails]` with shorter names (e.g., `monitor_risk_tolerance` → `monitor_tolerance`). Env prefix changed from `SQUIRE_SECURITY_`/`SQUIRE_RISK_` to `SQUIRE_GUARDRAILS_`. This is a breaking change — existing `squire.toml` files need to be updated.
-
 - **Sticky chat top bar with icon button** — the chat header (title, connection dot, new chat) now uses `shrink-0 bg-card` so it stays pinned at the top of the flex column during long conversations. Replaced the "New Chat" text link with a `SquarePen` icon button for a cleaner look.
 - **Web UI restructure: chat-first identity** — Squire is the brain, not the eyes. Removed dashboard and alert rule CRUD in favor of a chat-first experience that leans on dedicated homelab tools (Beszel, Grafana, Portainer) for metrics and container management.
   - Removed Dashboard page and all dashboard components (stat cards, container grid, trend chart) — for live metrics, use Beszel or Grafana.
@@ -325,7 +330,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Configuration viewer with tabbed sections (app, LLM, database, security, watch, notifications, risk, hosts).
   - Dark/light theme toggle with system preference detection.
   - Mobile-responsive layout with collapsible sidebar navigation.
-- **`squire web` CLI command** — starts the combined API + frontend server (`--port`, `--host`, `--reload` flags). Default port 8420.
+- `**squire web` CLI command** — starts the combined API + frontend server (`--port`, `--host`, `--reload` flags). Default port 8420.
 - `fastapi` and `uvicorn[standard]` added to project dependencies.
 - Background snapshot collection in the web server — periodic system status updates shared across all API consumers.
 
@@ -338,7 +343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`safe_tool` decorator** — defense-in-depth wrapper applied to all ADK tool functions. Catches any uncaught exception and returns it as a string so the LLM can reason about failures instead of crashing. Preserves function metadata for ADK schema discovery.
+- `**safe_tool` decorator** — defense-in-depth wrapper applied to all ADK tool functions. Catches any uncaught exception and returns it as a string so the LLM can reason about failures instead of crashing. Preserves function metadata for ADK schema discovery.
 - **Watch mode error context injection** — when a watch cycle fails, the next cycle's prompt includes the error so the agent can adapt (e.g. skip unavailable tools).
 
 ## [0.2.0] - 2026-03-15
@@ -365,7 +370,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`risk_tolerance` config uses `RiskTolerance` enum** — replaced untyped `Any` field with a `StrEnum` (`read-only`, `cautious`, `standard`, `full-trust`). Integer and digit-string inputs are coerced via a `BeforeValidator`, so existing TOML and env var values continue to work.
+- `**risk_tolerance` config uses `RiskTolerance` enum** — replaced untyped `Any` field with a `StrEnum` (`read-only`, `cautious`, `standard`, `full-trust`). Integer and digit-string inputs are coerced via a `BeforeValidator`, so existing TOML and env var values continue to work.
 - **Risk gate callback refactored to factory pattern** — `risk_gate_callback` replaced by `create_risk_gate()` which accepts `ApprovalProvider` via closure instead of importing a TUI singleton. Core agent logic no longer imports from `tui/`.
 - **Approval bridge singleton removed** — `ApprovalBridge` is now instantiated in `main.py` and injected into the risk gate factory and TUI via constructor parameters.
 - **Background snapshots decoupled from TUI** — `_background_snapshots()` accepts an `on_snapshot` callback instead of a TUI reference.
@@ -417,7 +422,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Tools now resolve their backend via a central `BackendRegistry` instead of module-level `LocalBackend()` singletons. This is a transparent internal change — tool signatures gain an optional `host` parameter but behavior is unchanged when omitted.
-- Renamed `PathsConfig` → `SecurityConfig` and `[paths]` → `[security]` TOML section — better reflects its role as tool security allow/deny lists. Env prefix changed from `SQUIRE_PATHS_` to `SQUIRE_SECURITY_`.
+- Renamed `PathsConfig` → `SecurityConfig` and `[paths]` → `[security]` TOML section — better reflects its role as tool security allow/deny lists. Env prefix changed from `SQUIRE_PATHS`_ to `SQUIRE_SECURITY_`.
 - Improved system prompt for conversational intelligence — Squire now matches its response to user intent (greetings get greetings, not system dumps). Reordered prompt sections so behavioral guidance comes before system data. Personality profiles now include conversational hints for greetings.
 - Tool calls and results no longer clutter the main chat — they appear only in the activity log.
 
@@ -430,3 +435,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Streaming message prefix — `[bold]Squire[/bold]:` no longer appears as literal text during streaming; markup prefix and user content are tracked separately.
 - Test isolation — config tests no longer pick up local `squire.toml` file.
 - Cross-platform CI — `test_system_info_basic` now patches `platform` so it passes on Linux runners.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# [CLAUDE.md](http://CLAUDE.md)
 
 ## Project overview
 
@@ -7,6 +7,7 @@ Squire is an AI-powered homelab monitoring and management agent. It uses Google 
 ## Tech stack
 
 **Backend (Python 3.12+):**
+
 - Google ADK — agent orchestration
 - FastAPI + Uvicorn — web API
 - Typer — CLI
@@ -18,6 +19,7 @@ Squire is an AI-powered homelab monitoring and management agent. It uses Google 
 - agent-risk-engine — risk evaluation library (PyPI package, zero external deps)
 
 **Frontend (`web/`, Next.js 16):**
+
 - React 19 with App Router
 - shadcn/ui v4 + Tailwind CSS v4
 - Recharts — trend charts
@@ -25,6 +27,7 @@ Squire is an AI-powered homelab monitoring and management agent. It uses Google 
 - WebSocket — real-time chat
 
 **Tooling:**
+
 - uv — package manager
 - Hatchling — build backend
 - ruff — linter and formatter
@@ -80,10 +83,9 @@ make format        # Auto-format Python
 make test          # pytest
 make ci            # Lint + format check + test (mirrors CI)
 
-make web-dev       # Next.js dev server
-make web-build     # Next.js production build
-
-make web           # Web interface (FastAPI, --reload)
+make web-dev       # Next.js dev server (set NEXT_PUBLIC_API_URL for API on another port)
+make web-build     # Next.js static export → web/out (also run by make web)
+make web           # web-build + FastAPI with static UI (--reload)
 make watch         # Autonomous watch mode
 
 make docker-build  # Build Docker image
@@ -94,8 +96,10 @@ Or invoke directly:
 
 ```bash
 uv run pytest tests/test_tools/test_docker.py   # Single test file
-uv run squire web --port 9000                    # Custom port
+uv run squire web --port 9000                    # Custom port (run from repo root, or set SQUIRE_WEB_STATIC_DIR to .../web/out)
 ```
+
+`make web` sets `SQUIRE_WEB_STATIC_DIR` to this repo’s `web/out` so FastAPI never serves an older `web/out` from another path. If the UI still looks wrong after a rebuild, hard-refresh the browser (cache) or run `make clean-web && make web`.
 
 ## Code conventions
 
@@ -114,6 +118,7 @@ uv run squire web --port 9000                    # Custom port
 ## CI
 
 GitHub Actions runs on every push/PR to `main`:
+
 1. `ruff check` (lint)
 2. `ruff format --check` (format verification)
 3. `pytest` (tests)

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,41 @@
 .DEFAULT_GOAL := help
 
+# Absolute path to the repo root (Makefile location). Keeps web build/serve aligned
+# even when Make is invoked with -C or from an unexpected working directory.
+REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 # ---------------------------------------------------------------------------
 # Python
 # ---------------------------------------------------------------------------
 
 .PHONY: install
 install: ## Install Python and frontend dependencies
-	uv sync --dev
-	cd web && npm install
+	cd $(REPO_ROOT) && uv sync --dev
+	cd $(REPO_ROOT)/web && npm install
 
 .PHONY: lint
 lint: ## Run ruff linter
-	uv run ruff check src/ tests/
+	cd $(REPO_ROOT) && uv run ruff check src/ tests/
 
 .PHONY: format
 format: ## Auto-format Python code with ruff
-	uv run ruff format src/ tests/
+	cd $(REPO_ROOT) && uv run ruff format src/ tests/
 
 .PHONY: format-check
 format-check: ## Check Python formatting (no changes)
-	uv run ruff format --check src/ tests/
+	cd $(REPO_ROOT) && uv run ruff format --check src/ tests/
 
 .PHONY: typecheck
 typecheck: ## Run mypy type checking
-	uv run mypy src/
+	cd $(REPO_ROOT) && uv run mypy src/
 
 .PHONY: test
 test: ## Run pytest suite
-	uv run pytest
+	cd $(REPO_ROOT) && uv run pytest
 
 .PHONY: test-v
 test-v: ## Run pytest with verbose output
-	uv run pytest -v
+	cd $(REPO_ROOT) && uv run pytest -v
 
 .PHONY: ci
 ci: lint format-check test web-lint web-build ## Run the full CI pipeline locally
@@ -42,31 +46,31 @@ ci: lint format-check test web-lint web-build ## Run the full CI pipeline locall
 
 .PHONY: web-install
 web-install: ## Install frontend dependencies
-	cd web && npm install
+	cd $(REPO_ROOT)/web && npm install
 
 .PHONY: web-dev
 web-dev: ## Start Next.js dev server
-	cd web && npm run dev
+	cd $(REPO_ROOT)/web && npm run dev
 
 .PHONY: web-build
-web-build: ## Build Next.js for production
-	cd web && npm run build
+web-build: ## Build Next.js static export into web/out (required for bundled UI)
+	cd $(REPO_ROOT)/web && npm run build
 
 .PHONY: web-lint
 web-lint: ## Lint frontend code
-	cd web && npm run lint
+	cd $(REPO_ROOT)/web && npm run lint
 
 # ---------------------------------------------------------------------------
 # Run
 # ---------------------------------------------------------------------------
 
 .PHONY: web
-web: ## Start the web interface (FastAPI + static frontend)
-	uv run squire web --reload
+web: web-build ## Build Next.js export then start FastAPI + static UI
+	cd $(REPO_ROOT) && SQUIRE_WEB_STATIC_DIR=$(REPO_ROOT)/web/out uv run squire web --reload
 
 .PHONY: watch
 watch: ## Start autonomous watch mode
-	uv run squire watch
+	cd $(REPO_ROOT) && uv run squire watch
 
 # ---------------------------------------------------------------------------
 # Docker
@@ -74,7 +78,7 @@ watch: ## Start autonomous watch mode
 
 .PHONY: docker-build
 docker-build: ## Build Docker image
-	docker build -f docker/Dockerfile -t squire .
+	cd $(REPO_ROOT) && docker build -f docker/Dockerfile -t squire .
 
 .PHONY: docker-run
 docker-run: ## Run Docker container (web UI on port 8420)
@@ -86,15 +90,15 @@ docker-run: ## Run Docker container (web UI on port 8420)
 
 .PHONY: clean
 clean: ## Remove Python caches and build artifacts
-	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
-	find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
-	find . -type d -name .mypy_cache -exec rm -rf {} + 2>/dev/null || true
-	find . -type d -name .ruff_cache -exec rm -rf {} + 2>/dev/null || true
-	rm -rf dist/ build/ *.egg-info src/*.egg-info
+	cd $(REPO_ROOT) && find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	cd $(REPO_ROOT) && find . -type d -name .pytest_cache -exec rm -rf {} + 2>/dev/null || true
+	cd $(REPO_ROOT) && find . -type d -name .mypy_cache -exec rm -rf {} + 2>/dev/null || true
+	cd $(REPO_ROOT) && find . -type d -name .ruff_cache -exec rm -rf {} + 2>/dev/null || true
+	rm -rf $(REPO_ROOT)/dist/ $(REPO_ROOT)/build/ $(REPO_ROOT)/*.egg-info $(REPO_ROOT)/src/*.egg-info
 
 .PHONY: clean-web
-clean-web: ## Remove frontend build artifacts and node_modules
-	rm -rf web/.next web/node_modules
+clean-web: ## Remove frontend build output, cache, and node_modules
+	rm -rf $(REPO_ROOT)/web/.next $(REPO_ROOT)/web/out $(REPO_ROOT)/web/node_modules
 
 .PHONY: clean-all
 clean-all: clean clean-web ## Remove all generated files

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,8 @@ graph TD
     SSHBackend --> RemoteHosts
 ```
 
+
+
 ## Agent Architecture
 
 Squire operates in one of two modes, controlled by `multi_agent` in `squire.toml`.
@@ -56,12 +58,14 @@ In both modes, the user always sees the single "Squire" persona — sub-agent na
 
 ### Sub-agents
 
-| Agent | Domain | Tools | Characteristic Risk |
-|---|---|---|---|
-| Monitor | System observation | `system_info`, `network_info`, `docker_ps`, `journalctl`, `read_config` | Read-only, risk 1 |
-| Container | Docker lifecycle | `docker_logs`, `docker_compose`, `docker_container`, `docker_image`, `docker_cleanup` | Cautious, risk 1–4 |
-| Admin | System administration | `systemctl`, `run_command` | Elevated, risk 1–4 |
-| Notifier | Alert management | `send_notification`, `list_alert_rules`, `create_alert_rule`, `update_alert_rule`, `delete_alert_rule` | Mostly read-only, risk 1–2 |
+
+| Agent     | Domain                | Tools                                                                                                  | Characteristic Risk        |
+| --------- | --------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------- |
+| Monitor   | System observation    | `system_info`, `network_info`, `docker_ps`, `journalctl`, `read_config`                                | Read-only, risk 1          |
+| Container | Docker lifecycle      | `docker_logs`, `docker_compose`, `docker_container`, `docker_image`, `docker_cleanup`                  | Cautious, risk 1–4         |
+| Admin     | System administration | `systemctl`, `run_command`                                                                             | Elevated, risk 1–4         |
+| Notifier  | Alert management      | `send_notification`, `list_alert_rules`, `create_alert_rule`, `update_alert_rule`, `delete_alert_rule` | Mostly read-only, risk 1–2 |
+
 
 ### Multi-agent routing
 
@@ -81,6 +85,8 @@ flowchart TD
     Root -->|"service management / shell commands"| Admin
     Root -->|"alerts / notifications"| Notifier
 ```
+
+
 
 ## Request Flow
 
@@ -113,6 +119,8 @@ sequenceDiagram
     A-->>I: Streamed response
     I-->>U: Display response
 ```
+
+
 
 ## Risk Evaluation Pipeline
 
@@ -154,18 +162,22 @@ flowchart TD
     PROMPT -->|Declined| DENY_U
 ```
 
+
+
 ### Homelab risk patterns
 
 The `PatternAnalyzer` inspects command arguments for patterns that escalate risk beyond the static level:
 
-| Pattern | Escalates to | Reason |
-|---|---|---|
-| `--privileged` | 5 | Privileged container mode |
-| `iptables`, `ufw`, `nftables` | 4 | Firewall rule modification |
-| `systemctl mask/disable` | 4 | Service disablement |
-| `/var/lib/docker/`, `/etc/docker/` | 4 | Docker data/config directories |
-| `ssh-keygen`, `authorized_keys` | 4 | SSH key modification |
-| `crontab -r/-e` | 3 | Crontab modification |
+
+| Pattern                            | Escalates to | Reason                         |
+| ---------------------------------- | ------------ | ------------------------------ |
+| `--privileged`                     | 5            | Privileged container mode      |
+| `iptables`, `ufw`, `nftables`      | 4            | Firewall rule modification     |
+| `systemctl mask/disable`           | 4            | Service disablement            |
+| `/var/lib/docker/`, `/etc/docker/` | 4            | Docker data/config directories |
+| `ssh-keygen`, `authorized_keys`    | 4            | SSH key modification           |
+| `crontab -r/-e`                    | 3            | Crontab modification           |
+
 
 ## Watch Mode Loop
 
@@ -195,39 +207,45 @@ flowchart TD
     SLEEP -->|SIGTERM / SIGINT| STOP
 ```
 
+
+
 Watch mode is started with `make watch` or `uv run squire watch`. The web UI's Watch page shows live stream events, cycle history, and current status. See [configuration.md](configuration.md) for `[watch]` and `[guardrails]` options.
 
 ## Tech Stack
 
-| Layer | Technology | Purpose |
-|---|---|---|
-| Agent Orchestration | Google ADK | Multi-agent routing, tool dispatch, conversation management |
-| LLM Abstraction | LiteLLM | Provider-agnostic model access (Ollama, Anthropic, OpenAI, Gemini, 50+) |
-| Risk Evaluation | agent-risk-engine | Pattern-based risk analysis, rule gating, tool blocking |
-| Web API | FastAPI + Uvicorn | REST endpoints, WebSocket streaming |
-| Web Frontend | Next.js + React + shadcn/ui | Browser-based chat, watch monitoring, configuration |
-| CLI | Typer | Command-line interface for scripting and quick tasks |
-| Database | aiosqlite (SQLite) | Session persistence, events, alert rules, watch state |
-| Remote Access | asyncssh | SSH-based multi-machine management |
-| Config | Pydantic Settings | Layered config (env vars > TOML > defaults) |
-| HTTP Client | httpx | Webhook notifications, health checks |
+
+| Layer               | Technology                  | Purpose                                                                 |
+| ------------------- | --------------------------- | ----------------------------------------------------------------------- |
+| Agent Orchestration | Google ADK                  | Multi-agent routing, tool dispatch, conversation management             |
+| LLM Abstraction     | LiteLLM                     | Provider-agnostic model access (Ollama, Anthropic, OpenAI, Gemini, 50+) |
+| Risk Evaluation     | agent-risk-engine           | Pattern-based risk analysis, rule gating, tool blocking                 |
+| Web API             | FastAPI + Uvicorn           | REST endpoints, WebSocket streaming                                     |
+| Web Frontend        | Next.js + React + shadcn/ui | Browser-based chat, watch monitoring, configuration                     |
+| CLI                 | Typer                       | Command-line interface for scripting and quick tasks                    |
+| Database            | aiosqlite (SQLite)          | Session persistence, events, alert rules, watch state                   |
+| Remote Access       | asyncssh                    | SSH-based multi-machine management                                      |
+| Config              | Pydantic Settings           | Layered config (env vars > TOML > defaults)                             |
+| HTTP Client         | httpx                       | Webhook notifications, health checks                                    |
+
 
 ## Database Schema
 
 All state is stored in a single SQLite file (default: `~/.local/share/squire/squire.db`). The schema is created idempotently on first connection.
 
-| Table | Purpose |
-|---|---|
-| `snapshots` | Time-series system snapshots (CPU, memory, uptime, raw JSON) |
-| `events` | Discrete events with category, tool name, and summary |
-| `conversations` | Chat messages keyed by session ID (role, content, tool calls) |
-| `sessions` | Session registry with created/last-active timestamps and preview |
-| `watch_state` | Key-value store for current watch mode status (cycle, PID, interval, etc.) |
-| `alert_rules` | Configured alert conditions with severity, cooldown, and last-fired timestamp |
-| `watch_events` | Fine-grained per-cycle events (cycle_start, tool_call, tool_result, token, cycle_end) |
-| `watch_commands` | Commands posted to the running watch loop (stop, update_config) |
-| `watch_approvals` | Approval requests from watch mode (pending / approved / denied) |
-| `managed_hosts` | Remote hosts registered via the Hosts page (address, SSH config, tags, services) |
+
+| Table             | Purpose                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------- |
+| `snapshots`       | Time-series system snapshots (CPU, memory, uptime, raw JSON)                          |
+| `events`          | Discrete events with category, tool name, and summary                                 |
+| `conversations`   | Chat messages keyed by session ID (role, content, tool calls)                         |
+| `sessions`        | Session registry with created/last-active timestamps and preview                      |
+| `watch_state`     | Key-value store for current watch mode status (cycle, PID, interval, etc.)            |
+| `alert_rules`     | Configured alert conditions with severity, cooldown, and last-fired timestamp         |
+| `watch_events`    | Fine-grained per-cycle events (cycle_start, tool_call, tool_result, token, cycle_end) |
+| `watch_commands`  | Commands posted to the running watch loop (stop, update_config)                       |
+| `watch_approvals` | Approval requests from watch mode (pending / approved / denied)                       |
+| `managed_hosts`   | Remote hosts registered via the Hosts page (address, SSH config, tags, services)      |
+
 
 ## Backend Registry
 
@@ -243,8 +261,8 @@ async def close() -> None
 
 Two implementations:
 
-- **`LocalBackend`** — wraps `asyncio.create_subprocess_exec`. Always present; registered as `"local"`.
-- **`SSHBackend`** — wraps `asyncssh`. Created lazily on first access for each configured remote host.
+- `**LocalBackend**` — wraps `asyncio.create_subprocess_exec`. Always present; registered as `"local"`.
+- `**SSHBackend**` — wraps `asyncssh`. Created lazily on first access for each configured remote host.
 
 `BackendRegistry.get("local")` always returns the `LocalBackend`. For remote hosts, the registry creates an `SSHBackend` on first use and caches it. Tools accept an optional `host` parameter (default `"local"`) which the registry resolves. Passing an unconfigured host name raises a `ValueError` before any tool logic runs.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,11 +6,11 @@ Squire is configured through a TOML file and environment variables.
 
 Settings are resolved in order (highest priority first):
 
-1. **Environment variables** (`SQUIRE_*`)
+1. **Environment variables** (`SQUIRE_`*)
 2. **TOML config file** -- first found from:
-   - `./squire.toml` (project directory)
-   - `~/.config/squire/squire.toml` (user config)
-   - `/etc/squire/squire.toml` (system-wide)
+  - `./squire.toml` (project directory)
+  - `~/.config/squire/squire.toml` (user config)
+  - `/etc/squire/squire.toml` (system-wide)
 3. **Built-in defaults**
 
 To get started, copy the example config:
@@ -25,17 +25,19 @@ cp squire.example.toml squire.toml
 
 ## Top-Level Settings
 
-These are set as top-level keys in `squire.toml` or via `SQUIRE_*` environment variables.
+These are set as top-level keys in `squire.toml` or via `SQUIRE_`* environment variables.
 
-| Key | Default | Env Var | Description |
-|---|---|---|---|
-| `app_name` | `"Squire"` | `SQUIRE_APP_NAME` | Application name for the ADK runner |
-| `user_id` | `"squire-user"` | `SQUIRE_USER_ID` | User ID for ADK session management |
-| `risk_tolerance` | `"cautious"` | `SQUIRE_RISK_TOLERANCE` | Global risk tolerance (see [Risk Tolerance](#risk-tolerance)) |
-| `risk_strict` | `false` | `SQUIRE_RISK_STRICT` | When `true`, tools above tolerance are denied instead of prompting |
-| `history_limit` | `50` | `SQUIRE_HISTORY_LIMIT` | Maximum messages in conversation context |
-| `max_tool_rounds` | `10` | `SQUIRE_MAX_TOOL_ROUNDS` | Maximum tool-call rounds per user message |
-| `multi_agent` | `false` | `SQUIRE_MULTI_AGENT` | Enable sub-agent decomposition (see [Multi-Agent Mode](#multi-agent-mode)) |
+
+| Key               | Default         | Env Var                  | Description                                                                |
+| ----------------- | --------------- | ------------------------ | -------------------------------------------------------------------------- |
+| `app_name`        | `"Squire"`      | `SQUIRE_APP_NAME`        | Application name for the ADK runner                                        |
+| `user_id`         | `"squire-user"` | `SQUIRE_USER_ID`         | User ID for ADK session management                                         |
+| `history_limit`   | `50`            | `SQUIRE_HISTORY_LIMIT`   | Maximum messages in conversation context                                   |
+| `max_tool_rounds` | `10`            | `SQUIRE_MAX_TOOL_ROUNDS` | Maximum tool-call rounds per user message                                  |
+| `multi_agent`     | `false`         | `SQUIRE_MULTI_AGENT`     | Enable sub-agent decomposition (see [Multi-Agent Mode](#multi-agent-mode)) |
+
+
+> **Note:** `risk_tolerance` and `risk_strict` have moved to `[guardrails]`. See [Guardrails](#guardrails----guardrails).
 
 ---
 
@@ -45,14 +47,17 @@ Risk tolerance controls which tools Squire can use automatically, which require 
 
 Every tool has a built-in risk level (1--5). The tolerance setting determines the cutoff:
 
-| Tolerance | Level | Auto-allows | Needs approval |
-|---|---|---|---|
-| `read-only` | 1 | System info, network info, container listing | Everything else |
-| `cautious` | 2 | + log viewing, config reads | Compose, systemctl, commands |
-| `standard` | 3 | + compose, systemctl | Arbitrary command execution |
-| `full-trust` | 5 | Everything | Nothing |
+
+| Tolerance    | Level | Auto-allows                                  | Needs approval               |
+| ------------ | ----- | -------------------------------------------- | ---------------------------- |
+| `read-only`  | 1     | System info, network info, container listing | Everything else              |
+| `cautious`   | 2     | + log viewing, config reads                  | Compose, systemctl, commands |
+| `standard`   | 3     | + compose, systemctl                         | Arbitrary command execution  |
+| `full-trust` | 5     | Everything                                   | Nothing                      |
+
 
 ```toml
+[guardrails]
 risk_tolerance = "cautious"    # default
 risk_strict = false            # false = prompt for approval; true = deny outright
 ```
@@ -60,26 +65,28 @@ risk_strict = false            # false = prompt for approval; true = deny outrig
 You can also pass integer values (1--5) or set via env var:
 
 ```bash
-export SQUIRE_RISK_TOLERANCE=standard
+export SQUIRE_GUARDRAILS_RISK_TOLERANCE=standard
 ```
 
 ### Built-In Tool Risk Levels
 
-| Tool | Risk Level | Description |
-|---|---|---|
-| `system_info` | 1 | CPU, memory, disk, uptime |
-| `network_info` | 1 | Network interfaces, routes |
-| `docker_ps` | 1 | List containers |
-| `list_alert_rules` | 1 | List configured alert rules |
-| `docker_logs` | 2 | View container logs |
-| `read_config` | 2 | Read configuration files |
-| `journalctl` | 2 | View system/service logs |
-| `send_notification` | 2 | Send a notification |
-| `create_alert_rule` | 2 | Create an alert rule |
-| `docker_compose` | 3 | Manage compose stacks (start/stop/restart) |
-| `systemctl` | 3 | Manage systemd services |
-| `delete_alert_rule` | 3 | Delete an alert rule |
-| `run_command` | 5 | Execute arbitrary shell commands |
+
+| Tool                | Risk Level | Description                                |
+| ------------------- | ---------- | ------------------------------------------ |
+| `system_info`       | 1          | CPU, memory, disk, uptime                  |
+| `network_info`      | 1          | Network interfaces, routes                 |
+| `docker_ps`         | 1          | List containers                            |
+| `list_alert_rules`  | 1          | List configured alert rules                |
+| `docker_logs`       | 2          | View container logs                        |
+| `read_config`       | 2          | Read configuration files                   |
+| `journalctl`        | 2          | View system/service logs                   |
+| `send_notification` | 2          | Send a notification                        |
+| `create_alert_rule` | 2          | Create an alert rule                       |
+| `docker_compose`    | 3          | Manage compose stacks (start/stop/restart) |
+| `systemctl`         | 3          | Manage systemd services                    |
+| `delete_alert_rule` | 3          | Delete an alert rule                       |
+| `run_command`       | 5          | Execute arbitrary shell commands           |
+
 
 ---
 
@@ -88,6 +95,23 @@ export SQUIRE_RISK_TOLERANCE=standard
 The `[guardrails]` section consolidates all safety policy in one place: tool-level overrides, per-agent tolerances, command/path guards, and watch-mode risk overrides.
 
 Env vars use the `SQUIRE_GUARDRAILS_` prefix.
+
+### Global Risk Policy
+
+The global risk tolerance and strict mode live here:
+
+```toml
+[guardrails]
+risk_tolerance = "cautious"              # read-only, cautious, standard, full-trust
+risk_strict = false                      # true = deny above threshold; false = prompt
+```
+
+
+| Key              | Default      | Env Var                            | Description                                                        |
+| ---------------- | ------------ | ---------------------------------- | ------------------------------------------------------------------ |
+| `risk_tolerance` | `"cautious"` | `SQUIRE_GUARDRAILS_RISK_TOLERANCE` | Global risk tolerance (see [Risk Tolerance](#risk-tolerance))      |
+| `risk_strict`    | `false`      | `SQUIRE_GUARDRAILS_RISK_STRICT`    | When `true`, tools above tolerance are denied instead of prompting |
+
 
 ### Tool-Level Overrides
 
@@ -100,12 +124,14 @@ tools_require_approval = ["docker_compose"]  # always prompt, even if tolerance 
 tools_deny = ["run_command"]             # hard block, never execute
 ```
 
-| Key | Default | Env Var | Description |
-|---|---|---|---|
-| `tools_allow` | `[]` | `SQUIRE_GUARDRAILS_TOOLS_ALLOW` | Tool names that bypass risk check |
-| `tools_require_approval` | `[]` | `SQUIRE_GUARDRAILS_TOOLS_REQUIRE_APPROVAL` | Tool names that always require approval |
-| `tools_deny` | `[]` | `SQUIRE_GUARDRAILS_TOOLS_DENY` | Tool names that are hard-blocked |
-| `tools_risk_overrides` | `{}` | `SQUIRE_GUARDRAILS_TOOLS_RISK_OVERRIDES` | Per-tool risk level overrides (see below) |
+
+| Key                      | Default | Env Var                                    | Description                               |
+| ------------------------ | ------- | ------------------------------------------ | ----------------------------------------- |
+| `tools_allow`            | `[]`    | `SQUIRE_GUARDRAILS_TOOLS_ALLOW`            | Tool names that bypass risk check         |
+| `tools_require_approval` | `[]`    | `SQUIRE_GUARDRAILS_TOOLS_REQUIRE_APPROVAL` | Tool names that always require approval   |
+| `tools_deny`             | `[]`    | `SQUIRE_GUARDRAILS_TOOLS_DENY`             | Tool names that are hard-blocked          |
+| `tools_risk_overrides`   | `{}`    | `SQUIRE_GUARDRAILS_TOOLS_RISK_OVERRIDES`   | Per-tool risk level overrides (see below) |
+
 
 ### Per-Tool Risk Level Overrides
 
@@ -126,10 +152,12 @@ commands_allow = ["ping", "traceroute", "df", "free", "uptime", "cat", "head", "
 commands_block = ["rm", "mkfs", "dd", "shutdown", "reboot"]
 ```
 
-| Key | Default | Env Var | Description |
-|---|---|---|---|
-| `commands_allow` | *(see below)* | `SQUIRE_GUARDRAILS_COMMANDS_ALLOW` | Commands that `run_command` can execute |
+
+| Key              | Default       | Env Var                            | Description                                      |
+| ---------------- | ------------- | ---------------------------------- | ------------------------------------------------ |
+| `commands_allow` | *(see below)* | `SQUIRE_GUARDRAILS_COMMANDS_ALLOW` | Commands that `run_command` can execute          |
 | `commands_block` | *(see below)* | `SQUIRE_GUARDRAILS_COMMANDS_BLOCK` | Commands that are always blocked (checked first) |
+
 
 **Default command allowlist:** `ping`, `traceroute`, `dig`, `nslookup`, `df`, `free`, `uptime`, `ip`, `ss`, `cat`, `head`, `tail`
 
@@ -146,9 +174,11 @@ Controls which directories `read_config` can access:
 config_paths = ["/etc/nginx/", "/opt/stacks/"]
 ```
 
-| Key | Default | Env Var | Description |
-|---|---|---|---|
-| `config_paths` | `[]` | `SQUIRE_GUARDRAILS_CONFIG_PATHS` | Directories that `read_config` can access |
+
+| Key            | Default | Env Var                          | Description                               |
+| -------------- | ------- | -------------------------------- | ----------------------------------------- |
+| `config_paths` | `[]`    | `SQUIRE_GUARDRAILS_CONFIG_PATHS` | Directories that `read_config` can access |
+
 
 ### Per-Agent Tolerance Overrides
 
@@ -164,12 +194,14 @@ admin_tolerance = "read-only"             # prompt for everything
 notifier_tolerance = "cautious"           # prompt for delete_alert_rule
 ```
 
-| Key | Env Var | Description |
-|---|---|---|
-| `monitor_tolerance` | `SQUIRE_GUARDRAILS_MONITOR_TOLERANCE` | Monitor sub-agent tolerance |
+
+| Key                   | Env Var                                 | Description                   |
+| --------------------- | --------------------------------------- | ----------------------------- |
+| `monitor_tolerance`   | `SQUIRE_GUARDRAILS_MONITOR_TOLERANCE`   | Monitor sub-agent tolerance   |
 | `container_tolerance` | `SQUIRE_GUARDRAILS_CONTAINER_TOLERANCE` | Container sub-agent tolerance |
-| `admin_tolerance` | `SQUIRE_GUARDRAILS_ADMIN_TOLERANCE` | Admin sub-agent tolerance |
-| `notifier_tolerance` | `SQUIRE_GUARDRAILS_NOTIFIER_TOLERANCE` | Notifier sub-agent tolerance |
+| `admin_tolerance`     | `SQUIRE_GUARDRAILS_ADMIN_TOLERANCE`     | Admin sub-agent tolerance     |
+| `notifier_tolerance`  | `SQUIRE_GUARDRAILS_NOTIFIER_TOLERANCE`  | Notifier sub-agent tolerance  |
+
 
 ### Watch-Mode Risk Overrides -- `[guardrails.watch]`
 
@@ -182,11 +214,13 @@ tools_allow = []                   # additional tools to auto-allow in watch
 tools_deny = []                    # additional tools to deny in watch
 ```
 
-| Key | Env Var | Description |
-|---|---|---|
-| `tolerance` | `SQUIRE_GUARDRAILS_WATCH_TOLERANCE` | Risk tolerance for watch mode |
+
+| Key           | Env Var                               | Description                             |
+| ------------- | ------------------------------------- | --------------------------------------- |
+| `tolerance`   | `SQUIRE_GUARDRAILS_WATCH_TOLERANCE`   | Risk tolerance for watch mode           |
 | `tools_allow` | `SQUIRE_GUARDRAILS_WATCH_TOOLS_ALLOW` | Additional tools to auto-allow in watch |
-| `tools_deny` | `SQUIRE_GUARDRAILS_WATCH_TOOLS_DENY` | Additional tools to deny in watch |
+| `tools_deny`  | `SQUIRE_GUARDRAILS_WATCH_TOOLS_DENY`  | Additional tools to deny in watch       |
+
 
 Watch mode is always strict (deny, never prompt) since there's no interactive approval provider.
 
@@ -200,12 +234,14 @@ When `multi_agent = true`, Squire decomposes into specialized sub-agents. The LL
 multi_agent = true
 ```
 
-| Sub-Agent | Tools | Risk Range |
-|---|---|---|
-| **Monitor** | `system_info`, `network_info`, `docker_ps`, `journalctl`, `read_config` | 1--2 |
-| **Container** | `docker_logs`, `docker_compose` | 2--3 |
-| **Admin** | `systemctl`, `run_command` | 3--5 |
-| **Notifier** | `send_notification`, `list_alert_rules`, `create_alert_rule`, `delete_alert_rule` | 1--3 |
+
+| Sub-Agent     | Tools                                                                             | Risk Range |
+| ------------- | --------------------------------------------------------------------------------- | ---------- |
+| **Monitor**   | `system_info`, `network_info`, `docker_ps`, `journalctl`, `read_config`           | 1--2       |
+| **Container** | `docker_logs`, `docker_compose`                                                   | 2--3       |
+| **Admin**     | `systemctl`, `run_command`                                                        | 3--5       |
+| **Notifier**  | `send_notification`, `list_alert_rules`, `create_alert_rule`, `delete_alert_rule` | 1--3       |
+
 
 ---
 
@@ -213,16 +249,19 @@ multi_agent = true
 
 Squire uses [LiteLLM](https://github.com/BerriAI/litellm), so any supported model works.
 
-| Key | Default | Env Var | Description |
-|---|---|---|---|
-| `model` | `"ollama_chat/llama3.1:8b"` | `SQUIRE_LLM_MODEL` | LiteLLM model identifier |
-| `api_base` | `null` | `SQUIRE_LLM_API_BASE` | API base URL (required for Ollama, optional for cloud providers) |
-| `temperature` | `0.2` | `SQUIRE_LLM_TEMPERATURE` | Sampling temperature (0.0--2.0) |
-| `max_tokens` | `4096` | `SQUIRE_LLM_MAX_TOKENS` | Maximum tokens in LLM response |
+
+| Key           | Default                     | Env Var                  | Description                                                      |
+| ------------- | --------------------------- | ------------------------ | ---------------------------------------------------------------- |
+| `model`       | `"ollama_chat/llama3.1:8b"` | `SQUIRE_LLM_MODEL`       | LiteLLM model identifier                                         |
+| `api_base`    | `null`                      | `SQUIRE_LLM_API_BASE`    | API base URL (required for Ollama, optional for cloud providers) |
+| `temperature` | `0.2`                       | `SQUIRE_LLM_TEMPERATURE` | Sampling temperature (0.0--2.0)                                  |
+| `max_tokens`  | `4096`                      | `SQUIRE_LLM_MAX_TOKENS`  | Maximum tokens in LLM response                                   |
+
 
 ### Examples
 
 **Ollama (local or remote):**
+
 ```toml
 [llm]
 model = "ollama_chat/qwen3.5:35b"
@@ -230,6 +269,7 @@ api_base = "http://localhost:11434"
 ```
 
 **Anthropic:**
+
 ```toml
 [llm]
 model = "anthropic/claude-sonnet-4-20250514"
@@ -237,6 +277,7 @@ model = "anthropic/claude-sonnet-4-20250514"
 ```
 
 **OpenAI:**
+
 ```toml
 [llm]
 model = "gpt-4o"
@@ -244,6 +285,7 @@ model = "gpt-4o"
 ```
 
 **Google Gemini:**
+
 ```toml
 [llm]
 model = "gemini/gemini-2.0-flash"
@@ -254,10 +296,12 @@ model = "gemini/gemini-2.0-flash"
 
 Squire relies heavily on tool/function calling. Models with strong tool-calling support produce the best results, especially for multi-step orchestration in watch mode.
 
-| Model | Provider | Status | Notes |
-|---|---|---|---|
-| `ollama_chat/mistral-small3.2:24b` | Ollama | **Recommended** | Current development model (v0.5.0+). Reliable tool-calling accuracy. |
-| `ollama_chat/llama3.1:8b` | Ollama | Not recommended | Used pre-v0.4.0. Tool-call accuracy was limited; suitable for basic queries only. |
+
+| Model                              | Provider | Status          | Notes                                                                             |
+| ---------------------------------- | -------- | --------------- | --------------------------------------------------------------------------------- |
+| `ollama_chat/mistral-small3.2:24b` | Ollama   | **Recommended** | Current development model (v0.5.0+). Reliable tool-calling accuracy.              |
+| `ollama_chat/llama3.1:8b`          | Ollama   | Not recommended | Used pre-v0.4.0. Tool-call accuracy was limited; suitable for basic queries only. |
+
 
 **Cloud providers (Anthropic, OpenAI, Gemini):** These are supported via LiteLLM and expected to perform well -- particularly larger models with strong tool-calling capabilities -- but have not been validated with Squire yet. If you try a cloud model, feedback is welcome via [GitHub issues](https://github.com/willdahern/squire/issues).
 
@@ -269,9 +313,11 @@ Squire relies heavily on tool/function calling. Models with strong tool-calling 
 
 Skills are file-based instruction sets aligned with the [Open Agent Skills spec](https://agentskills.io/specification). Each skill lives in a `NAME/SKILL.md` subdirectory under the configured skills path.
 
-| Key | Default | Env Var | Description |
-|---|---|---|---|
+
+| Key    | Default                        | Env Var              | Description                            |
+| ------ | ------------------------------ | -------------------- | -------------------------------------- |
 | `path` | `~/.local/share/squire/skills` | `SQUIRE_SKILLS_PATH` | Directory containing skill definitions |
+
 
 ```toml
 [skills]
@@ -297,13 +343,15 @@ If any containers are in an errored state, check their logs and restart them.
 
 The format follows the [Open Agent Skills spec](https://agentskills.io/specification). `name` and `description` are spec-required top-level fields. Squire-specific fields live under `metadata`:
 
-| Key | Required | Default | Description |
-|---|---|---|---|
-| `name` | Yes | | Skill name — lowercase letters, numbers, hyphens, max 64 chars. Must match directory name. |
-| `description` | Yes | | What the skill does and when to use it (max 1024 chars). |
-| `metadata.host` | No | `all` | Target host (`all` or a specific host name) |
-| `metadata.trigger` | No | `manual` | `manual` (on-demand) or `watch` (each watch cycle) |
-| `metadata.enabled` | No | `true` | Whether the skill is active |
+
+| Key                | Required | Default  | Description                                                                                |
+| ------------------ | -------- | -------- | ------------------------------------------------------------------------------------------ |
+| `name`             | Yes      |          | Skill name — lowercase letters, numbers, hyphens, max 64 chars. Must match directory name. |
+| `description`      | Yes      |          | What the skill does and when to use it (max 1024 chars).                                   |
+| `metadata.host`    | No       | `all`    | Target host (`all` or a specific host name)                                                |
+| `metadata.trigger` | No       | `manual` | `manual` (on-demand) or `watch` (each watch cycle)                                         |
+| `metadata.enabled` | No       | `true`   | Whether the skill is active                                                                |
+
 
 The `metadata` key is omitted entirely when all Squire-specific fields are at their defaults.
 
@@ -315,10 +363,12 @@ Skills with `trigger: watch` are appended to the watch mode check-in prompt each
 
 Squire persists chat history, system snapshots, events, and alert rules to SQLite.
 
-| Key | Default | Env Var | Description |
-|---|---|---|---|
-| `path` | `~/.local/share/squire/squire.db` | `SQUIRE_DB_PATH` | Path to the SQLite database file |
-| `snapshot_interval_minutes` | `15` | `SQUIRE_DB_SNAPSHOT_INTERVAL_MINUTES` | Minutes between automatic system snapshots |
+
+| Key                         | Default                           | Env Var                               | Description                                |
+| --------------------------- | --------------------------------- | ------------------------------------- | ------------------------------------------ |
+| `path`                      | `~/.local/share/squire/squire.db` | `SQUIRE_DB_PATH`                      | Path to the SQLite database file           |
+| `snapshot_interval_minutes` | `15`                              | `SQUIRE_DB_SNAPSHOT_INTERVAL_MINUTES` | Minutes between automatic system snapshots |
+
 
 ```toml
 [db]
@@ -341,16 +391,18 @@ squire hosts add --name media-server --address 192.168.1.10 --user will
 squire hosts add --name nas --address 192.168.1.20 --user will --port 2222 --tags storage --services plex,sonarr
 ```
 
-| Flag | Default | Description |
-|---|---|---|
-| `--name` | *(required)* | Unique alias for the host |
-| `--address` | *(required)* | Hostname or IP address |
-| `--user` | `"root"` | SSH username |
-| `--port` | `22` | SSH port |
-| `--key-file` | *(auto-generated)* | Path to SSH private key (uses auto-generated ed25519 key by default) |
-| `--tags` | `[]` | Comma-separated tags for grouping |
-| `--services` | `[]` | Comma-separated Docker Compose service names on this host |
-| `--service-root` | `"/opt"` | Root directory for compose service directories on the host |
+
+| Flag             | Default            | Description                                                          |
+| ---------------- | ------------------ | -------------------------------------------------------------------- |
+| `--name`         | *(required)*       | Unique alias for the host                                            |
+| `--address`      | *(required)*       | Hostname or IP address                                               |
+| `--user`         | `"root"`           | SSH username                                                         |
+| `--port`         | `22`               | SSH port                                                             |
+| `--key-file`     | *(auto-generated)* | Path to SSH private key (uses auto-generated ed25519 key by default) |
+| `--tags`         | `[]`               | Comma-separated tags for grouping                                    |
+| `--services`     | `[]`               | Comma-separated Docker Compose service names on this host            |
+| `--service-root` | `"/opt"`           | Root directory for compose service directories on the host           |
+
 
 ### Enrollment Flow
 
@@ -382,10 +434,12 @@ The web UI host detail page also displays the public key for `pending_key` hosts
 
 ### Host Status
 
-| Status | Meaning |
-|---|---|
-| `active` | SSH key installed, Squire can connect |
+
+| Status        | Meaning                                             |
+| ------------- | --------------------------------------------------- |
+| `active`      | SSH key installed, Squire can connect               |
 | `pending_key` | Awaiting public key installation on the target host |
+
 
 ### Listing and Removing Hosts
 
@@ -404,13 +458,15 @@ The `/hosts` page in the web UI provides an "Add Host" dialog and lists all enro
 
 Equivalent API endpoints:
 
-| Method | Path | Description |
-|---|---|---|
-| `POST` | `/api/hosts` | Enroll a new host |
-| `GET` | `/api/hosts` | List all hosts |
-| `DELETE` | `/api/hosts/{name}` | Remove a host |
-| `POST` | `/api/hosts/{name}/verify` | Verify SSH connectivity |
-| `GET` | `/api/hosts/{name}/public-key` | Retrieve the host's public key |
+
+| Method   | Path                           | Description                    |
+| -------- | ------------------------------ | ------------------------------ |
+| `POST`   | `/api/hosts`                   | Enroll a new host              |
+| `GET`    | `/api/hosts`                   | List all hosts                 |
+| `DELETE` | `/api/hosts/{name}`            | Remove a host                  |
+| `POST`   | `/api/hosts/{name}/verify`     | Verify SSH connectivity        |
+| `GET`    | `/api/hosts/{name}/public-key` | Retrieve the host's public key |
+
 
 ---
 
@@ -420,15 +476,17 @@ Operational configuration for autonomous watch mode (`squire watch`). See [CLI r
 
 Risk policy for watch mode is configured under `[guardrails.watch]`, not here.
 
-| Key | Default | Env Var | Description |
-|---|---|---|---|
-| `interval_minutes` | `5` | `SQUIRE_WATCH_INTERVAL_MINUTES` | Minutes between watch cycles |
-| `max_tool_calls_per_cycle` | `15` | `SQUIRE_WATCH_MAX_TOOL_CALLS_PER_CYCLE` | Tool call budget per cycle |
-| `cycle_timeout_seconds` | `300` | `SQUIRE_WATCH_CYCLE_TIMEOUT_SECONDS` | Max wall-clock time per cycle |
-| `cycles_per_session` | `50` | `SQUIRE_WATCH_CYCLES_PER_SESSION` | Rotate session after N cycles |
-| `checkin_prompt` | *(built-in)* | `SQUIRE_WATCH_CHECKIN_PROMPT` | Prompt injected each cycle |
-| `notify_on_action` | `true` | `SQUIRE_WATCH_NOTIFY_ON_ACTION` | Notify on corrective actions |
-| `notify_on_blocked` | `true` | `SQUIRE_WATCH_NOTIFY_ON_BLOCKED` | Notify on blocked tool calls |
+
+| Key                        | Default      | Env Var                                 | Description                   |
+| -------------------------- | ------------ | --------------------------------------- | ----------------------------- |
+| `interval_minutes`         | `5`          | `SQUIRE_WATCH_INTERVAL_MINUTES`         | Minutes between watch cycles  |
+| `max_tool_calls_per_cycle` | `15`         | `SQUIRE_WATCH_MAX_TOOL_CALLS_PER_CYCLE` | Tool call budget per cycle    |
+| `cycle_timeout_seconds`    | `300`        | `SQUIRE_WATCH_CYCLE_TIMEOUT_SECONDS`    | Max wall-clock time per cycle |
+| `cycles_per_session`       | `50`         | `SQUIRE_WATCH_CYCLES_PER_SESSION`       | Rotate session after N cycles |
+| `checkin_prompt`           | *(built-in)* | `SQUIRE_WATCH_CHECKIN_PROMPT`           | Prompt injected each cycle    |
+| `notify_on_action`         | `true`       | `SQUIRE_WATCH_NOTIFY_ON_ACTION`         | Notify on corrective actions  |
+| `notify_on_blocked`        | `true`       | `SQUIRE_WATCH_NOTIFY_ON_BLOCKED`        | Notify on blocked tool calls  |
+
 
 ```toml
 [watch]
@@ -444,19 +502,23 @@ cycles_per_session = 50
 
 Webhook-based notifications for events, watch mode alerts, and approval outcomes.
 
-| Key | Default | Env Var | Description |
-|---|---|---|---|
-| `enabled` | `false` | `SQUIRE_NOTIFICATIONS_ENABLED` | Enable the notification system |
-| `webhooks` | `[]` | | List of webhook endpoints (see below) |
+
+| Key        | Default | Env Var                        | Description                           |
+| ---------- | ------- | ------------------------------ | ------------------------------------- |
+| `enabled`  | `false` | `SQUIRE_NOTIFICATIONS_ENABLED` | Enable the notification system        |
+| `webhooks` | `[]`    |                                | List of webhook endpoints (see below) |
+
 
 Each webhook entry:
 
-| Key | Default | Description |
-|---|---|---|
-| `name` | *(required)* | Human-readable name (e.g., `"discord"`, `"ntfy"`) |
-| `url` | *(required)* | URL to POST event payloads to |
-| `events` | `["*"]` | Event categories to subscribe to (`"*"` for all) |
-| `headers` | `{}` | Optional HTTP headers (e.g., `Authorization`) |
+
+| Key       | Default      | Description                                       |
+| --------- | ------------ | ------------------------------------------------- |
+| `name`    | *(required)* | Human-readable name (e.g., `"discord"`, `"ntfy"`) |
+| `url`     | *(required)* | URL to POST event payloads to                     |
+| `events`  | `["*"]`      | Event categories to subscribe to (`"*"` for all)  |
+| `headers` | `{}`         | Optional HTTP headers (e.g., `Authorization`)     |
+
 
 ```toml
 [notifications]
@@ -491,29 +553,34 @@ to_addresses = ["admin@example.com"]
 events = ["watch.alert", "watch.action"]
 ```
 
-| Key | Default | Description |
-|---|---|---|
-| `enabled` | `false` | Whether email notifications are enabled |
-| `smtp_host` | `""` | SMTP server hostname |
-| `smtp_port` | `587` | SMTP port (typically 587 for TLS) |
-| `use_tls` | `true` | Use STARTTLS for SMTP connection |
-| `smtp_user` | `""` | SMTP authentication username |
-| `smtp_password` | `""` | SMTP authentication password |
-| `from_address` | `""` | Email sender address |
-| `to_addresses` | `[]` | Recipient email addresses |
-| `events` | `["*"]` | Event categories to send (`"*"` for all) |
+
+| Key             | Default | Description                              |
+| --------------- | ------- | ---------------------------------------- |
+| `enabled`       | `false` | Whether email notifications are enabled  |
+| `smtp_host`     | `""`    | SMTP server hostname                     |
+| `smtp_port`     | `587`   | SMTP port (typically 587 for TLS)        |
+| `use_tls`       | `true`  | Use STARTTLS for SMTP connection         |
+| `smtp_user`     | `""`    | SMTP authentication username             |
+| `smtp_password` | `""`    | SMTP authentication password             |
+| `from_address`  | `""`    | Email sender address                     |
+| `to_addresses`  | `[]`    | Recipient email addresses                |
+| `events`        | `["*"]` | Event categories to send (`"*"` for all) |
+
 
 ### Event Categories
 
-| Category | Source | Description |
-|---|---|---|
-| `tool_call` | Chat | A tool was called |
-| `error` | Chat | An error occurred |
-| `approval_denied` | Chat | User denied a tool approval |
-| `watch.start` | Watch | Watch mode started |
-| `watch.stop` | Watch | Watch mode stopped |
-| `watch.action` | Watch | Agent took a corrective action |
-| `watch.blocked` | Watch | Tool call denied by risk policy |
-| `watch.alert` | Watch | Alert rule triggered |
-| `watch.error` | Watch | Exception during a watch cycle |
-| `user` | Agent | Ad-hoc notification sent by the agent |
+
+| Category          | Source | Description                           |
+| ----------------- | ------ | ------------------------------------- |
+| `tool_call`       | Chat   | A tool was called                     |
+| `error`           | Chat   | An error occurred                     |
+| `approval_denied` | Chat   | User denied a tool approval           |
+| `watch.start`     | Watch  | Watch mode started                    |
+| `watch.stop`      | Watch  | Watch mode stopped                    |
+| `watch.action`    | Watch  | Agent took a corrective action        |
+| `watch.blocked`   | Watch  | Tool call denied by risk policy       |
+| `watch.alert`     | Watch  | Alert rule triggered                  |
+| `watch.error`     | Watch  | Exception during a watch cycle        |
+| `user`            | Agent  | Ad-hoc notification sent by the agent |
+
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ make web
 uv run squire web
 ```
 
-Opens at **http://localhost:8420**. The web server runs FastAPI with a built-in Next.js frontend — no separate process needed.
+Opens at **[http://localhost:8420](http://localhost:8420)**. The web server runs FastAPI with a built-in Next.js frontend — no separate process needed.
 
 Custom port:
 
@@ -30,16 +30,18 @@ uv run squire web --port 9000
 
 The web UI has eight pages:
 
-| Page | What it does |
-|---|---|
-| **Chat** | WebSocket-streamed conversation with tool call indicators and approval dialogs |
-| **Activity** | Timeline of tool calls, watch mode actions, and denied requests |
-| **Sessions** | Browse, resume, and delete past conversations |
-| **Skills** | Create, edit, toggle, execute, and delete skills with a form-based editor |
-| **Watch** | Start/stop watch mode, live-stream cycle activity, interactive tool approval with countdown timers, and runtime config changes |
-| **Hosts** | Host registry with reachable/unreachable status, services, and tags |
-| **Notifications** | Notification category overview and recent history |
-| **Config** | Current effective configuration viewer |
+
+| Page              | What it does                                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Chat**          | WebSocket-streamed conversation with tool call indicators and approval dialogs                                                 |
+| **Activity**      | Timeline of tool calls, watch mode actions, and denied requests                                                                |
+| **Sessions**      | Browse, resume, and delete past conversations                                                                                  |
+| **Skills**        | Create, edit, toggle, execute, and delete skills with a form-based editor                                                      |
+| **Watch**         | Start/stop watch mode, live-stream cycle activity, interactive tool approval with countdown timers, and runtime config changes |
+| **Hosts**         | Host registry with reachable/unreachable status, services, and tags                                                            |
+| **Notifications** | Notification category overview and recent history                                                                              |
+| **Config**        | Current effective configuration viewer                                                                                         |
+
 
 ### CLI
 
@@ -64,11 +66,11 @@ See the [CLI Reference](cli.md) for full option details on every command.
 
 Settings are resolved in order (highest priority first):
 
-1. **Environment variables** — prefixed with `SQUIRE_*`
+1. **Environment variables** — prefixed with `SQUIRE_`*
 2. **TOML config file** — first found from:
-   - `./squire.toml` (project directory)
-   - `~/.config/squire/squire.toml` (user config)
-   - `/etc/squire/squire.toml` (system-wide)
+  - `./squire.toml` (project directory)
+  - `~/.config/squire/squire.toml` (user config)
+  - `/etc/squire/squire.toml` (system-wide)
 3. **Built-in defaults**
 
 Copy the annotated example config to get started:
@@ -77,7 +79,7 @@ Copy the annotated example config to get started:
 cp squire.example.toml squire.toml
 ```
 
-The example file ([`squire.example.toml`](../squire.example.toml)) documents every option with its default.
+The example file (`[squire.example.toml](../squire.example.toml)`) documents every option with its default.
 
 ### LLM Setup
 
@@ -114,12 +116,14 @@ Risk tolerance is the main dial for controlling what Squire can do automatically
 
 Every tool has a built-in risk level (1–5). The tolerance setting determines the cutoff:
 
-| Tolerance | Level | Auto-allows | Needs approval |
-|---|---|---|---|
-| `read-only` | 1 | System info, network info, container listing | Everything else |
-| `cautious` | 2 | + log viewing, config reads | Compose, systemctl, commands |
-| `standard` | 3 | + compose, systemctl | Arbitrary command execution |
-| `full-trust` | 5 | Everything | Nothing |
+
+| Tolerance    | Level | Auto-allows                                  | Needs approval               |
+| ------------ | ----- | -------------------------------------------- | ---------------------------- |
+| `read-only`  | 1     | System info, network info, container listing | Everything else              |
+| `cautious`   | 2     | + log viewing, config reads                  | Compose, systemctl, commands |
+| `standard`   | 3     | + compose, systemctl                         | Arbitrary command execution  |
+| `full-trust` | 5     | Everything                                   | Nothing                      |
+
 
 ```toml
 risk_tolerance = "cautious"    # default
@@ -183,12 +187,14 @@ By default Squire runs as a single agent. Enable sub-agent decomposition to rout
 multi_agent = true
 ```
 
-| Sub-agent | Role | Default risk tolerance | Tools |
-|---|---|---|---|
-| Monitor | Read-only system observation | `read-only` | `system_info`, `network_info`, `docker_ps`, `journalctl`, `read_config` |
-| Container | Docker lifecycle management | `cautious` | `docker_logs`, `docker_compose`, `docker_container`, `docker_image`, `docker_cleanup` |
-| Admin | Systemd and command execution | `standard` | `systemctl`, `run_command` |
-| Notifier | Alerts and notifications | `read-only` | `send_notification`, `list_alert_rules`, `create_alert_rule`, `delete_alert_rule` |
+
+| Sub-agent | Role                          | Default risk tolerance | Tools                                                                                 |
+| --------- | ----------------------------- | ---------------------- | ------------------------------------------------------------------------------------- |
+| Monitor   | Read-only system observation  | `read-only`            | `system_info`, `network_info`, `docker_ps`, `journalctl`, `read_config`               |
+| Container | Docker lifecycle management   | `cautious`             | `docker_logs`, `docker_compose`, `docker_container`, `docker_image`, `docker_cleanup` |
+| Admin     | Systemd and command execution | `standard`             | `systemctl`, `run_command`                                                            |
+| Notifier  | Alerts and notifications      | `read-only`            | `send_notification`, `list_alert_rules`, `create_alert_rule`, `delete_alert_rule`     |
+
 
 The LLM routes requests to the appropriate specialist. You always interact with Squire — the sub-agent structure is an implementation detail.
 
@@ -226,18 +232,18 @@ You can also start and supervise watch mode from the web UI (Watch page) with li
 
 1. Configure at least one LLM provider (see [LLM Setup](#llm-setup) above)
 2. Set a conservative watch risk tolerance:
-   ```toml
+  ```toml
    [guardrails.watch]
    tolerance = "read-only"
-   ```
+  ```
 3. Optionally add alert rules:
-   ```bash
+  ```bash
    squire alerts add --name "disk-full" --condition "disk_percent > 90" --severity warning
-   ```
+  ```
 4. Start watch mode:
-   ```bash
+  ```bash
    squire watch
-   ```
+  ```
 5. Monitor from the web UI: `squire web` → Watch page
 
 ### Watch Mode Configuration
@@ -290,6 +296,7 @@ Conditions follow the format `<field> <op> <value>`:
 - **value** — number or string literal
 
 Examples:
+
 ```
 cpu_percent > 90
 memory_used_mb >= 14000
@@ -301,17 +308,19 @@ The condition evaluator is safe — no `eval()`, just a structured parser.
 
 ### Snapshot Fields
 
-| Field | Type | Description |
-|---|---|---|
-| `cpu_percent` | float | CPU usage percentage |
-| `memory_used_mb` | float | Memory usage in MB |
+
+| Field            | Type  | Description             |
+| ---------------- | ----- | ----------------------- |
+| `cpu_percent`    | float | CPU usage percentage    |
+| `memory_used_mb` | float | Memory usage in MB      |
 | `memory_percent` | float | Memory usage percentage |
-| `disk_percent` | float | Disk usage percentage |
-| `disk_used_gb` | float | Disk usage in GB |
-| `load_1m` | float | 1-minute load average |
-| `load_5m` | float | 5-minute load average |
-| `load_15m` | float | 15-minute load average |
-| `uptime_hours` | float | System uptime in hours |
+| `disk_percent`   | float | Disk usage percentage   |
+| `disk_used_gb`   | float | Disk usage in GB        |
+| `load_1m`        | float | 1-minute load average   |
+| `load_5m`        | float | 5-minute load average   |
+| `load_15m`       | float | 15-minute load average  |
+| `uptime_hours`   | float | System uptime in hours  |
+
 
 Dot-path notation works for nested fields (e.g., `containers.nginx.state`).
 
@@ -352,10 +361,12 @@ Verify the containers come back healthy after restart.
 
 ### Triggers
 
-| Trigger | When it runs |
-|---|---|
-| `manual` | On demand — from the web UI, CLI, or API |
-| `watch` | Appended to the check-in prompt each watch mode cycle |
+
+| Trigger  | When it runs                                          |
+| -------- | ----------------------------------------------------- |
+| `manual` | On demand — from the web UI, CLI, or API              |
+| `watch`  | Appended to the check-in prompt each watch mode cycle |
+
 
 Here is a watch-triggered example:
 
@@ -430,14 +441,16 @@ events = ["watch.alert", "watch.error"]
 
 ### Event Categories
 
-| Event | Description |
-|---|---|
-| `watch.start` | Watch mode started |
-| `watch.stop` | Watch mode stopped |
-| `watch.action` | Agent took a corrective action |
+
+| Event           | Description                     |
+| --------------- | ------------------------------- |
+| `watch.start`   | Watch mode started              |
+| `watch.stop`    | Watch mode stopped              |
+| `watch.action`  | Agent took a corrective action  |
 | `watch.blocked` | Tool call denied by risk policy |
-| `watch.alert` | Alert rule triggered |
-| `watch.error` | Exception during a cycle |
+| `watch.alert`   | Alert rule triggered            |
+| `watch.error`   | Exception during a cycle        |
+
 
 Use `"*"` to subscribe to all events. See [Configuration Reference](configuration.md#notifications----notifications) for full options including custom headers.
 
@@ -455,7 +468,7 @@ The recommended way to run Squire in Docker:
 docker compose up -d
 ```
 
-The web UI is available at **http://localhost:8420**.
+The web UI is available at **[http://localhost:8420](http://localhost:8420)**.
 
 The default `docker-compose.yml` assumes Ollama is running on the Docker host. Edit the `environment` section to configure your LLM provider — see the comments in the file for examples with Anthropic, OpenAI, and Gemini.
 
@@ -475,19 +488,23 @@ docker run -d -p 8420:8420 -v squire-data:/data \
 
 ### Ports
 
-| Port | Service |
-|---|---|
+
+| Port     | Service                                     |
+| -------- | ------------------------------------------- |
 | **8420** | Web UI + REST API + WebSocket (single port) |
+
 
 ### Data Volume
 
 All persistent data lives under `/data` inside the container. Mount a named volume or host directory to preserve state across restarts:
 
-| Path | Contents |
-|---|---|
+
+| Path              | Contents                                                     |
+| ----------------- | ------------------------------------------------------------ |
 | `/data/squire.db` | SQLite database (sessions, events, alert rules, watch state) |
-| `/data/skills/` | Skill definitions (Open Agent Skills format) |
-| `/data/keys/` | SSH key pairs for managed remote hosts |
+| `/data/skills/`   | Skill definitions (Open Agent Skills format)                 |
+| `/data/keys/`     | SSH key pairs for managed remote hosts                       |
+
 
 ```bash
 # Use a named volume (recommended)

--- a/squire.example.toml
+++ b/squire.example.toml
@@ -11,8 +11,6 @@
 # --- Top-level application settings ---
 # app_name = "Squire"
 # user_id = "squire-user"
-# risk_tolerance = "cautious"      # 1-5 or alias: read-only(1), cautious(2), standard(3), full-trust(5)
-# risk_strict = false              # true = deny above threshold; false = prompt for approval
 # history_limit = 50               # Max messages in conversation context
 # max_tool_rounds = 10             # Max tool-call rounds per user message
 # multi_agent = false              # Enable sub-agent decomposition (Monitor, Container, Admin, Notifier)
@@ -29,8 +27,10 @@
 # path = "~/.local/share/squire/squire.db"
 # snapshot_interval_minutes = 15
 
-# --- Guardrails: tool overrides, command/path guards, per-agent tolerances ---
+# --- Guardrails: risk policy, tool overrides, command/path guards, per-agent tolerances ---
 [guardrails]
+# risk_tolerance = "cautious"              # 1-5 or alias: read-only(1), cautious(2), standard(3), full-trust(5)
+# risk_strict = false                      # true = deny above threshold; false = prompt for approval
 # tools_allow = ["docker_logs"]            # bypass risk check, auto-run
 # tools_require_approval = ["docker_compose"]  # always ask user first
 # tools_deny = ["run_command"]             # hard block, never run

--- a/src/squire/agents/squire_agent.py
+++ b/src/squire/agents/squire_agent.py
@@ -7,7 +7,7 @@ from google.genai import types
 from ..config import AppConfig, LLMConfig
 from ..instructions.squire_agent import build_instruction
 from ..tools import ALL_TOOLS
-from ..types import BeforeToolCallback, RiskGateFactory
+from ..types import BeforeToolCallback, RiskGateFactory, RiskGateFactoryBuilder
 
 
 def create_squire_agent(
@@ -15,6 +15,7 @@ def create_squire_agent(
     llm_config: LLMConfig | None = None,
     before_tool_callback: BeforeToolCallback | None = None,
     risk_gate_factory: RiskGateFactory | None = None,
+    risk_gate_factory_builder: RiskGateFactoryBuilder | None = None,
 ) -> Agent:
     """Factory function that creates the root Squire agent.
 
@@ -27,6 +28,9 @@ def create_squire_agent(
         risk_gate_factory: Factory that creates scoped before_tool_callbacks
             for sub-agents. Required when ``multi_agent=True``. Accepts
             a ``tool_risk_levels`` dict and returns a callback.
+        risk_gate_factory_builder: Builder that returns a per-agent factory
+            given the sub-agent name. When provided, overrides
+            ``risk_gate_factory`` for multi-agent mode.
 
     Returns:
         A fully configured ADK Agent ready to run.
@@ -39,7 +43,7 @@ def create_squire_agent(
         model_kwargs["api_base"] = llm_config.api_base
 
     if app_config.multi_agent:
-        return _create_multi_agent(app_config, llm_config, model_kwargs, risk_gate_factory)
+        return _create_multi_agent(app_config, llm_config, model_kwargs, risk_gate_factory, risk_gate_factory_builder)
 
     return Agent(
         name="Squire",
@@ -59,6 +63,7 @@ def _create_multi_agent(
     llm_config: LLMConfig,
     model_kwargs: dict,
     risk_gate_factory: RiskGateFactory | None,
+    risk_gate_factory_builder: RiskGateFactoryBuilder | None = None,
 ) -> Agent:
     """Create the multi-agent hierarchy with sub-agent routing."""
     from ..instructions.router_agent import build_instruction as build_router_instruction
@@ -67,13 +72,18 @@ def _create_multi_agent(
     from .monitor_agent import create_monitor_agent
     from .notifier_agent import create_notifier_agent
 
-    if risk_gate_factory is None:
-        raise ValueError("risk_gate_factory is required when multi_agent=True")
+    if risk_gate_factory is None and risk_gate_factory_builder is None:
+        raise ValueError("risk_gate_factory or risk_gate_factory_builder is required when multi_agent=True")
 
-    monitor = create_monitor_agent(llm_config, app_config, risk_gate_factory)
-    container = create_container_agent(llm_config, app_config, risk_gate_factory)
-    admin = create_admin_agent(llm_config, app_config, risk_gate_factory)
-    notifier = create_notifier_agent(llm_config, app_config, risk_gate_factory)
+    def _factory_for(agent_name: str) -> RiskGateFactory:
+        if risk_gate_factory_builder is not None:
+            return risk_gate_factory_builder(agent_name)
+        return risk_gate_factory  # type: ignore[return-value]
+
+    monitor = create_monitor_agent(llm_config, app_config, _factory_for("Monitor"))
+    container = create_container_agent(llm_config, app_config, _factory_for("Container"))
+    admin = create_admin_agent(llm_config, app_config, _factory_for("Admin"))
+    notifier = create_notifier_agent(llm_config, app_config, _factory_for("Notifier"))
 
     return Agent(
         name="Squire",

--- a/src/squire/api/app.py
+++ b/src/squire/api/app.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -28,6 +29,7 @@ from ..notifications.factory import build_notification_router
 from ..skills import SkillService
 from ..system.registry import BackendRegistry
 from ..tools import set_db as tools_set_db
+from ..tools import set_guardrails as tools_set_guardrails
 from ..tools import set_notifier as tools_set_notifier
 from ..tools import set_registry as tools_set_registry
 from . import dependencies as deps
@@ -91,6 +93,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     tools_set_registry(deps.registry)
     tools_set_db(deps.db)
     tools_set_notifier(deps.notifier)
+    tools_set_guardrails(deps.guardrails)
 
     # Collect initial snapshots
     try:
@@ -122,16 +125,38 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
 
 def _find_static_dir() -> Path | None:
-    """Locate the Next.js static export directory."""
-    # Check relative to the package (installed)
-    pkg_dir = Path(__file__).resolve().parent.parent.parent.parent / "web" / "out"
-    if pkg_dir.is_dir():
-        return pkg_dir
-    # Check cwd (development)
-    cwd_dir = Path.cwd() / "web" / "out"
-    if cwd_dir.is_dir():
-        return cwd_dir
-    return None
+    """Locate the Next.js static export directory.
+
+    Resolution order:
+    1. ``SQUIRE_WEB_STATIC_DIR`` — explicit path (set by ``make web`` so the bundle matches the build).
+    2. ``<cwd>/web/out`` then package-root ``web/out``; if both exist and differ, pick the tree with
+       the newer ``index.html`` (avoids serving a stale duplicate checkout).
+    """
+    override = os.environ.get("SQUIRE_WEB_STATIC_DIR")
+    if override:
+        p = Path(override).expanduser().resolve()
+        if p.is_dir() and (p / "index.html").is_file():
+            return p
+
+    repo_root = Path(__file__).resolve().parent.parent.parent.parent
+    candidates: list[Path] = []
+    for base in (Path.cwd(), repo_root):
+        out = (base / "web" / "out").resolve()
+        if out.is_dir() and (out / "index.html").is_file():
+            candidates.append(out)
+
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for c in candidates:
+        if c not in seen:
+            seen.add(c)
+            unique.append(c)
+
+    if not unique:
+        return None
+    if len(unique) == 1:
+        return unique[0]
+    return max(unique, key=lambda p: (p / "index.html").stat().st_mtime)
 
 
 def create_app() -> FastAPI:
@@ -186,8 +211,8 @@ def create_app() -> FastAPI:
                     "<h1>Squire API</h1>"
                     "<p>The API is running. To use the web interface:</p>"
                     "<ol>"
-                    "<li>Build the frontend: <code>cd web && npm install && npm run build</code></li>"
-                    "<li>Restart: <code>squire web</code></li>"
+                    "<li>From the repo root: <code>make web</code> (builds the frontend and starts the server)</li>"
+                    "<li>Or: <code>cd web && npm run build</code> then <code>squire web</code></li>"
                     "</ol>"
                     "<p>Or for development, run <code>cd web && npm run dev</code> separately "
                     "(frontend on port 3000, API on this port).</p>"

--- a/src/squire/api/routers/chat.py
+++ b/src/squire/api/routers/chat.py
@@ -16,8 +16,9 @@ from google.genai import types
 
 from ...agents import create_squire_agent
 from ...callbacks.risk_gate import ADK_INTERNAL_TOOLS, build_pattern_analyzer, create_risk_gate
-from ...config import GuardrailsConfig
 from ...tools import TOOL_RISK_LEVELS
+from ...types import RiskGateFactory
+from .. import dependencies as deps
 from ..dependencies import get_app_config, get_db, get_llm_config, get_registry
 from ..schemas import ChatSessionResponse
 
@@ -122,10 +123,10 @@ async def create_chat_session(
     runner = InMemoryRunner(app_name=app_config.app_name, app=adk_app)
 
     # Build risk evaluation pipeline
-    guardrails = GuardrailsConfig()
+    guardrails = deps.guardrails
     rule_gate = RuleGate(
-        threshold=app_config.risk_tolerance,
-        strict=app_config.risk_strict,
+        threshold=guardrails.risk_tolerance,
+        strict=guardrails.risk_strict,
         allowed=set(guardrails.tools_allow),
         approve=set(guardrails.tools_require_approval),
         denied=set(guardrails.tools_deny),
@@ -163,7 +164,6 @@ async def chat_websocket(
     # FastAPI parameter injection for WebSocket endpoints).
     skill_name = websocket.query_params.get("skill") or None
 
-    from .. import dependencies as deps
     from ..app import get_latest_snapshot
 
     app_config = deps.get_app_config()
@@ -175,13 +175,16 @@ async def chat_websocket(
     # Create approval bridge for this WebSocket connection
     approval_bridge = WebApprovalBridge(websocket)
 
-    # Build agent with approval bridge wired in
-    def _make_risk_gate(tool_risk_levels: dict[str, int]):
-        guardrails = GuardrailsConfig()
+    # Build agent with approval bridge wired in.
+    # For multi-agent, each sub-agent gets its own factory with per-agent tolerance.
+    guardrails_snapshot = deps.guardrails
+
+    def _make_risk_gate(tool_risk_levels: dict[str, int], agent_tolerance: int | None = None):
         return create_risk_gate(
             tool_risk_levels=tool_risk_levels,
-            risk_overrides=dict(guardrails.tools_risk_overrides),
+            risk_overrides=dict(guardrails_snapshot.tools_risk_overrides),
             approval_provider=approval_bridge,
+            default_threshold=agent_tolerance,
         )
 
     # Skills require direct tool access, so always use single-agent mode
@@ -190,16 +193,34 @@ async def chat_websocket(
     use_multi_agent = app_config.multi_agent and not skill_name
 
     if use_multi_agent:
+        agent_tolerances = {
+            "Monitor": guardrails_snapshot.monitor_tolerance,
+            "Container": guardrails_snapshot.container_tolerance,
+            "Admin": guardrails_snapshot.admin_tolerance,
+            "Notifier": guardrails_snapshot.notifier_tolerance,
+        }
+
+        def _resolve_threshold(name: str) -> int | None:
+            tol = agent_tolerances.get(name)
+            return RuleGate(threshold=tol).threshold if tol else None
+
+        def _per_agent_factory(agent_name: str) -> RiskGateFactory:
+            threshold = _resolve_threshold(agent_name)
+
+            def factory(tool_risk_levels: dict[str, int]):
+                return _make_risk_gate(tool_risk_levels, agent_tolerance=threshold)
+
+            return factory
+
         agent = create_squire_agent(
             app_config=app_config,
             llm_config=llm_config,
-            risk_gate_factory=_make_risk_gate,
+            risk_gate_factory_builder=_per_agent_factory,
         )
     else:
-        guardrails_for_gate = GuardrailsConfig()
         risk_gate_callback = create_risk_gate(
             tool_risk_levels=TOOL_RISK_LEVELS,
-            risk_overrides=dict(guardrails_for_gate.tools_risk_overrides),
+            risk_overrides=dict(deps.guardrails.tools_risk_overrides),
             approval_provider=approval_bridge,
         )
         # Override multi_agent so create_squire_agent takes the
@@ -215,10 +236,10 @@ async def chat_websocket(
     runner = InMemoryRunner(app_name=app_config.app_name, app=adk_app)
 
     # Build session state
-    guardrails = GuardrailsConfig()
+    guardrails = deps.guardrails
     rule_gate = RuleGate(
-        threshold=app_config.risk_tolerance,
-        strict=app_config.risk_strict,
+        threshold=guardrails.risk_tolerance,
+        strict=guardrails.risk_strict,
         allowed=set(guardrails.tools_allow),
         approve=set(guardrails.tools_require_approval),
         denied=set(guardrails.tools_deny),

--- a/src/squire/api/routers/config.py
+++ b/src/squire/api/routers/config.py
@@ -13,6 +13,7 @@ from squire.config.notifications import EmailConfig, WebhookConfig
 from squire.config.skills import SkillsConfig
 from squire.notifications.factory import build_notification_router
 from squire.skills import SkillService
+from squire.tools import set_guardrails as tools_set_guardrails
 from squire.tools import set_notifier as tools_set_notifier
 
 from .. import dependencies as deps
@@ -253,6 +254,9 @@ async def patch_config(
         tools_set_notifier(deps.notifier)
         if old_notifier is not None:
             await old_notifier.close()
+
+    if section == "guardrails":
+        tools_set_guardrails(new_config)
 
     if section == "skills":
         deps.skills_service = SkillService(new_config.path)

--- a/src/squire/api/routers/watch.py
+++ b/src/squire/api/routers/watch.py
@@ -7,7 +7,7 @@ import os
 from agent_risk_engine import RuleGate
 from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
 
-from ..dependencies import get_app_config, get_db, get_guardrails, get_watch_config
+from ..dependencies import get_db, get_guardrails, get_watch_config
 from ..schemas import (
     WatchApprovalAction,
     WatchCommandResponse,
@@ -19,9 +19,9 @@ from ..schemas import (
 router = APIRouter()
 
 
-def _effective_watch_risk_level(guardrails, app_config) -> int:
+def _effective_watch_risk_level(guardrails) -> int:
     """Numeric risk threshold (1–5) used in watch mode UI and live updates."""
-    wt = guardrails.watch_tolerance or app_config.risk_tolerance
+    wt = guardrails.watch_tolerance or guardrails.risk_tolerance
     return RuleGate(threshold=wt, strict=True, allowed=set(), denied=set()).threshold
 
 
@@ -123,7 +123,6 @@ async def watch_stop(db=Depends(get_db)):
 async def watch_config_get(
     watch_config=Depends(get_watch_config),
     guardrails=Depends(get_guardrails),
-    app_config=Depends(get_app_config),
 ):
     """Get current watch configuration."""
     return WatchConfigResponse(
@@ -135,7 +134,7 @@ async def watch_config_get(
         notify_on_blocked=watch_config.notify_on_blocked,
         cycles_per_session=watch_config.cycles_per_session,
         max_context_events=watch_config.max_context_events,
-        risk_tolerance=_effective_watch_risk_level(guardrails, app_config),
+        risk_tolerance=_effective_watch_risk_level(guardrails),
     )
 
 

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -228,8 +228,6 @@ class ConfigDetailResponse(BaseModel):
 class AppConfigUpdate(BaseModel):
     app_name: str | None = None
     user_id: str | None = None
-    risk_tolerance: str | None = None
-    risk_strict: bool | None = None
     history_limit: int | None = None
     max_tool_rounds: int | None = None
     multi_agent: bool | None = None
@@ -254,6 +252,8 @@ class WatchConfigPatch(BaseModel):
 
 
 class GuardrailsConfigUpdate(BaseModel):
+    risk_tolerance: str | None = None
+    risk_strict: bool | None = None
     tools_allow: list[str] | None = None
     tools_require_approval: list[str] | None = None
     tools_deny: list[str] | None = None

--- a/src/squire/callbacks/risk_gate.py
+++ b/src/squire/callbacks/risk_gate.py
@@ -128,11 +128,11 @@ def create_risk_gate(
         action = Action(kind="tool_call", name=compound_name, parameters=args, risk=tool_risk)
         result = await evaluator.evaluate(action)
 
-        # The PatternAnalyzer may have escalated risk beyond what the RuleGate
-        # saw (which only used the static tool_risk). If the analyzed risk now
-        # exceeds the threshold, treat it as NEEDS_APPROVAL so the existing
-        # approval/headless flow handles it.
-        risk_threshold = tool_context.state.get("risk_tolerance", 3)
+        # Use per-agent threshold when provided, otherwise fall back to session state.
+        if default_threshold is not None:
+            risk_threshold = default_threshold
+        else:
+            risk_threshold = tool_context.state.get("risk_tolerance", 3)
         analyzer_escalated = result.decision == GateResult.ALLOWED and result.risk_score.level > risk_threshold
 
         if result.decision == GateResult.DENIED:

--- a/src/squire/config/app.py
+++ b/src/squire/config/app.py
@@ -1,8 +1,8 @@
 from enum import StrEnum
 from importlib.metadata import version as _pkg_version
-from typing import Annotated, Any
+from typing import Any
 
-from pydantic import BeforeValidator, Field
+from pydantic import Field
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 from .loader import TomlSectionSource, get_top_level
@@ -70,14 +70,6 @@ class AppConfig(BaseSettings):
     user_id: str = Field(
         default="squire-user",
         description="User ID for ADK session management",
-    )
-    risk_tolerance: Annotated[RiskTolerance, BeforeValidator(_coerce_risk_tolerance)] = Field(
-        default=RiskTolerance.CAUTIOUS,
-        description="Risk tolerance (1-5 or alias: read-only, cautious, standard, full-trust)",
-    )
-    risk_strict: bool = Field(
-        default=False,
-        description="When true, tools above tolerance are denied outright instead of prompting for approval",
     )
     history_limit: int = Field(
         default=50,

--- a/src/squire/config/guardrails.py
+++ b/src/squire/config/guardrails.py
@@ -40,6 +40,17 @@ class GuardrailsConfig(BaseSettings):
             file_secret_settings,
         )
 
+    # --- Global risk policy ---
+
+    risk_tolerance: Annotated[RiskTolerance, BeforeValidator(_coerce_risk_tolerance)] = Field(
+        default=RiskTolerance.CAUTIOUS,
+        description="Risk tolerance (1-5 or alias: read-only, cautious, standard, full-trust)",
+    )
+    risk_strict: bool = Field(
+        default=False,
+        description="When true, tools above tolerance are denied outright instead of prompting for approval",
+    )
+
     # --- Tool-level overrides ---
 
     tools_allow: list[str] = Field(
@@ -82,18 +93,45 @@ class GuardrailsConfig(BaseSettings):
 
     commands_allow: list[str] = Field(
         default_factory=lambda: [
+            # File / directory listing
+            "ls",
+            "stat",
+            "file",
+            "du",
+            "find",
+            "wc",
+            # Text reading
+            "cat",
+            "head",
+            "tail",
+            "grep",
+            # System info
+            "hostname",
+            "date",
+            "whoami",
+            "id",
+            "uname",
+            "uptime",
+            "df",
+            "free",
+            "mount",
+            "lsblk",
+            "top",
+            "ps",
+            "which",
+            # Network diagnostics
             "ping",
             "traceroute",
             "dig",
             "nslookup",
-            "df",
-            "free",
-            "uptime",
             "ip",
             "ss",
-            "cat",
-            "head",
-            "tail",
+            "netstat",
+            # Service management (read-only actions guarded by risk levels)
+            "docker",
+            "systemctl",
+            "journalctl",
+            "lsof",
         ],
         description="Commands that run_command is allowed to execute",
     )

--- a/src/squire/tools/__init__.py
+++ b/src/squire/tools/__init__.py
@@ -16,9 +16,11 @@ Tool conventions:
 """
 
 from ._registry import get_db as get_db
+from ._registry import get_guardrails as get_guardrails
 from ._registry import get_notifier as get_notifier
 from ._registry import get_registry as get_registry
 from ._registry import set_db as set_db
+from ._registry import set_guardrails as set_guardrails
 from ._registry import set_notifier as set_notifier
 from ._registry import set_registry as set_registry
 from ._safe import safe_tool

--- a/src/squire/tools/_registry.py
+++ b/src/squire/tools/_registry.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from ..config import GuardrailsConfig
     from ..database.service import DatabaseService
     from ..notifications.webhook import WebhookDispatcher
     from ..system.registry import BackendRegistry
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
 _registry: BackendRegistry | None = None
 _db: DatabaseService | None = None
 _notifier: WebhookDispatcher | None = None
+_guardrails: GuardrailsConfig | None = None
 
 
 def set_registry(registry: BackendRegistry | None) -> None:
@@ -68,3 +70,22 @@ def get_notifier():
     Returns None if not set — callers should handle gracefully.
     """
     return _notifier
+
+
+def set_guardrails(guardrails: GuardrailsConfig | None) -> None:
+    """Set the global guardrails config (called at startup and after PATCH)."""
+    global _guardrails
+    _guardrails = guardrails
+
+
+def get_guardrails():
+    """Return the live guardrails config.
+
+    Falls back to a freshly loaded instance if none has been set
+    (e.g. during tests or standalone CLI usage).
+    """
+    if _guardrails is None:
+        from ..config import GuardrailsConfig
+
+        return GuardrailsConfig()
+    return _guardrails

--- a/src/squire/tools/read_config.py
+++ b/src/squire/tools/read_config.py
@@ -3,19 +3,9 @@
 import os
 import posixpath
 
-from ..config import GuardrailsConfig
-from ._registry import get_registry
+from ._registry import get_guardrails, get_registry
 
 RISK_LEVEL = 2  # Low
-
-_guardrails_config: GuardrailsConfig | None = None
-
-
-def _get_guardrails_config() -> GuardrailsConfig:
-    global _guardrails_config
-    if _guardrails_config is None:
-        _guardrails_config = GuardrailsConfig()
-    return _guardrails_config
 
 
 async def read_config(path: str, head: int | None = None, host: str = "local") -> str:
@@ -32,8 +22,7 @@ async def read_config(path: str, head: int | None = None, host: str = "local") -
 
     Returns the file contents as text.
     """
-    # Resolve and check path guards
-    guardrails = _get_guardrails_config()
+    guardrails = get_guardrails()
     allowlist = guardrails.config_paths
     if allowlist:
         if host == "local":

--- a/src/squire/tools/run_command.py
+++ b/src/squire/tools/run_command.py
@@ -2,19 +2,9 @@
 
 import shlex
 
-from ..config import GuardrailsConfig
-from ._registry import get_registry
+from ._registry import get_guardrails, get_registry
 
 RISK_LEVEL = 5  # Critical
-
-_guardrails_config: GuardrailsConfig | None = None
-
-
-def _get_guardrails_config() -> GuardrailsConfig:
-    global _guardrails_config
-    if _guardrails_config is None:
-        _guardrails_config = GuardrailsConfig()
-    return _guardrails_config
 
 
 async def run_command(command: str, timeout: float = 30.0, host: str = "local") -> str:
@@ -41,7 +31,7 @@ async def run_command(command: str, timeout: float = 30.0, host: str = "local") 
 
     base_cmd = parts[0]
 
-    guardrails = _get_guardrails_config()
+    guardrails = get_guardrails()
 
     # Check blocklist first
     if base_cmd in guardrails.commands_block:

--- a/src/squire/types.py
+++ b/src/squire/types.py
@@ -11,3 +11,6 @@ BeforeToolCallback = Callable[[BaseTool, dict[str, Any], ToolContext], Any]
 
 # Factory that creates a scoped BeforeToolCallback from a tool risk levels dict
 RiskGateFactory = Callable[[dict[str, int]], BeforeToolCallback]
+
+# Builder that returns a per-agent RiskGateFactory given the agent name
+RiskGateFactoryBuilder = Callable[[str], RiskGateFactory]

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -187,7 +187,7 @@ async def start_watch() -> None:
 
     # Build the risk evaluation pipeline
     guardrails = GuardrailsConfig()
-    watch_tolerance = guardrails.watch_tolerance or app_config.risk_tolerance
+    watch_tolerance = guardrails.watch_tolerance or guardrails.risk_tolerance
     rule_gate = RuleGate(
         threshold=watch_tolerance,
         strict=True,  # Always strict in watch mode — deny, don't prompt
@@ -200,19 +200,36 @@ async def start_watch() -> None:
     # Build the agent with headless risk gate
     block_notifier = notifier if watch_config.notify_on_blocked else None
 
-    def _make_headless_risk_gate(tool_risk_levels: dict[str, int]):
+    def _make_headless_risk_gate(tool_risk_levels: dict[str, int], agent_threshold: int | None = None):
         return create_risk_gate(
             tool_risk_levels=tool_risk_levels,
             risk_overrides=dict(guardrails.tools_risk_overrides),
+            default_threshold=agent_threshold,
             headless=True,
             notifier=block_notifier,
         )
 
     if app_config.multi_agent:
+        agent_tolerances = {
+            "Monitor": guardrails.monitor_tolerance,
+            "Container": guardrails.container_tolerance,
+            "Admin": guardrails.admin_tolerance,
+            "Notifier": guardrails.notifier_tolerance,
+        }
+
+        def _per_agent_builder(agent_name: str):
+            tol = agent_tolerances.get(agent_name)
+            threshold = RuleGate(threshold=tol).threshold if tol else None
+
+            def factory(tool_risk_levels: dict[str, int]):
+                return _make_headless_risk_gate(tool_risk_levels, agent_threshold=threshold)
+
+            return factory
+
         agent = create_squire_agent(
             app_config=app_config,
             llm_config=llm_config,
-            risk_gate_factory=_make_headless_risk_gate,
+            risk_gate_factory_builder=_per_agent_builder,
         )
     else:
         agent = create_squire_agent(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,15 +18,8 @@ class TestAppConfig:
         monkeypatch.setattr(loader_mod, "_cached", {})
         config = AppConfig()
         assert config.app_name == "Squire"
-        assert config.risk_tolerance == "cautious"
         assert config.history_limit == 50
         assert config.max_tool_rounds == 10
-
-    def test_env_override(self, monkeypatch):
-        monkeypatch.setattr(loader_mod, "_cached", {})
-        monkeypatch.setenv("SQUIRE_RISK_TOLERANCE", "full-trust")
-        config = AppConfig()
-        assert config.risk_tolerance == "full-trust"
 
 
 class TestLLMConfig:
@@ -46,11 +39,20 @@ class TestGuardrailsConfig:
     def test_defaults(self, monkeypatch):
         monkeypatch.setattr(loader_mod, "_cached", {})
         config = GuardrailsConfig()
+        assert config.risk_tolerance == "cautious"
+        assert config.risk_strict is False
+        assert "ls" in config.commands_allow
         assert "ping" in config.commands_allow
         assert "rm" in config.commands_block
         assert config.tools_allow == []
         assert config.tools_require_approval == []
         assert config.tools_deny == []
+
+    def test_risk_tolerance_env_override(self, monkeypatch):
+        monkeypatch.setattr(loader_mod, "_cached", {})
+        monkeypatch.setenv("SQUIRE_GUARDRAILS_RISK_TOLERANCE", "full-trust")
+        config = GuardrailsConfig()
+        assert config.risk_tolerance == "full-trust"
 
     def test_config_paths_empty_by_default(self, monkeypatch):
         monkeypatch.setattr(loader_mod, "_cached", {})
@@ -116,10 +118,10 @@ class TestTomlLoading:
         monkeypatch.setattr(loader_mod, "_cached", data)
 
     def test_app_config_from_toml(self, monkeypatch):
-        self._patch_toml(monkeypatch, {"risk_tolerance": "full-trust", "history_limit": 100})
+        self._patch_toml(monkeypatch, {"history_limit": 100, "max_tool_rounds": 5})
         config = AppConfig()
-        assert config.risk_tolerance == "full-trust"
         assert config.history_limit == 100
+        assert config.max_tool_rounds == 5
 
     def test_llm_config_from_toml(self, monkeypatch):
         self._patch_toml(monkeypatch, {"llm": {"model": "anthropic/claude-sonnet-4-20250514", "temperature": 0.5}})
@@ -181,11 +183,17 @@ class TestTomlLoading:
         config = NotificationsConfig()
         assert config.enabled is True
 
-    def test_env_overrides_toml(self, monkeypatch):
+    def test_guardrails_risk_tolerance_from_toml(self, monkeypatch):
+        """risk_tolerance now lives in [guardrails]."""
+        self._patch_toml(monkeypatch, {"guardrails": {"risk_tolerance": "full-trust"}})
+        config = GuardrailsConfig()
+        assert config.risk_tolerance == "full-trust"
+
+    def test_env_overrides_guardrails_risk_tolerance(self, monkeypatch):
         """Env vars should take precedence over TOML values."""
-        self._patch_toml(monkeypatch, {"risk_tolerance": "full-trust"})
-        monkeypatch.setenv("SQUIRE_RISK_TOLERANCE", "read-only")
-        config = AppConfig()
+        self._patch_toml(monkeypatch, {"guardrails": {"risk_tolerance": "full-trust"}})
+        monkeypatch.setenv("SQUIRE_GUARDRAILS_RISK_TOLERANCE", "read-only")
+        config = GuardrailsConfig()
         assert config.risk_tolerance == "read-only"
 
     def test_unknown_toml_keys_ignored(self, monkeypatch):
@@ -242,11 +250,11 @@ class TestHostConfig:
 
 class TestLoaderUtilities:
     def test_get_env_overrides_detects_set_vars(self, monkeypatch):
-        monkeypatch.setenv("SQUIRE_RISK_TOLERANCE", "full-trust")
         monkeypatch.setenv("SQUIRE_HISTORY_LIMIT", "100")
-        result = get_env_overrides("SQUIRE_", ["risk_tolerance", "history_limit", "multi_agent"])
-        assert "risk_tolerance" in result
+        monkeypatch.setenv("SQUIRE_MAX_TOOL_ROUNDS", "5")
+        result = get_env_overrides("SQUIRE_", ["history_limit", "max_tool_rounds", "multi_agent"])
         assert "history_limit" in result
+        assert "max_tool_rounds" in result
         assert "multi_agent" not in result
 
     def test_get_env_overrides_empty_when_none_set(self):

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -40,12 +40,11 @@ class TestGetConfig:
     async def test_returns_env_overrides(self, monkeypatch):
         from squire.api.routers.config import get_config
 
-        monkeypatch.setenv("SQUIRE_RISK_TOLERANCE", "full-trust")
-        # Recreate config so the env var is picked up
-        monkeypatch.setattr(deps, "app_config", AppConfig())
+        monkeypatch.setenv("SQUIRE_GUARDRAILS_RISK_TOLERANCE", "full-trust")
+        monkeypatch.setattr(deps, "guardrails", GuardrailsConfig())
 
         result = await get_config(app_config=deps.app_config, llm_config=deps.llm_config)
-        assert "risk_tolerance" in result.app.env_overrides
+        assert "risk_tolerance" in result.guardrails.env_overrides
 
     async def test_returns_section_values(self):
         from squire.api.routers.config import get_config
@@ -71,12 +70,12 @@ class TestGetConfig:
 
 @pytest.mark.usefixtures("_setup_deps")
 class TestPatchConfig:
-    async def test_patch_app_updates_in_memory(self):
+    async def test_patch_guardrails_risk_tolerance(self):
         from squire.api.routers.config import patch_config
 
-        result = await patch_config("app", {"risk_tolerance": "full-trust"}, persist=False)
+        result = await patch_config("guardrails", {"risk_tolerance": "full-trust"}, persist=False)
         assert result["values"]["risk_tolerance"] == "full-trust"
-        assert deps.app_config.risk_tolerance == "full-trust"
+        assert deps.guardrails.risk_tolerance == "full-trust"
 
     async def test_patch_llm_updates_in_memory(self):
         from squire.api.routers.config import patch_config
@@ -104,11 +103,11 @@ class TestPatchConfig:
 
         from squire.api.routers.config import patch_config
 
-        monkeypatch.setenv("SQUIRE_RISK_TOLERANCE", "read-only")
+        monkeypatch.setenv("SQUIRE_GUARDRAILS_RISK_TOLERANCE", "read-only")
         with pytest.raises(HTTPException) as exc_info:
-            await patch_config("app", {"risk_tolerance": "full-trust"}, persist=False)
+            await patch_config("guardrails", {"risk_tolerance": "full-trust"}, persist=False)
         assert exc_info.value.status_code == 409
-        assert "SQUIRE_RISK_TOLERANCE" in exc_info.value.detail
+        assert "SQUIRE_GUARDRAILS_RISK_TOLERANCE" in exc_info.value.detail
 
     async def test_strips_redacted_sentinel(self):
         from squire.api.routers.config import patch_config

--- a/tests/test_tools/test_run_command.py
+++ b/tests/test_tools/test_run_command.py
@@ -1,19 +1,22 @@
 """Tests for run_command tool with mocked backend."""
 
-import sys
-
 import pytest
 
 from squire.config import GuardrailsConfig
 from squire.system.backend import CommandResult
-from squire.tools import run_command
+from squire.tools import run_command, set_guardrails
 
-_mod = sys.modules["squire.tools.run_command"]
+
+@pytest.fixture(autouse=True)
+def _default_guardrails():
+    """Ensure run_command sees a fresh default GuardrailsConfig."""
+    set_guardrails(GuardrailsConfig())
+    yield
+    set_guardrails(None)
 
 
 @pytest.mark.asyncio
-async def test_allowed_command(mock_backend, mock_registry, monkeypatch):
-    monkeypatch.setattr(_mod, "_guardrails_config", GuardrailsConfig())
+async def test_allowed_command(mock_backend, mock_registry):
     mock_backend.set_response("ping", CommandResult(returncode=0, stdout="PING ok\n", stderr=""))
 
     result = await run_command("ping -c 1 localhost")
@@ -21,17 +24,15 @@ async def test_allowed_command(mock_backend, mock_registry, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_denied_command(monkeypatch):
-    config = GuardrailsConfig(commands_block=["rm"], commands_allow=[])
-    monkeypatch.setattr(_mod, "_guardrails_config", config)
+async def test_denied_command():
+    set_guardrails(GuardrailsConfig(commands_block=["rm"], commands_allow=[]))
     result = await run_command("rm -rf /")
     assert "DENIED" in result
 
 
 @pytest.mark.asyncio
-async def test_unlisted_command(monkeypatch):
-    config = GuardrailsConfig(commands_allow=["ping"], commands_block=[])
-    monkeypatch.setattr(_mod, "_guardrails_config", config)
+async def test_unlisted_command():
+    set_guardrails(GuardrailsConfig(commands_allow=["ping"], commands_block=[]))
     result = await run_command("curl http://example.com")
     assert "DENIED" in result
 
@@ -49,9 +50,8 @@ async def test_invalid_syntax():
 
 
 @pytest.mark.asyncio
-async def test_run_command_with_host_param(mock_backend, mock_registry, monkeypatch):
+async def test_run_command_with_host_param(mock_backend, mock_registry):
     """The host parameter should be accepted."""
-    monkeypatch.setattr(_mod, "_guardrails_config", GuardrailsConfig())
     mock_backend.set_response("ping", CommandResult(returncode=0, stdout="PING ok\n", stderr=""))
 
     result = await run_command("ping -c 1 localhost", host="local")

--- a/tests/test_web_static_dir.py
+++ b/tests/test_web_static_dir.py
@@ -1,0 +1,15 @@
+"""Tests for Next.js static bundle path resolution."""
+
+from pathlib import Path
+
+import pytest
+
+from squire.api import app as app_mod
+
+
+def test_find_static_dir_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "index.html").write_text("<html></html>", encoding="utf-8")
+    monkeypatch.setenv("SQUIRE_WEB_STATIC_DIR", str(out))
+    assert app_mod._find_static_dir() == out.resolve()

--- a/web/src/app/config/page.tsx
+++ b/web/src/app/config/page.tsx
@@ -27,7 +27,16 @@ export default function ConfigPage() {
 
   return (
     <div className="space-y-6 animate-fade-in-up">
-      <h1 className="text-2xl">Configuration</h1>
+      <div className="space-y-2">
+        <h1 className="text-2xl">Configuration</h1>
+        <p className="max-w-3xl text-sm text-muted-foreground">
+          In-memory settings update the running web process when you save. Use <strong>Save to disk</strong> on each tab
+          to write <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">squire.toml</code> (when a path is
+          known). Environment variables override TOML—see the banner above the tabs when any apply. Watch-only options
+          need a running watch or restart to take effect there; database path and LLM secrets need a full process
+          restart.
+        </p>
+      </div>
       <ConfigEditor config={config} onSaved={() => mutate()} />
     </div>
   );

--- a/web/src/components/config/app-config-form.tsx
+++ b/web/src/components/config/app-config-form.tsx
@@ -6,13 +6,6 @@ import { apiPatch } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import {
   Tooltip,
@@ -20,7 +13,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfigHint, ConfigIntro } from "./config-help";
 
 interface AppConfigFormProps {
   values: Record<string, unknown>;
@@ -28,13 +22,6 @@ interface AppConfigFormProps {
   tomlPath: string | null;
   onSaved: () => void;
 }
-
-const RISK_OPTIONS = [
-  { value: "read-only", label: "Read Only" },
-  { value: "cautious", label: "Cautious" },
-  { value: "standard", label: "Standard" },
-  { value: "full-trust", label: "Full Trust" },
-];
 
 function EnvLock({ field, prefix }: { field: string; prefix: string }) {
   return (
@@ -54,8 +41,6 @@ function EnvLock({ field, prefix }: { field: string; prefix: string }) {
 export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppConfigFormProps) {
   const [appName, setAppName] = useState(String(values.app_name ?? "Squire"));
   const [userId, setUserId] = useState(String(values.user_id ?? "squire-user"));
-  const [riskTolerance, setRiskTolerance] = useState(String(values.risk_tolerance ?? "cautious"));
-  const [riskStrict, setRiskStrict] = useState(Boolean(values.risk_strict));
   const [historyLimit, setHistoryLimit] = useState(Number(values.history_limit ?? 50));
   const [maxToolRounds, setMaxToolRounds] = useState(Number(values.max_tool_rounds ?? 10));
   const [multiAgent, setMultiAgent] = useState(Boolean(values.multi_agent));
@@ -68,8 +53,6 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
   const isDirty =
     appName !== String(values.app_name ?? "Squire") ||
     userId !== String(values.user_id ?? "squire-user") ||
-    riskTolerance !== String(values.risk_tolerance ?? "cautious") ||
-    riskStrict !== Boolean(values.risk_strict) ||
     historyLimit !== Number(values.history_limit ?? 50) ||
     maxToolRounds !== Number(values.max_tool_rounds ?? 10) ||
     multiAgent !== Boolean(values.multi_agent);
@@ -77,8 +60,6 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
   const revert = () => {
     setAppName(String(values.app_name ?? "Squire"));
     setUserId(String(values.user_id ?? "squire-user"));
-    setRiskTolerance(String(values.risk_tolerance ?? "cautious"));
-    setRiskStrict(Boolean(values.risk_strict));
     setHistoryLimit(Number(values.history_limit ?? 50));
     setMaxToolRounds(Number(values.max_tool_rounds ?? 10));
     setMultiAgent(Boolean(values.multi_agent));
@@ -92,8 +73,6 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
       const changed: Record<string, unknown> = {};
       if (appName !== String(values.app_name ?? "Squire")) changed.app_name = appName;
       if (userId !== String(values.user_id ?? "squire-user")) changed.user_id = userId;
-      if (riskTolerance !== String(values.risk_tolerance ?? "cautious")) changed.risk_tolerance = riskTolerance;
-      if (riskStrict !== Boolean(values.risk_strict)) changed.risk_strict = riskStrict;
       if (historyLimit !== Number(values.history_limit ?? 50)) changed.history_limit = historyLimit;
       if (maxToolRounds !== Number(values.max_tool_rounds ?? 10)) changed.max_tool_rounds = maxToolRounds;
       if (multiAgent !== Boolean(values.multi_agent)) changed.multi_agent = multiAgent;
@@ -112,8 +91,17 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
     <Card>
       <CardHeader>
         <CardTitle className="text-base">App</CardTitle>
+        <CardDescription>
+          Identity and session behavior. Affects new and ongoing chat sessions.
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <ConfigIntro title="When changes apply">
+          <p>
+            Saving updates the running API server immediately for new and ongoing chat sessions. Check{" "}
+            <strong>Save to disk</strong> below to write values into <code>squire.toml</code> when a file is found.
+          </p>
+        </ConfigIntro>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>App name</Label>
@@ -125,7 +113,7 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
             disabled={isLocked("app_name")}
             className="text-sm"
           />
-          <p className="text-xs text-muted-foreground">Passed to the ADK runner as the application name.</p>
+          <ConfigHint>Application name registered with the ADK runner (sessions and tooling see this label).</ConfigHint>
         </div>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
@@ -138,43 +126,11 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
             disabled={isLocked("user_id")}
             className="text-sm font-mono"
           />
-          <p className="text-xs text-muted-foreground">ADK session scope for this Squire instance.</p>
+          <ConfigHint>
+            User scope for ADK session storage. Changing it starts a new logical user; use only if you intentionally
+            want to separate sessions.
+          </ConfigHint>
         </div>
-        <div className="space-y-2">
-          <div className="flex items-center gap-1.5">
-            <Label>Risk Tolerance</Label>
-            {isLocked("risk_tolerance") && <EnvLock field="risk_tolerance" prefix="SQUIRE_" />}
-          </div>
-          <Select
-            value={riskTolerance}
-            onValueChange={(v) => v && setRiskTolerance(v)}
-            disabled={isLocked("risk_tolerance")}
-          >
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {RISK_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <Label>Risk Strict</Label>
-            {isLocked("risk_strict") && <EnvLock field="risk_strict" prefix="SQUIRE_" />}
-          </div>
-          <Switch
-            checked={riskStrict}
-            onCheckedChange={setRiskStrict}
-            disabled={isLocked("risk_strict")}
-          />
-        </div>
-
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>History Limit</Label>
@@ -187,6 +143,10 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
             onChange={(e) => setHistoryLimit(parseInt(e.target.value) || 1)}
             disabled={isLocked("history_limit")}
           />
+          <ConfigHint>
+            Maximum chat messages kept in context for the model. Lower values reduce token use; higher values preserve
+            longer conversations.
+          </ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -201,24 +161,34 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
             onChange={(e) => setMaxToolRounds(parseInt(e.target.value) || 1)}
             disabled={isLocked("max_tool_rounds")}
           />
+          <ConfigHint>
+            Cap on tool-call iterations per single user message. Stops runaway tool loops; raise if the model often needs
+            many steps to finish one request.
+          </ConfigHint>
         </div>
 
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <Label>Multi-Agent</Label>
-            {isLocked("multi_agent") && <EnvLock field="multi_agent" prefix="SQUIRE_" />}
+        <div className="space-y-2 rounded-md border border-border/60 bg-muted/20 px-3 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-1.5">
+              <Label>Multi-Agent</Label>
+              {isLocked("multi_agent") && <EnvLock field="multi_agent" prefix="SQUIRE_" />}
+            </div>
+            <Switch
+              checked={multiAgent}
+              onCheckedChange={setMultiAgent}
+              disabled={isLocked("multi_agent")}
+            />
           </div>
-          <Switch
-            checked={multiAgent}
-            onCheckedChange={setMultiAgent}
-            disabled={isLocked("multi_agent")}
-          />
+          <ConfigHint>
+            When enabled, requests can be routed to specialized internal agents (still presented as one assistant in the
+            UI). Uses more model calls; can improve focus for mixed tasks.
+          </ConfigHint>
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}
 
         <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
             <input
               type="checkbox"
               checked={persist}
@@ -226,7 +196,10 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
               disabled={!tomlPath}
               className="rounded"
             />
-            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+            <span>
+              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — also writes{" "}
+              <code className="font-mono text-[11px]">squire.toml</code> so values survive restart.
+            </span>
           </label>
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>

--- a/web/src/components/config/config-editor.tsx
+++ b/web/src/components/config/config-editor.tsx
@@ -12,6 +12,7 @@ import { LLMConfigForm } from "./llm-config-form";
 import { WatchConfigForm } from "./watch-config-form";
 import { GuardrailsConfigForm } from "./guardrails-config-form";
 import { SkillsConfigForm } from "./skills-config-form";
+import { ConfigEnvOverrideNotice, ConfigIntro } from "./config-help";
 
 interface ConfigEditorProps {
   config: ConfigDetailResponse;
@@ -92,7 +93,9 @@ function ReadOnlySection({
 
 export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
   return (
-    <Tabs defaultValue="app">
+    <div className="space-y-4">
+      <ConfigEnvOverrideNotice config={config} />
+      <Tabs defaultValue="app">
       <TabsList className="flex flex-wrap">
         <TabsTrigger value="app">App</TabsTrigger>
         <TabsTrigger value="llm">LLM</TabsTrigger>
@@ -139,7 +142,16 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
       </TabsContent>
 
       <TabsContent value="notifications">
-        <ChannelsTab />
+        <div className="space-y-4">
+          <ConfigIntro title="What this controls">
+            <p>
+              Turn channels on or off, add webhooks, and configure email. Saving updates the running server immediately
+              and rebuilds notification delivery. Use <strong>Save</strong> on this page to persist to{" "}
+              <code>squire.toml</code> when a config file is present.
+            </p>
+          </ConfigIntro>
+          <ChannelsTab />
+        </div>
       </TabsContent>
 
       <TabsContent value="guardrails">
@@ -170,8 +182,17 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
       </TabsContent>
 
       <TabsContent value="hosts">
-        <ReadOnlySection title="Hosts" data={config.hosts} />
+        <div className="space-y-4">
+          <ConfigIntro title="Hosts">
+            <p>
+              Read-only snapshot of managed hosts. Add, remove, or enroll hosts on the <strong>Hosts</strong> page;
+              refresh this page (or revisit the tab) after changes to see updates here.
+            </p>
+          </ConfigIntro>
+          <ReadOnlySection title="Hosts" data={config.hosts} />
+        </div>
       </TabsContent>
     </Tabs>
+    </div>
   );
 }

--- a/web/src/components/config/config-help.tsx
+++ b/web/src/components/config/config-help.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+import type { ConfigDetailResponse } from "@/lib/types";
+
+const hintClass =
+  "text-xs text-muted-foreground leading-relaxed [&_code]:rounded-sm [&_code]:bg-muted [&_code]:px-1 [&_code]:py-px [&_code]:text-[11px] [&_code]:font-mono";
+
+/** Short explanation under a field or block. */
+export function ConfigHint({ children, className }: { children: ReactNode; className?: string }) {
+  return <p className={`${hintClass}${className ? ` ${className}` : ""}`}>{children}</p>;
+}
+
+/** Callout for section-level context (how saving works, warnings). */
+export function ConfigIntro({ title, children }: { title?: string; children: ReactNode }) {
+  return (
+    <div className="rounded-md border border-border bg-muted/40 px-4 py-3">
+      {title ? <p className="text-sm font-medium text-foreground">{title}</p> : null}
+      <div className={`${title ? "mt-1.5 " : ""}space-y-2 text-xs text-muted-foreground leading-relaxed [&_code]:rounded-sm [&_code]:bg-muted [&_code]:px-1 [&_code]:py-px [&_code]:font-mono [&_code]:text-[11px]`}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/** When any section has env-forced values, list them so users know why Save may fail or fields are locked. */
+export function ConfigEnvOverrideNotice({ config }: { config: ConfigDetailResponse }) {
+  const sections: { label: string; vars: string[] }[] = [];
+  const add = (label: string, prefix: string, keys: string[]) => {
+    if (keys.length === 0) return;
+    sections.push({ label, vars: keys.map((k) => `${prefix}${k.toUpperCase()}`) });
+  };
+
+  add("App", "SQUIRE_", config.app.env_overrides);
+  add("LLM", "SQUIRE_LLM_", config.llm.env_overrides);
+  add("Database", "SQUIRE_DB_", config.database.env_overrides);
+  add("Notifications", "SQUIRE_NOTIFICATIONS_", config.notifications.env_overrides);
+  add("Guardrails", "SQUIRE_GUARDRAILS_", config.guardrails.env_overrides);
+  add("Watch", "SQUIRE_WATCH_", config.watch.env_overrides);
+  add("Skills", "SQUIRE_SKILLS_", config.skills.env_overrides);
+
+  if (sections.length === 0) return null;
+
+  return (
+    <div className="rounded-md border border-amber-500/25 bg-amber-500/5 px-4 py-3 dark:border-amber-500/20 dark:bg-amber-500/10">
+      <p className="text-sm font-medium text-foreground">Some values are set by environment variables</p>
+      <ul className="mt-2 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+        {sections.map((s) => (
+          <li key={s.label}>
+            <span className="font-medium text-foreground">{s.label}:</span> {s.vars.join(", ")}
+          </li>
+        ))}
+      </ul>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Locked fields show a lock icon. To change them from the UI, unset the variable and restart Squire, or edit your
+        deploy configuration.
+      </p>
+    </div>
+  );
+}

--- a/web/src/components/config/guardrails-config-form.tsx
+++ b/web/src/components/config/guardrails-config-form.tsx
@@ -14,6 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import {
   Tooltip,
   TooltipContent,
@@ -21,7 +22,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Textarea } from "@/components/ui/textarea";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfigHint, ConfigIntro } from "./config-help";
 
 interface GuardrailsConfigFormProps {
   values: Record<string, unknown>;
@@ -30,12 +32,16 @@ interface GuardrailsConfigFormProps {
   onSaved: () => void;
 }
 
-const TOLERANCE_OPTIONS = [
-  { value: "", label: "Default (inherit)" },
+const RISK_OPTIONS = [
   { value: "read-only", label: "Read Only" },
   { value: "cautious", label: "Cautious" },
   { value: "standard", label: "Standard" },
   { value: "full-trust", label: "Full Trust" },
+];
+
+const TOLERANCE_OPTIONS = [
+  { value: "", label: "Default (inherit)" },
+  ...RISK_OPTIONS,
 ];
 
 function EnvLock({ field, prefix }: { field: string; prefix: string }) {
@@ -121,6 +127,8 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
   const toArr = (v: unknown): string[] => (Array.isArray(v) ? (v as string[]) : []);
   const toStr = (v: unknown): string => (v != null ? String(v) : "");
 
+  const [riskTolerance, setRiskTolerance] = useState(toStr(values.risk_tolerance) || "cautious");
+  const [riskStrict, setRiskStrict] = useState(Boolean(values.risk_strict));
   const [toolsAllow, setToolsAllow] = useState(toArr(values.tools_allow));
   const [toolsRequireApproval, setToolsRequireApproval] = useState(toArr(values.tools_require_approval));
   const [toolsDeny, setToolsDeny] = useState(toArr(values.tools_deny));
@@ -147,6 +155,8 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    setRiskTolerance(toStr(values.risk_tolerance) || "cautious");
+    setRiskStrict(Boolean(values.risk_strict));
     setToolsAllow(toArr(values.tools_allow));
     setToolsRequireApproval(toArr(values.tools_require_approval));
     setToolsDeny(toArr(values.tools_deny));
@@ -174,6 +184,8 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
   const isLocked = (field: string) => envOverrides.includes(field);
 
   const isDirty =
+    riskTolerance !== (toStr(values.risk_tolerance) || "cautious") ||
+    riskStrict !== Boolean(values.risk_strict) ||
     !arraysEqual(values.tools_allow, toolsAllow) ||
     !arraysEqual(values.tools_require_approval, toolsRequireApproval) ||
     !arraysEqual(values.tools_deny, toolsDeny) ||
@@ -190,6 +202,8 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
     toolsRiskJson.trim() !== riskOrigJson.trim();
 
   const revert = () => {
+    setRiskTolerance(toStr(values.risk_tolerance) || "cautious");
+    setRiskStrict(Boolean(values.risk_strict));
     setToolsAllow(toArr(values.tools_allow));
     setToolsRequireApproval(toArr(values.tools_require_approval));
     setToolsDeny(toArr(values.tools_deny));
@@ -227,6 +241,8 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
       }
 
       const changed: Record<string, unknown> = {};
+      if (riskTolerance !== (toStr(values.risk_tolerance) || "cautious")) changed.risk_tolerance = riskTolerance;
+      if (riskStrict !== Boolean(values.risk_strict)) changed.risk_strict = riskStrict;
       if (!arraysEqual(values.tools_allow, toolsAllow)) changed.tools_allow = toolsAllow;
       if (!arraysEqual(values.tools_require_approval, toolsRequireApproval))
         changed.tools_require_approval = toolsRequireApproval;
@@ -262,9 +278,65 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
     <Card>
       <CardHeader>
         <CardTitle className="text-base">Guardrails</CardTitle>
+        <CardDescription>
+          Global risk policy, tool lists, per-agent overrides, watch-specific policy, and command/path restrictions.
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <ConfigIntro title="How this interacts with chat and watch">
+          <p>
+            All settings here—including risk tolerance, tool lists, and command allowlists—take effect immediately for
+            new chat sessions and tool calls as soon as you save. The separate <strong>watch</strong> process loads
+            guardrails at startup; restart watch for changes to take effect there.
+          </p>
+        </ConfigIntro>
+
         <div className="space-y-2">
+          <div className="flex items-center gap-1.5">
+            <Label>Risk Tolerance</Label>
+            {isLocked("risk_tolerance") && <EnvLock field="risk_tolerance" prefix="SQUIRE_GUARDRAILS_" />}
+          </div>
+          <Select
+            value={riskTolerance}
+            onValueChange={(v) => v && setRiskTolerance(v)}
+            disabled={isLocked("risk_tolerance")}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {RISK_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <ConfigHint>
+            Global ceiling for how risky a tool may be before it needs approval. Higher tiers allow more destructive
+            actions without prompting.
+          </ConfigHint>
+        </div>
+
+        <div className="space-y-2 rounded-md border border-border/60 bg-muted/20 px-3 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-1.5">
+              <Label>Risk Strict</Label>
+              {isLocked("risk_strict") && <EnvLock field="risk_strict" prefix="SQUIRE_GUARDRAILS_" />}
+            </div>
+            <Switch
+              checked={riskStrict}
+              onCheckedChange={setRiskStrict}
+              disabled={isLocked("risk_strict")}
+            />
+          </div>
+          <ConfigHint>
+            When on, tools above your tolerance are <strong>denied outright</strong> instead of asking for approval—safer
+            for unattended or fast-moving sessions. When off, borderline tools prompt in the chat UI.
+          </ConfigHint>
+        </div>
+
+        <div className="border-t pt-4 space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>Tools Allow</Label>
             {isLocked("tools_allow") && <EnvLock field="tools_allow" prefix="SQUIRE_GUARDRAILS_" />}
@@ -275,6 +347,9 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
             disabled={isLocked("tools_allow")}
             placeholder="Tool name, press Enter"
           />
+          <ConfigHint>
+            Tool names that bypass the normal risk gate and may run without approval (use sparingly).
+          </ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -290,6 +365,7 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
             disabled={isLocked("tools_require_approval")}
             placeholder="Tool name, press Enter"
           />
+          <ConfigHint>Always prompt for approval before these tools run, even if global tolerance would allow them.</ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -303,10 +379,16 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
             disabled={isLocked("tools_deny")}
             placeholder="Tool name, press Enter"
           />
+          <ConfigHint>Hard-blocked tools: never executed, regardless of tolerance or approval UI.</ConfigHint>
         </div>
 
         <div className="border-t pt-4 space-y-3">
           <Label className="text-sm font-medium">Per-Agent Tolerance</Label>
+          <ConfigHint className="mb-1">
+            Optional per-role tolerance. When set, overrides the global Risk Tolerance above for that sub-agent. Empty
+            inherits the global value. Only applies when multi-agent mode is enabled; takes effect on the next chat
+            session.
+          </ConfigHint>
           {(
             [
               ["monitor_tolerance", "Monitor", monitorTolerance, setMonitorTolerance],
@@ -340,6 +422,10 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
 
         <div className="border-t pt-4 space-y-3">
           <Label className="text-sm font-medium">Watch Mode Overrides</Label>
+          <ConfigHint className="mb-1">
+            Policy for headless <code>squire watch</code>. Requires a watch restart to apply in the watch process; web
+            chat is unaffected.
+          </ConfigHint>
           <div className="flex items-center gap-3">
             <Label className="w-24 text-xs">Tolerance</Label>
             <Select
@@ -371,6 +457,10 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
 
         <div className="border-t pt-4 space-y-3">
           <Label className="text-sm font-medium">run_command and read_config</Label>
+          <ConfigHint className="mb-1">
+            Allowlists and blocklists for shell command basenames (not full paths). <code>read_config</code> may only read
+            under directories you list here.
+          </ConfigHint>
           <div className="space-y-2">
             <div className="flex items-center gap-1.5">
               <Label className="text-xs">Commands Allow</Label>
@@ -416,9 +506,10 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
               <EnvLock field="tools_risk_overrides" prefix="SQUIRE_GUARDRAILS_" />
             )}
           </div>
-          <p className="text-xs text-muted-foreground">
-            JSON object mapping tool names (or tool:action) to risk level integers 1–5.
-          </p>
+          <ConfigHint>
+            JSON object mapping tool names or <code>tool:action</code> keys to risk integers 1–5. Raises or lowers
+            baseline risk for specific tools; combine with allow/deny lists above.
+          </ConfigHint>
           <Textarea
             value={toolsRiskJson}
             onChange={(e) => setToolsRiskJson(e.target.value)}
@@ -431,7 +522,7 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
         {error && <p className="text-sm text-destructive">{error}</p>}
 
         <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
             <input
               type="checkbox"
               checked={persist}
@@ -439,7 +530,10 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
               disabled={!tomlPath}
               className="rounded"
             />
-            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+            <span>
+              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — writes the{" "}
+              <code className="font-mono text-[11px]">[guardrails]</code> section.
+            </span>
           </label>
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>

--- a/web/src/components/config/llm-config-form.tsx
+++ b/web/src/components/config/llm-config-form.tsx
@@ -12,7 +12,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfigHint, ConfigIntro } from "./config-help";
 
 interface LLMConfigFormProps {
   values: Record<string, unknown>;
@@ -102,8 +103,18 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
     <Card>
       <CardHeader>
         <CardTitle className="text-base">LLM</CardTitle>
+        <CardDescription>
+          LiteLLM model id and generation parameters for chat (and the web-driven agent). Takes effect on the next
+          request that builds the model client.
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <ConfigIntro title="Provider keys">
+          <p>
+            API keys for cloud providers are not stored here—configure them with environment variables as described in
+            LiteLLM. This form only changes model id, sampling, and optional base URL.
+          </p>
+        </ConfigIntro>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>Model</Label>
@@ -115,6 +126,10 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
             disabled={isLocked("model")}
             placeholder="e.g. ollama_chat/llama3.1:8b"
           />
+          <ConfigHint>
+            LiteLLM string such as <code>ollama_chat/...</code> or <code>gemini/...</code>. Must match a provider you
+            have credentials or local runtime for.
+          </ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -131,6 +146,10 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
             onChange={(e) => setTemperature(parseFloat(e.target.value) || 0)}
             disabled={isLocked("temperature")}
           />
+          <ConfigHint>
+            Randomness of completions: lower is more deterministic; higher explores more varied phrasing and tool
+            arguments.
+          </ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -145,6 +164,7 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
             onChange={(e) => setMaxTokens(parseInt(e.target.value) || 1)}
             disabled={isLocked("max_tokens")}
           />
+          <ConfigHint>Upper bound on tokens in each model response (output side). Raise if answers truncate.</ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -159,16 +179,16 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
             placeholder="e.g. http://localhost:11434 (Ollama)"
             className="font-mono text-xs"
           />
-          <p className="text-xs text-muted-foreground">
-            Optional LiteLLM API base. Provider API keys are usually set via environment variables (see LiteLLM docs).
-            Redacted values in the API response are omitted here; enter a new URL to replace the stored one.
-          </p>
+          <ConfigHint>
+            Override the default HTTP endpoint for the provider (e.g. local Ollama). Redacted values are hidden in the
+            API; type a new URL to replace the stored base. Clearing the field removes the override.
+          </ConfigHint>
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}
 
         <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
             <input
               type="checkbox"
               checked={persist}
@@ -176,7 +196,10 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
               disabled={!tomlPath}
               className="rounded"
             />
-            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+            <span>
+              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — persists the{" "}
+              <code className="font-mono text-[11px]">[llm]</code> section.
+            </span>
           </label>
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>

--- a/web/src/components/config/skills-config-form.tsx
+++ b/web/src/components/config/skills-config-form.tsx
@@ -12,7 +12,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfigHint, ConfigIntro } from "./config-help";
 
 interface SkillsConfigFormProps {
   values: Record<string, unknown>;
@@ -71,13 +72,17 @@ export function SkillsConfigForm({ values, envOverrides, tomlPath, onSaved }: Sk
     <Card>
       <CardHeader>
         <CardTitle className="text-base">Skills</CardTitle>
+        <CardDescription>
+          Filesystem root for Open Agent Skills—optional instructions the model can load for chat and watch.
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-xs text-muted-foreground">
-          Directory for Open Agent Skills (each skill in a <code className="font-mono">NAME/SKILL.md</code>{" "}
-          folder). Changes apply immediately to the API; the autonomous watch process reloads skills from disk each
-          cycle.
-        </p>
+        <ConfigIntro title="Layout and effect">
+          <p>
+            Each skill lives in <code>NAME/SKILL.md</code> under this directory. Changing the path updates the API’s
+            skill service immediately; autonomous watch re-reads skills from disk each cycle.
+          </p>
+        </ConfigIntro>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>Skills directory</Label>
@@ -89,10 +94,14 @@ export function SkillsConfigForm({ values, envOverrides, tomlPath, onSaved }: Sk
             disabled={isLocked("path")}
             className="font-mono text-xs"
           />
+          <ConfigHint>
+            Use an absolute path if possible. Ensure the process user can read this directory; invalid paths show up as
+            empty skill lists or errors in logs.
+          </ConfigHint>
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
         <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
             <input
               type="checkbox"
               checked={persist}
@@ -100,7 +109,9 @@ export function SkillsConfigForm({ values, envOverrides, tomlPath, onSaved }: Sk
               disabled={!tomlPath}
               className="rounded"
             />
-            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+            <span>
+              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — writes <code>[skills].path</code>.
+            </span>
           </label>
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>

--- a/web/src/components/config/watch-config-form.tsx
+++ b/web/src/components/config/watch-config-form.tsx
@@ -15,7 +15,8 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfigHint, ConfigIntro } from "./config-help";
 
 interface WatchConfigFormProps {
   values: Record<string, unknown>;
@@ -122,13 +123,23 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
     <Card>
       <CardHeader>
         <CardTitle className="text-base">Watch</CardTitle>
+        <CardDescription>
+          Autonomous <code>squire watch</code> loop: timing, prompts, limits, and notifications. Separate from web chat,
+          but many fields sync to a running watch when you save.
+        </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-xs text-muted-foreground">
-          These settings apply to the web API immediately. If autonomous watch mode is running, compatible fields are
-          also pushed to the watch process so they take effect on the next poll (typically within a few seconds).
-          Risk tolerance for watch is controlled under Guardrails (watch tolerance); restart watch after changing it.
-        </p>
+        <ConfigIntro title="Live vs restart">
+          <p>
+            Saving updates the web API’s copy of watch settings immediately. If watch status is <strong>running</strong>,
+            the same changes are queued for the watch process (usually within a few seconds).
+          </p>
+          <p>
+            Effective <strong>risk threshold</strong> during a watch cycle can be changed from the Watch page drawer or
+            live queue; changing <strong>Guardrails → Watch tolerance</strong> requires restarting watch to reload from
+            config files.
+          </p>
+        </ConfigIntro>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>Interval (minutes)</Label>
@@ -141,6 +152,7 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
             onChange={(e) => setIntervalMinutes(parseInt(e.target.value) || 1)}
             disabled={isLocked("interval_minutes")}
           />
+          <ConfigHint>Wall-clock wait between autonomous check-in cycles. Lower = more frequent monitoring.</ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -155,6 +167,9 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
             onChange={(e) => setCycleTimeout(parseInt(e.target.value) || 30)}
             disabled={isLocked("cycle_timeout_seconds")}
           />
+          <ConfigHint>
+            Maximum time one watch cycle may run before it is aborted. Prevents a stuck agent from blocking the loop.
+          </ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -168,30 +183,39 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
             onChange={(e) => setCheckinPrompt(e.target.value)}
             disabled={isLocked("checkin_prompt")}
           />
+          <ConfigHint>Instructions injected each cycle; shapes what the agent prioritizes during check-ins.</ConfigHint>
         </div>
 
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <Label>Notify on Action</Label>
-            {isLocked("notify_on_action") && <EnvLock field="notify_on_action" prefix="SQUIRE_WATCH_" />}
+        <div className="space-y-2 rounded-md border border-border/60 bg-muted/20 px-3 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-1.5">
+              <Label>Notify on Action</Label>
+              {isLocked("notify_on_action") && <EnvLock field="notify_on_action" prefix="SQUIRE_WATCH_" />}
+            </div>
+            <Switch
+              checked={notifyOnAction}
+              onCheckedChange={setNotifyOnAction}
+              disabled={isLocked("notify_on_action")}
+            />
           </div>
-          <Switch
-            checked={notifyOnAction}
-            onCheckedChange={setNotifyOnAction}
-            disabled={isLocked("notify_on_action")}
-          />
+          <ConfigHint>Notify when the watch agent runs one or more tools in a successful cycle.</ConfigHint>
         </div>
 
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            <Label>Notify on Blocked</Label>
-            {isLocked("notify_on_blocked") && <EnvLock field="notify_on_blocked" prefix="SQUIRE_WATCH_" />}
+        <div className="space-y-2 rounded-md border border-border/60 bg-muted/20 px-3 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-1.5">
+              <Label>Notify on Blocked</Label>
+              {isLocked("notify_on_blocked") && <EnvLock field="notify_on_blocked" prefix="SQUIRE_WATCH_" />}
+            </div>
+            <Switch
+              checked={notifyOnBlocked}
+              onCheckedChange={setNotifyOnBlocked}
+              disabled={isLocked("notify_on_blocked")}
+            />
           </div>
-          <Switch
-            checked={notifyOnBlocked}
-            onCheckedChange={setNotifyOnBlocked}
-            disabled={isLocked("notify_on_blocked")}
-          />
+          <ConfigHint>
+            Notify when a tool call is blocked by watch risk policy (visibility in strict setups).
+          </ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -208,6 +232,7 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
             onChange={(e) => setMaxToolCallsPerCycle(parseInt(e.target.value) || 1)}
             disabled={isLocked("max_tool_calls_per_cycle")}
           />
+          <ConfigHint>Hard cap on tools per cycle to limit blast radius and cost.</ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -222,6 +247,10 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
             onChange={(e) => setCyclesPerSession(parseInt(e.target.value) || 1)}
             disabled={isLocked("cycles_per_session")}
           />
+          <ConfigHint>
+            After this many completed cycles, watch starts a fresh ADK session with a short carryover summary—reduces
+            memory growth over long runs.
+          </ConfigHint>
         </div>
 
         <div className="space-y-2">
@@ -236,12 +265,16 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
             onChange={(e) => setMaxContextEvents(parseInt(e.target.value) || 10)}
             disabled={isLocked("max_context_events")}
           />
+          <ConfigHint>
+            How many recent ADK events are kept in session context each cycle. Lower trims history earlier; higher keeps
+            more tool transcript in memory.
+          </ConfigHint>
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}
 
         <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
             <input
               type="checkbox"
               checked={persist}
@@ -249,7 +282,10 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
               disabled={!tomlPath}
               className="rounded"
             />
-            Save to disk{tomlPath ? "" : " (no squire.toml found)"}
+            <span>
+              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — writes the{" "}
+              <code className="font-mono text-[11px]">[watch]</code> section.
+            </span>
           </label>
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>


### PR DESCRIPTION
## Problem

The guardrails system had several bugs that made the Configuration UI unreliable: `run_command` blocked allowed commands (e.g. `ls`) because tools cached a stale `GuardrailsConfig` at import time, chat sessions loaded fresh config from disk instead of using runtime changes, and per-agent tolerances were declared in the config schema but never wired into the risk gate. Additionally, the Configuration page lacked any contextual help — users couldn't tell what each setting did, whether changes took effect immediately, or when a restart was needed.

## Context

Reported during manual testing of the web UI config page. The `run_command` tool blocked `ls` despite it being allowed in Guardrails and risk tolerance being set to `full-trust`. Investigation revealed a chain of stale-config bugs affecting multiple code paths.

Closes #96 (partial — addresses the core guardrails bugs and config help; some follow-ups remain).

## Solution

**Guardrails fixes:**
- Introduced `set_guardrails`/`get_guardrails` in the tool registry so tools always read the live config singleton instead of a stale module-level cache
- Chat sessions now use `deps.guardrails` instead of instantiating fresh `GuardrailsConfig()` objects
- Wired per-agent tolerances through a `RiskGateFactoryBuilder` callback so `monitor_tolerance`, `container_tolerance`, etc. actually flow into each sub-agent's risk gate `default_threshold`
- Expanded `commands_allow` defaults to include `ls`, `stat`, `docker`, `systemctl`, and other common read-only commands

**Config restructuring:**
- Moved `risk_tolerance` and `risk_strict` from `AppConfig` to `GuardrailsConfig` (BREAKING: env vars and TOML keys change)

**Config help UI:**
- Added `ConfigHint`, `ConfigIntro`, and `ConfigEnvOverrideNotice` components
- Inline help text across all config forms (app, LLM, watch, skills, guardrails)
- Page-level intro explaining save vs persist vs env vs restart semantics

**Makefile/static-dir polish:**
- `REPO_ROOT`-anchored all Makefile recipes so builds work from any CWD
- `make web` always rebuilds frontend before serving; sets `SQUIRE_WEB_STATIC_DIR`
- `_find_static_dir()` prioritizes the env var, then picks the newer `index.html` between CWD and repo root

## Testing

### Unit tests
- Updated `tests/test_config.py` for moved `risk_tolerance`/`risk_strict` fields and new `commands_allow` defaults
- Updated `tests/test_config_api.py` for guardrails PATCH including risk tolerance
- Updated `tests/test_tools/test_run_command.py` to use `set_guardrails` instead of monkeypatching removed cache
- Added `tests/test_web_static_dir.py` for `_find_static_dir` env var override logic

### Integration tests
- Frontend builds successfully (`npm run build` + `npm run lint`)

### Test results
```
394 passed, 3 warnings in 2.91s
ruff check: All checks passed
ruff format: 145 files already formatted
eslint: clean
next build: 13/13 static pages generated
```

## Reviewer Validation

1. `make ci` — all 394 tests pass, lint + format clean, frontend builds
2. Start the web UI with `make web` and navigate to `/config`
   - Each section should have intro text and per-field hints
   - Guardrails section should now include Risk Tolerance and Strict Mode
   - App section should no longer show Risk Tolerance
3. In a chat, ask Squire to run `ls /` — should succeed without being blocked
4. Change risk tolerance in the Guardrails config form, save (without persist), open a new chat — the new tolerance should be respected

## TODOs / Follow-Ups

Per #96:
- Move `RiskTolerance` enum and `_coerce_risk_tolerance` from `app.py` to `guardrails.py`
- Fix Pydantic serialization warning for `risk_tolerance` enum
- Add integration tests for per-agent tolerance wiring
- Auto-migrate legacy `risk_tolerance`/`risk_strict` from top-level TOML
- CLI chat mode does not use `GuardrailsConfig` for risk pipeline (future CLI work)

Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)