### PR TITLE
feat: runtime tooling for run_command (ping, nc, Docker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Docker:** OS packages for default `run_command` diagnostics (`ping`, `traceroute`, `dig`/`nslookup`, `nc`, `ip`/`ss`, `netstat`, `lsof`, etc.) so the slim Python base image matches the default command allowlist
+- **Guardrails:** Default `commands_allow` includes `nc` for port reachability checks (operators can remove it for stricter policies)
+
 ## [0.14.0] — 2026-04-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Docker:** OS packages for default `run_command` diagnostics (`ping`, `traceroute`, `dig`/`nslookup`, `nc`, `ip`/`ss`, `netstat`, `lsof`, etc.) so the slim Python base image matches the default command allowlist
+- **Docker:** OS packages for common `run_command` diagnostics that `python:*-slim` usually omits (`ping`, `traceroute`, `dig`/`nslookup`, `nc`, `ip`/`ss`, `netstat`, `lsof`, etc.); the image does not install the full default allowlist (for example `docker`, `systemctl`, and `journalctl` remain host- or deployment-specific)
 - **Guardrails:** Default `commands_allow` includes `nc` for port reachability checks (operators can remove it for stricter policies)
+
+### Changed
+
+- **Docker / docs:** Clarified that the image adds diagnostic packages, not the entire default `commands_allow`; configuration docs point at `docker/Dockerfile` as the source of truth; `DEBIAN_FRONTEND=noninteractive` set for `apt-get`
 
 ## [0.14.0] — 2026-04-11
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,17 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# OS tools for default run_command allowlist (slim image omits most of these)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dnsutils \
+    iproute2 \
+    iputils-ping \
+    lsof \
+    net-tools \
+    netcat-openbsd \
+    traceroute \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install uv for fast dependency management
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,9 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-# OS tools for default run_command allowlist (slim image omits most of these)
+ENV DEBIAN_FRONTEND=noninteractive
+
+# OS tools for common run_command diagnostics (slim base omits most of these; not the full default allowlist)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     dnsutils \
     iproute2 \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,7 @@ Controls which commands `run_command` can execute:
 
 ```toml
 [guardrails]
-commands_allow = ["ping", "traceroute", "df", "free", "uptime", "cat", "head", "tail"]
+commands_allow = ["ping", "nc", "dig", "ip", "df", "cat", "docker"]
 commands_block = ["rm", "mkfs", "dd", "shutdown", "reboot"]
 ```
 
@@ -159,11 +159,15 @@ commands_block = ["rm", "mkfs", "dd", "shutdown", "reboot"]
 | `commands_block` | *(see below)* | `SQUIRE_GUARDRAILS_COMMANDS_BLOCK` | Commands that are always blocked (checked first) |
 
 
-**Default command allowlist:** `ping`, `traceroute`, `dig`, `nslookup`, `df`, `free`, `uptime`, `ip`, `ss`, `cat`, `head`, `tail`
+**Default command allowlist:** `ls`, `stat`, `file`, `du`, `find`, `wc`, `cat`, `head`, `tail`, `grep`, `hostname`, `date`, `whoami`, `id`, `uname`, `uptime`, `df`, `free`, `mount`, `lsblk`, `top`, `ps`, `which`, `ping`, `traceroute`, `dig`, `nslookup`, `ip`, `ss`, `netstat`, `nc`, `docker`, `systemctl`, `journalctl`, `lsof`
+
+`nc` is allowed for common homelab port checks (for example `nc -zv host 22`). It can also listen or relay traffic; remove it from `commands_allow` if you want a stricter policy.
 
 **Default command blocklist:** `rm`, `mkfs`, `dd`, `fdisk`, `parted`, `shutdown`, `reboot`, `init`, `bash`, `sh`, `zsh`, `fish`, `csh`, `tcsh`, `dash`, `python`, `python3`, `perl`, `ruby`, `node`, `lua`
 
 The blocklist is checked first -- a command on both lists is blocked.
+
+**Host / container PATH:** `run_command` runs binaries from the process environment. Minimal images (for example `python:*-slim`) may omit `ping`, `dig`, `nc`, and similar tools even when they are allowlisted. The published Squire Docker image installs packages for the default allowlist; on bare metal or custom images, install the equivalent OS packages or adjust `commands_allow` to match what is installed.
 
 ### Config Path Guards
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,8 @@ tools_risk_overrides = { "docker_compose:restart" = 4, "run_command" = 3 }
 
 Controls which commands `run_command` can execute:
 
+The snippet below is an **illustrative subset** only; the full default list is under **Default command allowlist**.
+
 ```toml
 [guardrails]
 commands_allow = ["ping", "nc", "dig", "ip", "df", "cat", "docker"]
@@ -167,7 +169,7 @@ commands_block = ["rm", "mkfs", "dd", "shutdown", "reboot"]
 
 The blocklist is checked first -- a command on both lists is blocked.
 
-**Host / container PATH:** `run_command` runs binaries from the process environment. Minimal images (for example `python:*-slim`) may omit `ping`, `dig`, `nc`, and similar tools even when they are allowlisted. The published Squire Docker image installs packages for the default allowlist; on bare metal or custom images, install the equivalent OS packages or adjust `commands_allow` to match what is installed.
+**Host / container PATH:** `run_command` runs binaries from the process environment. Minimal images (for example `python:*-slim`) may omit `ping`, `dig`, `nc`, and similar tools even when they are allowlisted. The published Squire Docker image installs the `apt` packages defined in `docker/Dockerfile` for those diagnostics, not every command on the default allowlist: `docker` CLI, `systemctl`, and `journalctl` are typical examples you must provide via the host, socket mounts, or extra image layers. On bare metal or custom images, install the OS packages you need or trim `commands_allow` to match what is installed.
 
 ### Config Path Guards
 

--- a/squire.example.toml
+++ b/squire.example.toml
@@ -44,9 +44,11 @@
 
 # run_command argument guards
 # commands_allow = [
-#     "ping", "traceroute", "dig", "nslookup",
-#     "df", "free", "uptime", "ip", "ss",
-#     "cat", "head", "tail",
+#     "ls", "stat", "file", "du", "find", "wc",
+#     "cat", "head", "tail", "grep",
+#     "hostname", "date", "whoami", "id", "uname", "uptime", "df", "free", "mount", "lsblk", "top", "ps", "which",
+#     "ping", "traceroute", "dig", "nslookup", "ip", "ss", "netstat", "nc",
+#     "docker", "systemctl", "journalctl", "lsof",
 # ]
 # commands_block = [
 #     "rm", "mkfs", "dd", "fdisk", "parted",

--- a/src/squire/config/guardrails.py
+++ b/src/squire/config/guardrails.py
@@ -127,6 +127,7 @@ class GuardrailsConfig(BaseSettings):
             "ip",
             "ss",
             "netstat",
+            "nc",
             # Service management (read-only actions guarded by risk levels)
             "docker",
             "systemctl",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,6 +43,7 @@ class TestGuardrailsConfig:
         assert config.risk_strict is False
         assert "ls" in config.commands_allow
         assert "ping" in config.commands_allow
+        assert "nc" in config.commands_allow
         assert "rm" in config.commands_block
         assert config.tools_allow == []
         assert config.tools_require_approval == []


### PR DESCRIPTION
## Problem

`run_command` could allow `ping` and other diagnostics while the slim Docker image had no corresponding binaries, producing confusing "command not found" results. `nc` was a common way to probe TCP ports but was not on the default command allowlist, so legitimate connectivity checks were denied by policy.

## Context

Homelab monitoring often needs ICMP and simple port checks from the same environment where Squire runs. Policy and PATH need to stay aligned so the agent is not blocked by missing packages or an incomplete default allowlist.

## Solution

- Install Debian packages in the published Docker image for tools that match the default `commands_allow` (ping, traceroute, DNS utils, netcat, iproute2, net-tools, lsof).
- Add `nc` to the default allowlist, with documentation of the trade-off (operators can remove it for stricter deployments).
- Refresh configuration docs and the example TOML so defaults and PATH expectations are accurate; extend config tests and changelog.

## Testing

### Unit tests

- `tests/test_config.py` — default guardrails include `nc` alongside existing checks for `ping` and `ls`.

### Integration tests

- None added; `run_command` behavior is unchanged aside from defaults and image contents.

### Test results

`make ci` passed locally before commit: ruff check/format, 394 pytest tests, web lint and `next build`.

## Reviewer Validation

1. Read `docker/Dockerfile` and confirm the `apt-get` package set matches the intended diagnostics.
2. Run `uv run pytest tests/test_config.py tests/test_tools/test_run_command.py -q` and confirm all pass.
3. Optionally run `docker build -f docker/Dockerfile .` and exec `ping -c1 127.0.0.1` / `nc -zv 127.0.0.1 8420` inside the image.

## TODOs / Follow-Ups

None — this PR is self-contained. Remote hosts and optional `docker` CLI on the container remain deployment-specific.

Made with [Cursor](https://cursor.com)