### PR TITLE
feat: make watch mode a flagship autonomous operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Watch autonomy:** Added structured watch lifecycle contract (detect → RCA → remediate → verify → escalate), incident/playbook injection, phase and incident event types, cycle outcomes in telemetry, anti-flapping controls (`max_identical_actions_per_cycle`, cooldown windows, remote action cap), and periodic digest notifications
 - **Watch analytics:** Persisted cumulative watch metrics in `watch_state` (`total_actions`, `total_blocked`, `total_resolved`, `total_escalated`, `last_outcome`) and exposed richer cycle summaries (`blocked_count`, incident stats, resolved/escalated flags)
 - **Tests:** Added `test_watch_autonomy.py` and expanded watch emitter/config coverage for new autonomy and safety behavior
+- **Watch playbooks (user-managed):** Added dynamic playbook routing from Skills metadata (`incident_keys` + `hosts`) with deterministic matching, single-match plausibility checks, LLM tie-break for overlaps, semantic fallback for unmatched incidents, and generic fallback on low confidence
+- **Skills API/UI:** Added incident family catalog endpoint, router dry-run simulation endpoint, starter playbook bootstrap endpoint, conflict preview UI, and watch-playbook metadata editing (`hosts`, `incident_keys`)
+- **Watch telemetry:** Added playbook selection phase events and counters for deterministic/semantic/generic routing paths
 
 ### Changed
 
 - **Watch UI:** Live stream and cycle history now display incident/phase telemetry, blocked counts, and resolved/escalated outcomes; watch config drawer now supports new autonomy safety controls
 - **Docs/config:** Updated watch-mode docs and example config to reflect strict-autonomy behavior, corrected `cycles_per_session` default to `12`, and documented new watch config fields and notification categories
+- **Skills schema:** Canonicalized skill host targeting to `metadata.hosts` (list) with legacy `metadata.host` retrofit on load; renderer persists only `hosts`
 
 ## [0.14.1] — 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docs/config:** Updated watch-mode docs and example config to reflect strict-autonomy behavior, corrected `cycles_per_session` default to `12`, and documented new watch config fields and notification categories
 - **Skills schema:** Canonicalized skill host targeting to `metadata.hosts` (list) with legacy `metadata.host` retrofit on load; renderer persists only `hosts`
 
+### Fixed
+
+- **Watch safety updates:** Live `update_config` commands now validate incoming values against `WatchConfig` constraints and reject invalid guardrail-disabling values (such as `0` for per-cycle safety limits)
+- **Playbook routing resilience:** Added bounded LLM usage for watch/dry-run playbook routing with per-request call caps and per-call timeouts; watch mode also wraps routing in a cycle-safe timeout fallback
+- **Skills dry-run safeguards:** `POST /api/skills/playbooks/dry-run` now limits incident batch size and defaults to heuristic routing unless `use_llm=true` is explicitly requested
+
 ## [0.14.1] — 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Watch autonomy:** Added structured watch lifecycle contract (detect → RCA → remediate → verify → escalate), incident/playbook injection, phase and incident event types, cycle outcomes in telemetry, anti-flapping controls (`max_identical_actions_per_cycle`, cooldown windows, remote action cap), and periodic digest notifications
+- **Watch analytics:** Persisted cumulative watch metrics in `watch_state` (`total_actions`, `total_blocked`, `total_resolved`, `total_escalated`, `last_outcome`) and exposed richer cycle summaries (`blocked_count`, incident stats, resolved/escalated flags)
+- **Tests:** Added `test_watch_autonomy.py` and expanded watch emitter/config coverage for new autonomy and safety behavior
+
+### Changed
+
+- **Watch UI:** Live stream and cycle history now display incident/phase telemetry, blocked counts, and resolved/escalated outcomes; watch config drawer now supports new autonomy safety controls
+- **Docs/config:** Updated watch-mode docs and example config to reflect strict-autonomy behavior, corrected `cycles_per_session` default to `12`, and documented new watch config fields and notification categories
+
 ## [0.14.1] — 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Watch safety updates:** Live `update_config` commands now validate incoming values against `WatchConfig` constraints and reject invalid guardrail-disabling values (such as `0` for per-cycle safety limits)
 - **Playbook routing resilience:** Added bounded LLM usage for watch/dry-run playbook routing with per-request call caps and per-call timeouts; watch mode also wraps routing in a cycle-safe timeout fallback
 - **Skills dry-run safeguards:** `POST /api/skills/playbooks/dry-run` now limits incident batch size and defaults to heuristic routing unless `use_llm=true` is explicitly requested
+- **Tests/CI:** Wrapped a long `Incident(...)` constructor call in `test_watch_playbook_router.py` to satisfy Ruff's 120-character line length check and unblock the lint job
 
 ## [0.14.1] — 2026-04-11
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,7 +228,8 @@ tools_deny = []                    # additional tools to deny in watch
 | `tools_deny`  | `SQUIRE_GUARDRAILS_WATCH_TOOLS_DENY`  | Additional tools to deny in watch       |
 
 
-Watch mode is always strict (deny, never prompt) since there's no interactive approval provider.
+Watch mode is always strict (deny, never prompt) and optimized for autonomous operation. The web dashboard can supervise
+live events and outcomes, but does not gate high-risk actions with interactive approval prompts.
 
 ---
 
@@ -488,7 +489,11 @@ Risk policy for watch mode is configured under `[guardrails.watch]`, not here.
 | `interval_minutes`         | `5`          | `SQUIRE_WATCH_INTERVAL_MINUTES`         | Minutes between watch cycles  |
 | `max_tool_calls_per_cycle` | `15`         | `SQUIRE_WATCH_MAX_TOOL_CALLS_PER_CYCLE` | Tool call budget per cycle    |
 | `cycle_timeout_seconds`    | `300`        | `SQUIRE_WATCH_CYCLE_TIMEOUT_SECONDS`    | Max wall-clock time per cycle |
-| `cycles_per_session`       | `50`         | `SQUIRE_WATCH_CYCLES_PER_SESSION`       | Rotate session after N cycles |
+| `cycles_per_session`       | `12`         | `SQUIRE_WATCH_CYCLES_PER_SESSION`       | Rotate session after N cycles |
+| `max_context_events`       | `40`         | `SQUIRE_WATCH_MAX_CONTEXT_EVENTS`       | Keep only recent ADK events in context |
+| `max_identical_actions_per_cycle` | `2`  | `SQUIRE_WATCH_MAX_IDENTICAL_ACTIONS_PER_CYCLE` | Anti-flapping action cap |
+| `blocked_action_cooldown_cycles` | `3`   | `SQUIRE_WATCH_BLOCKED_ACTION_COOLDOWN_CYCLES` | Cooldown for repeated actions |
+| `max_remote_actions_per_cycle` | `4`     | `SQUIRE_WATCH_MAX_REMOTE_ACTIONS_PER_CYCLE` | Safety cap for remote actions |
 | `checkin_prompt`           | *(built-in)* | `SQUIRE_WATCH_CHECKIN_PROMPT`           | Prompt injected each cycle    |
 | `notify_on_action`         | `true`       | `SQUIRE_WATCH_NOTIFY_ON_ACTION`         | Notify on corrective actions  |
 | `notify_on_blocked`        | `true`       | `SQUIRE_WATCH_NOTIFY_ON_BLOCKED`        | Notify on blocked tool calls  |
@@ -499,7 +504,11 @@ Risk policy for watch mode is configured under `[guardrails.watch]`, not here.
 interval_minutes = 5
 max_tool_calls_per_cycle = 15
 cycle_timeout_seconds = 300
-cycles_per_session = 50
+cycles_per_session = 12
+max_context_events = 40
+max_identical_actions_per_cycle = 2
+blocked_action_cooldown_cycles = 3
+max_remote_actions_per_cycle = 4
 ```
 
 ---
@@ -587,6 +596,11 @@ events = ["watch.alert", "watch.action"]
 | `watch.blocked`   | Watch  | Tool call denied by risk policy       |
 | `watch.alert`     | Watch  | Alert rule triggered                  |
 | `watch.error`     | Watch  | Exception during a watch cycle        |
+| `watch.incident_detected` | Watch | New incident fingerprint detected |
+| `watch.remediation` | Watch | Autonomous remediation action summary |
+| `watch.verification` | Watch | Verification outcome for remediation |
+| `watch.escalation` | Watch | Escalation required for unresolved issue |
+| `watch.digest` | Watch | Periodic operational summary |
 | `user`            | Agent  | Ad-hoc notification sent by the agent |
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,7 +340,7 @@ Each skill is a directory containing a `SKILL.md` file with YAML frontmatter and
 name: restart-on-error
 description: Check container health and restart errored containers.
 metadata:
-  host: prod-apps-01
+  hosts: ["prod-apps-01"]
   trigger: manual
 ---
 
@@ -355,14 +355,15 @@ The format follows the [Open Agent Skills spec](https://agentskills.io/specifica
 | ------------------ | -------- | -------- | ------------------------------------------------------------------------------------------ |
 | `name`             | Yes      |          | Skill name — lowercase letters, numbers, hyphens, max 64 chars. Must match directory name. |
 | `description`      | Yes      |          | What the skill does and when to use it (max 1024 chars).                                   |
-| `metadata.host`    | No       | `all`    | Target host (`all` or a specific host name)                                                |
+| `metadata.hosts`   | No       | `["all"]`| Target hosts (`["all"]` or specific host names)                                            |
 | `metadata.trigger` | No       | `manual` | `manual` (on-demand) or `watch` (each watch cycle)                                         |
 | `metadata.enabled` | No       | `true`   | Whether the skill is active                                                                |
+| `metadata.incident_keys` | No | `[]`     | Watch-playbook incident-family prefixes (for example `disk-pressure:`)                    |
 
 
 The `metadata` key is omitted entirely when all Squire-specific fields are at their defaults.
 
-Skills with `trigger: watch` are appended to the watch mode check-in prompt each cycle. Manual skills can be executed from the web UI or CLI.
+Skills with `trigger: watch` and non-empty `incident_keys` become playbook candidates for dynamic routing (deterministic prefix matching, LLM tie-break, semantic fallback, generic fallback). Watch skills with no `incident_keys` are appended as generic watch instructions. Manual skills can be executed from the web UI or CLI.
 
 ---
 

--- a/docs/design/watch-web-integration.md
+++ b/docs/design/watch-web-integration.md
@@ -4,7 +4,9 @@
 
 Watch mode is Squire's autonomous monitoring loop — it runs headless, collecting system snapshots and sending check-in prompts to the agent on a configurable interval. Today it's started via CLI (`squire watch`), outputs to stdout logs, and persists state to SQLite. The web UI has a minimal read-only status endpoint but no meaningful integration.
 
-Users need to manage and observe watch mode through the web UI: start/stop the process, see live agent activity as cycles run, review historical cycles, adjust configuration on the fly, and optionally approve risky tool calls when actively supervising.
+Users need to manage and observe watch mode through the web UI: start/stop the process, see live agent activity as cycles run,
+review historical cycles, adjust configuration on the fly, and monitor autonomy outcomes (incident detection, RCA, remediation,
+verification, escalation).
 
 ## Architecture
 
@@ -84,17 +86,13 @@ The web API's `POST /api/watch/start` endpoint:
 3. Spawns `squire watch` as a detached subprocess
 4. Returns immediately — frontend polls status until it transitions to "running"
 
-### Approval Bridge
+### Strict-Autonomy Gate
 
-A new `DatabaseApprovalProvider` implements the existing approval provider protocol:
-1. Writes an `approval_request` event to `watch_events`
-2. Writes a row to `watch_approvals` with `status='pending'`
-3. Polls `watch_approvals` for status change (200ms interval, 60s timeout)
-4. Returns approved/denied, or auto-denies on timeout
+Watch mode runs with strict headless risk policy (`strict=True`, `headless=True`) and never waits for interactive approvals.
+Supervisor connections in the web UI provide observability only. High-risk actions are denied, deduplicated, and surfaced as
+autonomy telemetry and notifications.
 
-The watch process checks `watch_state` for `supervisor_connected` at cycle start. If a supervisor is connected, the risk gate uses `DatabaseApprovalProvider` instead of the default strict (auto-deny) behavior. If no supervisor is connected, existing headless behavior is unchanged.
-
-File: `src/squire/callbacks/risk_gate.py`
+File: `src/squire/watch.py`, `src/squire/callbacks/risk_gate.py`
 
 ## Backend API
 
@@ -205,7 +203,8 @@ Files: `web/src/app/watch/page.tsx`, `web/src/components/watch/*.tsx`
 2. **Live streaming**: With watch running, open `/watch` and verify tokens, tool calls, and cycle boundaries stream in real-time (~200ms latency).
 3. **Cycle history**: After several cycles, switch to History tab and verify cycles are listed with correct stats. Expand a cycle and verify full event stream is shown.
 4. **Configuration**: Open config drawer, change interval to 1 minute, apply. Verify next cycle runs after ~1 minute instead of default 5.
-5. **Approval flow**: Set risk tolerance low enough that a tool triggers approval. With the watch page open, verify the approval card appears. Approve it and verify the tool executes. Test denial. Test timeout (close the page and verify auto-deny).
+5. **Strict-autonomy blocking**: Set risk tolerance low enough that a tool is blocked. Verify watch continues with fallback/escalation
+   and emits `watch.blocked` / `watch.escalation` telemetry without waiting for approval.
 6. **Headless fallback**: Stop the web server, run `squire watch` from CLI. Verify it still works independently — events are written to DB, strict risk gate auto-denies, no errors about missing web server.
 7. **Reconnection**: Disconnect and reconnect the WebSocket mid-cycle. Verify the stream catches up (initial burst of current cycle events).
 8. **Concurrent viewers**: Open `/watch` in two browser tabs. Verify both see the stream. Submit an approval from one tab, verify the other shows it as resolved.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -353,7 +353,7 @@ Skills are file-based instruction sets following the [Open Agent Skills](https:/
 name: restart-on-error
 description: Check container health and restart errored containers.
 metadata:
-  host: prod-apps-01
+  hosts: ["prod-apps-01"]
   trigger: manual
 ---
 
@@ -363,7 +363,7 @@ the root cause and restart them.
 Verify the containers come back healthy after restart.
 ```
 
-`name` and `description` are required by the spec. Names must be lowercase letters, numbers, and hyphens (max 64 chars). Squire-specific fields (`host`, `trigger`, `enabled`) live under `metadata`.
+`name` and `description` are required by the spec. Names must be lowercase letters, numbers, and hyphens (max 64 chars). Squire-specific fields (`hosts`, `trigger`, `enabled`, `incident_keys`) live under `metadata`.
 
 ### Triggers
 
@@ -371,7 +371,7 @@ Verify the containers come back healthy after restart.
 | Trigger  | When it runs                                          |
 | -------- | ----------------------------------------------------- |
 | `manual` | On demand — from the web UI, CLI, or API              |
-| `watch`  | Appended to the check-in prompt each watch mode cycle |
+| `watch`  | Routed as playbooks for matching incidents (or appended as generic watch skills when no `incident_keys` are provided) |
 
 
 Here is a watch-triggered example:
@@ -381,8 +381,9 @@ Here is a watch-triggered example:
 name: nightly-cleanup
 description: Clean up unused Docker images and volumes nightly.
 metadata:
-  host: all
+  hosts: ["all"]
   trigger: watch
+  incident_keys: ["disk-pressure:", "disk-warning:"]
 ---
 
 Check for unused Docker images older than 7 days and dangling volumes.
@@ -390,6 +391,12 @@ Remove them to free disk space. Report what was cleaned up.
 ```
 
 Executing a manual skill opens a new chat session with the instructions pre-loaded.
+
+The Skills page now includes watch-playbook tools:
+- incident family picker (`incident_keys`)
+- conflict preview for overlapping playbooks
+- one-click starter install (`recover-container-unhealthy`, `triage-disk-pressure`)
+- dry-run router simulation for "given incident X, what playbook is selected?"
 
 ### CLI Management
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,7 +37,7 @@ The web UI has eight pages:
 | **Activity**      | Timeline of tool calls, watch mode actions, and denied requests                                                                |
 | **Sessions**      | Browse, resume, and delete past conversations                                                                                  |
 | **Skills**        | Create, edit, toggle, execute, and delete skills with a form-based editor                                                      |
-| **Watch**         | Start/stop watch mode, live-stream cycle activity, interactive tool approval with countdown timers, and runtime config changes |
+| **Watch**         | Start/stop watch mode, live-stream cycle activity, inspect structured RCA/remediation outcomes, and apply runtime config changes |
 | **Hosts**         | Host registry with reachable/unreachable status, services, and tags                                                            |
 | **Notifications** | Notification category overview and recent history                                                                              |
 | **Config**        | Current effective configuration viewer                                                                                         |
@@ -126,6 +126,7 @@ Every tool has a built-in risk level (1–5). The tolerance setting determines t
 
 
 ```toml
+[guardrails]
 risk_tolerance = "cautious"    # default
 risk_strict = false            # false = prompt for approval; true = deny outright
 ```
@@ -133,7 +134,7 @@ risk_strict = false            # false = prompt for approval; true = deny outrig
 Set via environment variable:
 
 ```bash
-export SQUIRE_RISK_TOLERANCE=standard
+export SQUIRE_GUARDRAILS_RISK_TOLERANCE=standard
 ```
 
 **Fine-grained overrides** live in the `[guardrails]` section — per-tool allow/deny/require-approval, command and path guards, and per-agent tolerances. See [Configuration Reference](configuration.md#guardrails----guardrails) for details.
@@ -226,7 +227,8 @@ uv run squire watch              # start the loop
 uv run squire watch status       # check status from another terminal
 ```
 
-You can also start and supervise watch mode from the web UI (Watch page) with live cycle streaming, cycle history, and interactive tool approval with countdown timers.
+You can also start and supervise watch mode from the web UI (Watch page) with live cycle streaming, cycle history, and
+structured autonomy telemetry (incident detection, RCA, remediation, verification, escalation).
 
 ### Getting Started with Watch Mode
 
@@ -255,7 +257,11 @@ Operational settings go in `[watch]`; risk policy goes in `[guardrails.watch]`.
 interval_minutes = 5           # minutes between cycles
 max_tool_calls_per_cycle = 15  # tool call budget per cycle
 cycle_timeout_seconds = 300    # max wall-clock time per cycle
-cycles_per_session = 50        # rotate session after N cycles
+cycles_per_session = 12        # rotate session after N cycles
+max_context_events = 40        # keep only recent ADK events
+max_identical_actions_per_cycle = 2   # anti-flapping cap
+blocked_action_cooldown_cycles = 3    # suppress repeated signatures
+max_remote_actions_per_cycle = 4      # remote safety bound
 notify_on_action = true        # notify when corrective action taken
 notify_on_blocked = true       # notify when tool call blocked
 

--- a/squire.example.toml
+++ b/squire.example.toml
@@ -75,7 +75,11 @@
 # interval_minutes = 5
 # max_tool_calls_per_cycle = 15
 # cycle_timeout_seconds = 300
-# cycles_per_session = 50
+# cycles_per_session = 12
+# max_context_events = 40
+# max_identical_actions_per_cycle = 2
+# blocked_action_cooldown_cycles = 3
+# max_remote_actions_per_cycle = 4
 # notify_on_action = true
 # notify_on_blocked = true
 

--- a/src/squire/api/routers/chat.py
+++ b/src/squire/api/routers/chat.py
@@ -265,7 +265,7 @@ async def chat_websocket(
             skill_active = True
             session_state["active_skill"] = {
                 "skill_name": skill_data.name,
-                "host": skill_data.host,
+                "hosts": skill_data.hosts,
                 "instructions": skill_data.instructions,
             }
             logger.info("Loaded skill '%s' into session %s", skill_name, session_id)

--- a/src/squire/api/routers/skills.py
+++ b/src/squire/api/routers/skills.py
@@ -2,9 +2,20 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from ...config import LLMConfig
 from ...skills import Skill
-from ..dependencies import get_skills_service
-from ..schemas import SkillCreate, SkillUpdate
+from ...watch_autonomy import INCIDENT_FAMILY_CATALOG, Incident
+from ...watch_playbooks.router import route_playbooks_for_incidents
+from ..dependencies import get_llm_config, get_skills_service
+from ..schemas import (
+    BootstrapPlaybooksResponse,
+    IncidentFamilyInfo,
+    PlaybookDryRunRequest,
+    PlaybookDryRunResponse,
+    PlaybookDryRunSelection,
+    SkillCreate,
+    SkillUpdate,
+)
 
 router = APIRouter()
 
@@ -17,6 +28,98 @@ def list_skills(skills_service=Depends(get_skills_service)):
     return skills_service.list_skills()
 
 
+@router.get("/incident-families", response_model=list[IncidentFamilyInfo])
+def list_incident_families():
+    """Return canonical incident family prefixes for playbook routing."""
+    return [{"prefix": prefix, "description": desc} for prefix, desc in INCIDENT_FAMILY_CATALOG.items()]
+
+
+@router.post("/bootstrap-watch-playbooks", response_model=BootstrapPlaybooksResponse)
+def bootstrap_watch_playbooks(skills_service=Depends(get_skills_service)):
+    """Install starter watch playbooks if missing."""
+    starter = [
+        Skill(
+            name="recover-container-unhealthy",
+            description="Diagnose and recover unhealthy or restarting containers with bounded actions.",
+            trigger="watch",
+            hosts=["all"],
+            incident_keys=["container-unhealthy:"],
+            instructions=(
+                "When a container is unhealthy or restarting:\n"
+                "1) Inspect recent logs before restart.\n"
+                "2) Restart only the affected container.\n"
+                "3) Do not restart the same container more than once per cycle.\n"
+                "4) Verify post-restart health.\n"
+                "5) Escalate if still unhealthy."
+            ),
+        ),
+        Skill(
+            name="triage-disk-pressure",
+            description="Validate disk pressure signals and perform safe cleanup steps.",
+            trigger="watch",
+            hosts=["all"],
+            incident_keys=["disk-pressure:", "disk-warning:"],
+            instructions=(
+                "When disk pressure is detected:\n"
+                "1) Verify actual primary mount utilization before remediation.\n"
+                "2) Identify largest consumers with read-only diagnostics.\n"
+                "3) Prefer low-risk cleanup steps first.\n"
+                "4) Re-check free space after each action.\n"
+                "5) Escalate with top consumers if unresolved."
+            ),
+        ),
+    ]
+    created: list[str] = []
+    skipped: list[str] = []
+    for skill in starter:
+        if skills_service.get_skill(skill.name):
+            skipped.append(skill.name)
+            continue
+        skills_service.save_skill(skill)
+        created.append(skill.name)
+    return {"created": created, "skipped": skipped}
+
+
+@router.post("/playbooks/dry-run", response_model=PlaybookDryRunResponse)
+async def dry_run_playbook_routing(
+    body: PlaybookDryRunRequest,
+    skills_service=Depends(get_skills_service),
+    llm_config: LLMConfig = Depends(get_llm_config),
+):
+    """Simulate playbook routing for one or more incidents."""
+    incidents = [
+        Incident(
+            key=i.key,
+            severity=i.severity,
+            title=i.title or i.key,
+            detail=i.detail,
+            host=i.host,
+        )
+        for i in body.incidents
+    ]
+    watch_skills = skills_service.list_skills(enabled_only=True, trigger="watch")
+    playbook_skills = [s for s in watch_skills if s.incident_keys]
+    _, selections = await route_playbooks_for_incidents(incidents, playbook_skills, llm_config=llm_config)
+    response_selections = [
+        PlaybookDryRunSelection(
+            incident={
+                "key": s.incident.key,
+                "severity": s.incident.severity,
+                "host": s.incident.host,
+                "title": s.incident.title,
+                "detail": s.incident.detail,
+            },
+            candidate_count=s.candidate_count,
+            selected_playbook=s.selected_playbook,
+            path_taken=s.path_taken,
+            confidence=s.confidence,
+            reasoning=s.reasoning,
+        )
+        for s in selections
+    ]
+    return {"selections": response_selections}
+
+
 @router.post("", response_model=Skill, status_code=201)
 def create_skill(body: SkillCreate, skills_service=Depends(get_skills_service)):
     """Create a new skill."""
@@ -26,6 +129,7 @@ def create_skill(body: SkillCreate, skills_service=Depends(get_skills_service)):
         raise HTTPException(status_code=422, detail="Instructions are required")
     if not body.description.strip():
         raise HTTPException(status_code=422, detail="Description is required")
+    _validate_incident_keys(body.incident_keys, allow_custom=body.allow_custom_incident_prefixes)
 
     if skills_service.get_skill(body.name):
         raise HTTPException(status_code=409, detail=f"A skill named '{body.name}' already exists")
@@ -34,8 +138,9 @@ def create_skill(body: SkillCreate, skills_service=Depends(get_skills_service)):
         skill = Skill(
             name=body.name,
             description=body.description,
-            host=body.host,
+            hosts=body.hosts,
             trigger=body.trigger,
+            incident_keys=body.incident_keys,
             instructions=body.instructions,
         )
     except ValueError as e:
@@ -66,6 +171,10 @@ def update_skill(name: str, body: SkillUpdate, skills_service=Depends(get_skills
 
     if not fields:
         raise HTTPException(status_code=422, detail="No fields to update")
+    incident_keys = fields.get("incident_keys")
+    allow_custom = bool(fields.pop("allow_custom_incident_prefixes", False))
+    if incident_keys is not None:
+        _validate_incident_keys(incident_keys, allow_custom=allow_custom)
 
     updated = skill.model_copy(update=fields)
     skills_service.save_skill(updated)
@@ -111,3 +220,15 @@ def execute_skill(name: str, skills_service=Depends(get_skills_service)):
         "skill_name": skill.name,
         "instructions": skill.instructions,
     }
+
+
+def _validate_incident_keys(keys: list[str], *, allow_custom: bool) -> None:
+    """Validate incident family prefixes against the catalog."""
+    for key in keys:
+        if not key.endswith(":"):
+            raise HTTPException(status_code=422, detail=f"incident_keys entry must end with ':': {key}")
+        if allow_custom:
+            continue
+        if key not in INCIDENT_FAMILY_CATALOG:
+            allowed = ", ".join(sorted(INCIDENT_FAMILY_CATALOG))
+            raise HTTPException(status_code=422, detail=f"Unknown incident key prefix '{key}'. Allowed: {allowed}")

--- a/src/squire/api/routers/skills.py
+++ b/src/squire/api/routers/skills.py
@@ -20,6 +20,7 @@ from ..schemas import (
 router = APIRouter()
 
 VALID_TRIGGERS = ("manual", "watch")
+_DRY_RUN_MAX_LLM_CALLS = 8
 
 
 @router.get("", response_model=list[Skill])
@@ -99,7 +100,13 @@ async def dry_run_playbook_routing(
     ]
     watch_skills = skills_service.list_skills(enabled_only=True, trigger="watch")
     playbook_skills = [s for s in watch_skills if s.incident_keys]
-    _, selections = await route_playbooks_for_incidents(incidents, playbook_skills, llm_config=llm_config)
+    selected_llm_config = llm_config if body.use_llm else None
+    _, selections = await route_playbooks_for_incidents(
+        incidents,
+        playbook_skills,
+        llm_config=selected_llm_config,
+        max_llm_calls=_DRY_RUN_MAX_LLM_CALLS,
+    )
     response_selections = [
         PlaybookDryRunSelection(
             incident={

--- a/src/squire/api/routers/watch.py
+++ b/src/squire/api/routers/watch.py
@@ -134,6 +134,9 @@ async def watch_config_get(
         notify_on_blocked=watch_config.notify_on_blocked,
         cycles_per_session=watch_config.cycles_per_session,
         max_context_events=watch_config.max_context_events,
+        max_identical_actions_per_cycle=watch_config.max_identical_actions_per_cycle,
+        blocked_action_cooldown_cycles=watch_config.blocked_action_cooldown_cycles,
+        max_remote_actions_per_cycle=watch_config.max_remote_actions_per_cycle,
         risk_tolerance=_effective_watch_risk_level(guardrails),
     )
 

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -132,26 +132,66 @@ class AlertRuleUpdate(BaseModel):
 class Skill(BaseModel):
     name: str
     description: str = ""
-    host: str = "all"
+    hosts: list[str] = ["all"]
     trigger: str = "manual"
     enabled: bool = True
+    incident_keys: list[str] = []
     instructions: str = ""
 
 
 class SkillCreate(BaseModel):
     name: str
     description: str
-    host: str = "all"
+    hosts: list[str] = ["all"]
     trigger: str = "manual"
+    incident_keys: list[str] = []
+    allow_custom_incident_prefixes: bool = False
     instructions: str
 
 
 class SkillUpdate(BaseModel):
     description: str | None = None
-    host: str | None = None
+    hosts: list[str] | None = None
     trigger: str | None = None
     enabled: bool | None = None
+    incident_keys: list[str] | None = None
+    allow_custom_incident_prefixes: bool | None = None
     instructions: str | None = None
+
+
+class IncidentFamilyInfo(BaseModel):
+    prefix: str
+    description: str
+
+
+class PlaybookDryRunIncident(BaseModel):
+    key: str
+    severity: str = "high"
+    host: str = "local"
+    title: str = ""
+    detail: str = ""
+
+
+class PlaybookDryRunRequest(BaseModel):
+    incidents: list[PlaybookDryRunIncident]
+
+
+class PlaybookDryRunSelection(BaseModel):
+    incident: PlaybookDryRunIncident
+    candidate_count: int
+    selected_playbook: str | None = None
+    path_taken: str
+    confidence: float
+    reasoning: str
+
+
+class PlaybookDryRunResponse(BaseModel):
+    selections: list[PlaybookDryRunSelection]
+
+
+class BootstrapPlaybooksResponse(BaseModel):
+    created: list[str]
+    skipped: list[str]
 
 
 # --- Events ---

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -249,6 +249,9 @@ class WatchConfigPatch(BaseModel):
     notify_on_blocked: bool | None = None
     cycles_per_session: int | None = None
     max_context_events: int | None = None
+    max_identical_actions_per_cycle: int | None = None
+    blocked_action_cooldown_cycles: int | None = None
+    max_remote_actions_per_cycle: int | None = None
 
 
 class GuardrailsConfigUpdate(BaseModel):
@@ -294,6 +297,12 @@ class WatchStatusResponse(BaseModel):
     session_id: str | None = None
     last_response: str | None = None
     pid: str | None = None
+    total_actions: str | None = None
+    total_blocked: str | None = None
+    total_errors: str | None = None
+    total_resolved: str | None = None
+    total_escalated: str | None = None
+    last_outcome: str | None = None
 
 
 class WatchConfigUpdate(BaseModel):
@@ -305,6 +314,9 @@ class WatchConfigUpdate(BaseModel):
     notify_on_blocked: bool | None = None
     cycles_per_session: int | None = None
     max_context_events: int | None = None
+    max_identical_actions_per_cycle: int | None = None
+    blocked_action_cooldown_cycles: int | None = None
+    max_remote_actions_per_cycle: int | None = None
     risk_tolerance: int | None = None
 
 
@@ -317,6 +329,9 @@ class WatchConfigResponse(BaseModel):
     notify_on_blocked: bool
     cycles_per_session: int
     max_context_events: int
+    max_identical_actions_per_cycle: int
+    blocked_action_cooldown_cycles: int
+    max_remote_actions_per_cycle: int
     risk_tolerance: int | None
 
 

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -1,6 +1,6 @@
 """Pydantic response models for the Squire web API."""
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 # --- System / Snapshots ---
 
@@ -173,7 +173,8 @@ class PlaybookDryRunIncident(BaseModel):
 
 
 class PlaybookDryRunRequest(BaseModel):
-    incidents: list[PlaybookDryRunIncident]
+    incidents: list[PlaybookDryRunIncident] = Field(min_length=1, max_length=25)
+    use_llm: bool = False
 
 
 class PlaybookDryRunSelection(BaseModel):
@@ -281,17 +282,17 @@ class LLMConfigUpdate(BaseModel):
 
 
 class WatchConfigPatch(BaseModel):
-    interval_minutes: int | None = None
-    max_tool_calls_per_cycle: int | None = None
-    cycle_timeout_seconds: int | None = None
+    interval_minutes: int | None = Field(default=None, ge=1)
+    max_tool_calls_per_cycle: int | None = Field(default=None, ge=1)
+    cycle_timeout_seconds: int | None = Field(default=None, ge=30)
     checkin_prompt: str | None = None
     notify_on_action: bool | None = None
     notify_on_blocked: bool | None = None
-    cycles_per_session: int | None = None
-    max_context_events: int | None = None
-    max_identical_actions_per_cycle: int | None = None
-    blocked_action_cooldown_cycles: int | None = None
-    max_remote_actions_per_cycle: int | None = None
+    cycles_per_session: int | None = Field(default=None, ge=1)
+    max_context_events: int | None = Field(default=None, ge=10)
+    max_identical_actions_per_cycle: int | None = Field(default=None, ge=1)
+    blocked_action_cooldown_cycles: int | None = Field(default=None, ge=1)
+    max_remote_actions_per_cycle: int | None = Field(default=None, ge=1)
 
 
 class GuardrailsConfigUpdate(BaseModel):
@@ -346,18 +347,18 @@ class WatchStatusResponse(BaseModel):
 
 
 class WatchConfigUpdate(BaseModel):
-    interval_minutes: int | None = None
-    max_tool_calls_per_cycle: int | None = None
-    cycle_timeout_seconds: int | None = None
+    interval_minutes: int | None = Field(default=None, ge=1)
+    max_tool_calls_per_cycle: int | None = Field(default=None, ge=1)
+    cycle_timeout_seconds: int | None = Field(default=None, ge=30)
     checkin_prompt: str | None = None
     notify_on_action: bool | None = None
     notify_on_blocked: bool | None = None
-    cycles_per_session: int | None = None
-    max_context_events: int | None = None
-    max_identical_actions_per_cycle: int | None = None
-    blocked_action_cooldown_cycles: int | None = None
-    max_remote_actions_per_cycle: int | None = None
-    risk_tolerance: int | None = None
+    cycles_per_session: int | None = Field(default=None, ge=1)
+    max_context_events: int | None = Field(default=None, ge=10)
+    max_identical_actions_per_cycle: int | None = Field(default=None, ge=1)
+    blocked_action_cooldown_cycles: int | None = Field(default=None, ge=1)
+    max_remote_actions_per_cycle: int | None = Field(default=None, ge=1)
+    risk_tolerance: int | None = Field(default=None, ge=1, le=5)
 
 
 class WatchConfigResponse(BaseModel):

--- a/src/squire/callbacks/risk_gate.py
+++ b/src/squire/callbacks/risk_gate.py
@@ -15,6 +15,7 @@ from google.adk.tools.tool_context import ToolContext
 from ..approval import ApprovalProvider, AsyncApprovalProvider
 from ..tools import TOOL_RISK_LEVELS
 from ..types import BeforeToolCallback
+from ..watch_autonomy import action_signature
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +116,17 @@ def create_risk_gate(
         host = args.get("host", "local")
         if host != "local":
             tool_risk = min(tool_risk + 1, 5)
+
+        # Watch-mode action cooldown blocks repeated/flapping signatures.
+        blocked_signatures = set(tool_context.state.get("watch_blocked_action_signatures") or [])
+        signature = action_signature(tool_name, args)
+        if signature in blocked_signatures:
+            return {
+                "error": (
+                    f"[BLOCKED] '{compound_name}' suppressed by watch cooldown policy to prevent flapping. "
+                    "Do NOT retry this action in this cycle."
+                )
+            }
 
         # Bump risk for forced operations
         if args.get("force"):

--- a/src/squire/cli.py
+++ b/src/squire/cli.py
@@ -187,7 +187,7 @@ def alerts_list() -> None:
     table = Table(title="Alert Rules")
     table.add_column("Name", style="cyan", no_wrap=True)
     table.add_column("Condition", style="white")
-    table.add_column("Host", style="blue")
+    table.add_column("Hosts", style="blue")
     table.add_column("Severity", style="yellow")
     table.add_column("Cooldown", style="dim")
     table.add_column("Status", style="green")
@@ -363,7 +363,7 @@ def skills_list() -> None:
         table.add_row(
             s.name,
             (s.description or "")[:40],
-            s.host,
+            ",".join(s.hosts),
             s.trigger,
             status,
         )
@@ -392,7 +392,7 @@ def skills_show(
     console.print(f"[bold cyan]{skill.name}[/bold cyan]  [{status}]")
     if skill.description:
         console.print(f"  {skill.description}")
-    console.print(f"  Host: {skill.host}  |  Trigger: {skill.trigger}")
+    console.print(f"  Hosts: {', '.join(skill.hosts)}  |  Trigger: {skill.trigger}")
     console.print()
 
     if skill.instructions:
@@ -409,9 +409,15 @@ def skills_add(
     instructions_file: Annotated[
         str | None, typer.Option("--instructions-file", "-f", help="Markdown file with skill instructions")
     ] = None,
-    host: Annotated[str, typer.Option("--host", help="Target host ('all' or specific name)")] = "all",
+    hosts: Annotated[
+        str, typer.Option("--hosts", help="Comma-separated target hosts (use 'all' for unrestricted)")
+    ] = "all",
     trigger: Annotated[str, typer.Option("--trigger", "-t", help="'manual' or 'watch'")] = "manual",
 ) -> None:
+    host_list = [h.strip() for h in hosts.split(",") if h.strip()]
+    if not host_list:
+        host_list = ["all"]
+
     """Add a new skill."""
     from pathlib import Path
 
@@ -449,7 +455,7 @@ def skills_add(
         skill = Skill(
             name=name,
             description=description,
-            host=host,
+            hosts=host_list,
             trigger=trigger,
             instructions=instructions,
         )

--- a/src/squire/config/watch.py
+++ b/src/squire/config/watch.py
@@ -79,3 +79,18 @@ class WatchConfig(BaseSettings):
         ge=10,
         description="Maximum ADK session events kept in context; older events are pruned each cycle",
     )
+    max_identical_actions_per_cycle: int = Field(
+        default=2,
+        ge=1,
+        description="Maximum identical tool signatures allowed within one cycle before suppression",
+    )
+    blocked_action_cooldown_cycles: int = Field(
+        default=3,
+        ge=1,
+        description="How many cycles to suppress recently blocked/repeated action signatures",
+    )
+    max_remote_actions_per_cycle: int = Field(
+        default=4,
+        ge=1,
+        description="Maximum remote-host tool calls allowed in a single cycle",
+    )

--- a/src/squire/database/service.py
+++ b/src/squire/database/service.py
@@ -556,6 +556,11 @@ class DatabaseService:
                     "status": end_content.get("status", "unknown"),
                     "duration_seconds": end_content.get("duration_seconds"),
                     "tool_count": end_content.get("tool_count", 0),
+                    "blocked_count": end_content.get("blocked_count", 0),
+                    "incident_count": ((end_content.get("outcome") or {}).get("incident_count", 0)),
+                    "resolved": ((end_content.get("outcome") or {}).get("resolved", False)),
+                    "escalated": ((end_content.get("outcome") or {}).get("escalated", False)),
+                    "incident_key": ((end_content.get("outcome") or {}).get("incident_fingerprint")),
                     "event_count": row_dict["event_count"],
                 }
             )

--- a/src/squire/instructions/shared.py
+++ b/src/squire/instructions/shared.py
@@ -74,10 +74,19 @@ def build_skill_section(ctx: ReadonlyContext) -> str:
     if not instructions:
         return ""
 
-    host = active_skill.get("host", "all")
+    hosts = active_skill.get("hosts", ["all"])
+    if isinstance(hosts, str):
+        hosts = [hosts]
     host_line = ""
-    if host != "all":
-        host_line = f"\n**Target host:** `{host}` — pass this as the `host` parameter to every tool call."
+    if hosts and hosts != ["all"]:
+        if len(hosts) == 1:
+            host_line = f"\n**Target host:** `{hosts[0]}` — pass this as the `host` parameter to every tool call."
+        else:
+            host_line = (
+                "\n**Target hosts:** "
+                + ", ".join(f"`{h}`" for h in hosts)
+                + " — choose the appropriate `host` per tool call."
+            )
 
     return f"""
 ## Active Skill: "{skill_name}"

--- a/src/squire/notifications/alert_evaluator.py
+++ b/src/squire/notifications/alert_evaluator.py
@@ -9,14 +9,14 @@ from datetime import UTC, datetime, timedelta
 
 from ..database.service import DatabaseService
 from .conditions import ConditionError, evaluate_condition, parse_condition
-from .webhook import WebhookDispatcher
+from .router import NotificationRouter
 
 logger = logging.getLogger(__name__)
 
 
 async def evaluate_alerts(
     db: DatabaseService,
-    notifier: WebhookDispatcher,
+    notifier: NotificationRouter,
     snapshot: dict[str, dict],
 ) -> int:
     """Evaluate all active alert rules against the current snapshot.
@@ -75,7 +75,7 @@ async def evaluate_alerts(
 
 
 async def _dispatch_alert(
-    notifier: WebhookDispatcher,
+    notifier: NotificationRouter,
     summary: str,
     rule: dict,
     host: str,

--- a/src/squire/skills/service.py
+++ b/src/squire/skills/service.py
@@ -7,8 +7,8 @@ Each skill lives in its own directory under the configured skills path:
         SKILL.md
 
 SKILL.md uses YAML frontmatter + freeform Markdown body (Open Agent Skills spec).
-Squire-specific fields (host, trigger, enabled) are stored under the ``metadata``
-key to stay spec-compliant.
+Squire-specific fields (hosts, trigger, enabled, incident_keys) are stored under
+the ``metadata`` key to stay spec-compliant.
 """
 
 import re
@@ -16,7 +16,7 @@ import shutil
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 # Spec: lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, max 64 chars.
 _NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
@@ -27,9 +27,10 @@ class Skill(BaseModel):
 
     name: str
     description: str = ""
-    host: str = "all"
+    hosts: list[str] = Field(default_factory=lambda: ["all"])
     trigger: str = "manual"  # "manual" | "watch"
     enabled: bool = True
+    incident_keys: list[str] = Field(default_factory=list)
     instructions: str = ""  # freeform Markdown body
 
     @field_validator("name")
@@ -42,6 +43,30 @@ class Skill(BaseModel):
         if not _NAME_RE.match(v):
             raise ValueError("name must be lowercase letters, numbers, and hyphens only (no leading/trailing hyphens)")
         return v
+
+    @field_validator("hosts", mode="before")
+    @classmethod
+    def validate_hosts(cls, value) -> list[str]:
+        if value is None:
+            return ["all"]
+        if isinstance(value, str):
+            value = [value]
+        hosts = [str(v).strip() for v in value if str(v).strip()]
+        if not hosts:
+            return ["all"]
+        if "all" in hosts:
+            return ["all"]
+        return sorted(set(hosts))
+
+    @field_validator("incident_keys", mode="before")
+    @classmethod
+    def validate_incident_keys(cls, value) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            value = [value]
+        keys = [str(v).strip() for v in value if str(v).strip()]
+        return sorted(set(keys))
 
 
 class SkillService:
@@ -116,13 +141,18 @@ class SkillService:
 
         # Squire-specific fields live under metadata (spec-compliant)
         meta = frontmatter.get("metadata") or {}
+        hosts = meta.get("hosts")
+        if hosts is None and "host" in meta:
+            # Legacy retrofit: host -> hosts
+            hosts = [meta.get("host", "all")]
 
         return Skill(
             name=frontmatter.get("name", dir_name),
             description=frontmatter.get("description", ""),
-            host=meta.get("host", "all"),
+            hosts=hosts if hosts is not None else ["all"],
             trigger=meta.get("trigger", "manual"),
             enabled=meta.get("enabled", True),
+            incident_keys=meta.get("incident_keys", []),
             instructions=body,
         )
 
@@ -137,12 +167,14 @@ class SkillService:
             "description": skill.description,
         }
         metadata: dict = {}
-        if skill.host != "all":
-            metadata["host"] = skill.host
+        if skill.hosts != ["all"]:
+            metadata["hosts"] = skill.hosts
         if skill.trigger != "manual":
             metadata["trigger"] = skill.trigger
         if not skill.enabled:
             metadata["enabled"] = skill.enabled
+        if skill.incident_keys:
+            metadata["incident_keys"] = skill.incident_keys
         if metadata:
             frontmatter["metadata"] = metadata
         fm_str = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False).strip()

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -39,6 +39,7 @@ from .notifications.alert_evaluator import evaluate_alerts
 from .notifications.email import EmailNotifier
 from .notifications.router import NotificationRouter
 from .notifications.webhook import WebhookDispatcher
+from .skills import SkillService
 from .system.registry import BackendRegistry
 from .tools import TOOL_RISK_LEVELS, set_db, set_notifier, set_registry
 from .watch_autonomy import (
@@ -50,7 +51,7 @@ from .watch_autonomy import (
     parse_contract_sections,
 )
 from .watch_emitter import WatchEventEmitter
-from .watch_playbooks import select_playbooks
+from .watch_playbooks import route_playbooks_for_incidents
 
 load_dotenv()
 
@@ -178,6 +179,7 @@ async def start_watch() -> None:
     notif_config = NotificationsConfig()
     watch_config = WatchConfig()
     skills_config = SkillsConfig()
+    skill_service = SkillService(skills_config.path)
 
     # Create backend registry (hosts loaded from DB below)
     registry = BackendRegistry()
@@ -307,6 +309,9 @@ async def start_watch() -> None:
             "total_errors": "0",
             "total_resolved": "0",
             "total_escalated": "0",
+            "playbook_deterministic_match": "0",
+            "playbook_semantic_match": "0",
+            "playbook_generic_fallback": "0",
             "last_outcome": "{}",
         },
     )
@@ -404,21 +409,55 @@ async def start_watch() -> None:
             session.state["watch_max_identical_actions_per_cycle"] = watch_config.max_identical_actions_per_cycle
             session.state["watch_max_remote_actions_per_cycle"] = watch_config.max_remote_actions_per_cycle
 
-            playbooks = select_playbooks(incidents)
+            watch_skills = []
+            playbook_skills = []
+            try:
+                watch_skills = skill_service.list_skills(enabled_only=True, trigger="watch")
+                playbook_skills = [sk for sk in watch_skills if sk.incident_keys]
+            except Exception:
+                logger.debug("Failed to load watch skills", exc_info=True)
+
+            playbook_path_counts = {
+                "deterministic_single": 0,
+                "tie_break": 0,
+                "semantic": 0,
+                "generic": 0,
+            }
+            try:
+                playbooks, playbook_selections = await route_playbooks_for_incidents(
+                    incidents,
+                    playbook_skills,
+                    llm_config=llm_config,
+                )
+            except Exception:
+                logger.debug("Playbook routing failed; using generic fallback", exc_info=True)
+                playbooks = []
+                playbook_selections = []
+
+            if playbook_selections:
+                for selection in playbook_selections:
+                    playbook_path_counts[selection.path_taken] = playbook_path_counts.get(selection.path_taken, 0) + 1
+                    sel_name = selection.selected_playbook or "default-watch-triage"
+                    await emitter.emit_phase(
+                        cycle_count,
+                        "playbook",
+                        f"{selection.incident.key} -> {sel_name}",
+                        details=(
+                            f"path={selection.path_taken}, candidates={selection.candidate_count}, "
+                            f"confidence={selection.confidence:.2f}, reason={selection.reasoning}"
+                        ),
+                    )
             prompt = build_cycle_contract_prompt(prompt, incidents, playbooks, blocked_signatures)
 
             # Append watch-triggered skills
             try:
-                from .skills import SkillService
-
-                skill_service = SkillService(skills_config.path)
-                watch_skills = skill_service.list_skills(enabled_only=True, trigger="watch")
-                if watch_skills:
+                non_playbook_skills = [sk for sk in watch_skills if not sk.incident_keys]
+                if non_playbook_skills:
                     skill_sections = []
-                    for sk in watch_skills:
+                    for sk in non_playbook_skills:
                         if not sk.instructions:
                             continue
-                        host_label = sk.host
+                        host_label = ",".join(sk.hosts)
                         skill_sections.append(f"### Skill: {sk.name} (host: {host_label})\n{sk.instructions}")
                     if skill_sections:
                         prompt += (
@@ -489,6 +528,7 @@ async def start_watch() -> None:
                     blocked_count=blocked_count,
                     cycle_status="ok",
                 )
+                outcome["playbook_selection"] = playbook_path_counts
                 outcome["remote_tool_count"] = remote_tool_count
                 issue_key = dominant_incident_key(incidents)
                 if issue_key:
@@ -526,6 +566,7 @@ async def start_watch() -> None:
                     blocked_count=0,
                     cycle_status="error",
                 )
+                outcome["playbook_selection"] = playbook_path_counts
             except Exception as e:
                 last_cycle_error = f"{type(e).__name__}: {e}"
                 logger.error("Cycle %d failed: %s", cycle_count, e, exc_info=True)
@@ -540,6 +581,7 @@ async def start_watch() -> None:
                     blocked_count=0,
                     cycle_status="error",
                 )
+                outcome["playbook_selection"] = playbook_path_counts
 
             cycle_duration = (datetime.now(UTC) - cycle_start_time).total_seconds()
             cycle_status = "ok" if last_cycle_error is None else "error"
@@ -746,12 +788,21 @@ async def _persist_watch_metrics(db: DatabaseService, outcome: dict) -> None:
     total_errors = int(await db.get_watch_state("total_errors") or "0")
     total_resolved = int(await db.get_watch_state("total_resolved") or "0")
     total_escalated = int(await db.get_watch_state("total_escalated") or "0")
+    total_playbook_deterministic = int(await db.get_watch_state("playbook_deterministic_match") or "0")
+    total_playbook_semantic = int(await db.get_watch_state("playbook_semantic_match") or "0")
+    total_playbook_generic = int(await db.get_watch_state("playbook_generic_fallback") or "0")
+    playbook_selection = outcome.get("playbook_selection", {}) or {}
     totals = {
         "total_actions": total_actions + int(outcome.get("tool_count", 0)),
         "total_blocked": total_blocked + int(outcome.get("blocked_count", 0)),
         "total_errors": total_errors + (1 if outcome.get("cycle_status") != "ok" else 0),
         "total_resolved": total_resolved + (1 if outcome.get("resolved") else 0),
         "total_escalated": total_escalated + (1 if outcome.get("escalated") else 0),
+        "playbook_deterministic_match": total_playbook_deterministic
+        + int(playbook_selection.get("deterministic_single", 0))
+        + int(playbook_selection.get("tie_break", 0)),
+        "playbook_semantic_match": total_playbook_semantic + int(playbook_selection.get("semantic", 0)),
+        "playbook_generic_fallback": total_playbook_generic + int(playbook_selection.get("generic", 0)),
     }
     for key, value in totals.items():
         await db.set_watch_state(key, str(value))

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -11,6 +11,7 @@ import logging
 import os
 import signal
 import sys
+from collections import defaultdict
 from datetime import UTC, datetime
 
 from agent_risk_engine import RiskEvaluator, RuleGate
@@ -40,7 +41,16 @@ from .notifications.router import NotificationRouter
 from .notifications.webhook import WebhookDispatcher
 from .system.registry import BackendRegistry
 from .tools import TOOL_RISK_LEVELS, set_db, set_notifier, set_registry
+from .watch_autonomy import (
+    action_signature,
+    build_cycle_contract_prompt,
+    build_cycle_outcome,
+    detect_incidents,
+    dominant_incident_key,
+    parse_contract_sections,
+)
 from .watch_emitter import WatchEventEmitter
+from .watch_playbooks import select_playbooks
 
 load_dotenv()
 
@@ -57,6 +67,9 @@ _WATCH_LIVE_KEYS = frozenset(
         "notify_on_blocked",
         "cycles_per_session",
         "max_context_events",
+        "max_identical_actions_per_cycle",
+        "blocked_action_cooldown_cycles",
+        "max_remote_actions_per_cycle",
     }
 )
 
@@ -289,6 +302,12 @@ async def start_watch() -> None:
             "session_id": session.id,
             "interval_minutes": str(watch_config.interval_minutes),
             "risk_tolerance": str(watch_tolerance),
+            "total_actions": "0",
+            "total_blocked": "0",
+            "total_errors": "0",
+            "total_resolved": "0",
+            "total_escalated": "0",
+            "last_outcome": "{}",
         },
     )
 
@@ -314,6 +333,7 @@ async def start_watch() -> None:
 
     cycle_count = 0
     last_cycle_error: str | None = None
+    action_cooldowns: dict[str, int] = defaultdict(int)
 
     try:
         while not shutdown.is_set():
@@ -336,11 +356,22 @@ async def start_watch() -> None:
                 break
 
             # Collect fresh snapshots
+            incidents = []
             try:
                 snapshot = await _collect_all_snapshots(registry)
                 if "local" in snapshot:
                     await db.save_snapshot(snapshot["local"])
                 session.state["latest_snapshot"] = snapshot
+                incidents = detect_incidents(snapshot)
+                for incident in incidents:
+                    await emitter.emit_incident(
+                        cycle_count,
+                        key=incident.key,
+                        severity=incident.severity,
+                        title=incident.title,
+                        detail=incident.detail,
+                        host=incident.host,
+                    )
 
                 # Evaluate alert rules against fresh snapshot
                 try:
@@ -360,6 +391,21 @@ async def start_watch() -> None:
                     "Adjust your approach if needed (e.g. skip unavailable tools).\n\n"
                     f"{prompt}"
                 )
+
+            # Decay action cooldowns and expose active blocks to the risk gate.
+            blocked_signatures = []
+            for signature in list(action_cooldowns):
+                action_cooldowns[signature] -= 1
+                if action_cooldowns[signature] <= 0:
+                    del action_cooldowns[signature]
+                else:
+                    blocked_signatures.append(signature)
+            session.state["watch_blocked_action_signatures"] = blocked_signatures
+            session.state["watch_max_identical_actions_per_cycle"] = watch_config.max_identical_actions_per_cycle
+            session.state["watch_max_remote_actions_per_cycle"] = watch_config.max_remote_actions_per_cycle
+
+            playbooks = select_playbooks(incidents)
+            prompt = build_cycle_contract_prompt(prompt, incidents, playbooks, blocked_signatures)
 
             # Append watch-triggered skills
             try:
@@ -388,7 +434,19 @@ async def start_watch() -> None:
             cycle_tool_count = 0
             response_text = ""
             try:
-                response_text, cycle_tool_count = await asyncio.wait_for(
+                await emitter.emit_phase(
+                    cycle_count,
+                    "detect",
+                    f"Detected {len(incidents)} incident(s)",
+                    details="; ".join(f"{i.title}@{i.host}" for i in incidents[:8]),
+                )
+                (
+                    response_text,
+                    cycle_tool_count,
+                    blocked_count,
+                    cycle_signatures,
+                    remote_tool_count,
+                ) = await asyncio.wait_for(
                     _run_cycle(
                         runner,
                         session,
@@ -398,6 +456,8 @@ async def start_watch() -> None:
                         emitter=emitter,
                         cycle=cycle_count,
                         max_tool_calls=watch_config.max_tool_calls_per_cycle,
+                        max_identical_actions=watch_config.max_identical_actions_per_cycle,
+                        max_remote_actions=watch_config.max_remote_actions_per_cycle,
                     ),
                     timeout=watch_config.cycle_timeout_seconds,
                 )
@@ -406,20 +466,94 @@ async def start_watch() -> None:
                     await db.save_message(session_id=session.id, role="assistant", content=response_text)
                     await db.set_watch_state("last_response", response_text[:500])
                     logger.info("Cycle %d:\n%s", cycle_count, response_text)
+
+                response_sections = parse_contract_sections(response_text)
+                if response_sections.get("rca hypotheses"):
+                    await emitter.emit_phase(
+                        cycle_count,
+                        "rca",
+                        "RCA hypotheses generated",
+                        details=response_sections["rca hypotheses"][:600],
+                    )
+                if response_sections.get("action plan and actions taken"):
+                    await emitter.emit_phase(
+                        cycle_count,
+                        "remediate",
+                        "Remediation actions planned/executed",
+                        details=response_sections["action plan and actions taken"][:600],
+                    )
+                outcome = build_cycle_outcome(
+                    incidents,
+                    response_sections,
+                    tool_count=cycle_tool_count,
+                    blocked_count=blocked_count,
+                    cycle_status="ok",
+                )
+                outcome["remote_tool_count"] = remote_tool_count
+                issue_key = dominant_incident_key(incidents)
+                if issue_key:
+                    outcome["incident_fingerprint"] = issue_key
+                await emitter.emit_phase(
+                    cycle_count,
+                    "verify",
+                    "Verification completed",
+                    details=outcome["verification"],
+                )
+                if outcome.get("escalated"):
+                    await emitter.emit_phase(
+                        cycle_count,
+                        "escalate",
+                        "Escalation required",
+                        details=outcome.get("escalation", ""),
+                    )
+
+                for signature in cycle_signatures:
+                    action_cooldowns[signature] = max(
+                        action_cooldowns.get(signature, 0),
+                        watch_config.blocked_action_cooldown_cycles,
+                    )
             except TimeoutError:
                 last_cycle_error = f"Cycle timed out after {watch_config.cycle_timeout_seconds}s"
                 logger.warning("Cycle %d timed out after %ds", cycle_count, watch_config.cycle_timeout_seconds)
                 await db.set_watch_state("last_response", f"[timeout after {watch_config.cycle_timeout_seconds}s]")
                 await _dispatch(notifier, "watch.error", f"Watch cycle {cycle_count} timed out.")
+                blocked_count = 0
+                cycle_tool_count = 0
+                outcome = build_cycle_outcome(
+                    incidents,
+                    {},
+                    tool_count=0,
+                    blocked_count=0,
+                    cycle_status="error",
+                )
             except Exception as e:
                 last_cycle_error = f"{type(e).__name__}: {e}"
                 logger.error("Cycle %d failed: %s", cycle_count, e, exc_info=True)
                 await db.set_watch_state("last_response", f"[error: {e}]")
                 await _dispatch(notifier, "watch.error", f"Watch cycle {cycle_count} failed.")
+                blocked_count = 0
+                cycle_tool_count = 0
+                outcome = build_cycle_outcome(
+                    incidents,
+                    {},
+                    tool_count=0,
+                    blocked_count=0,
+                    cycle_status="error",
+                )
 
             cycle_duration = (datetime.now(UTC) - cycle_start_time).total_seconds()
             cycle_status = "ok" if last_cycle_error is None else "error"
-            await emitter.emit_cycle_end(cycle_count, cycle_status, cycle_duration, tool_count=cycle_tool_count)
+            outcome["cycle_status"] = cycle_status
+            await emitter.emit_cycle_end(
+                cycle_count,
+                cycle_status,
+                cycle_duration,
+                tool_count=cycle_tool_count,
+                blocked_count=blocked_count,
+                outcome=outcome,
+            )
+            await _persist_watch_metrics(db, outcome)
+            await _dispatch_outcome_notifications(db, notifier, cycle_count, outcome)
 
             if watch_config.notify_on_action and cycle_tool_count > 0 and last_cycle_error is None:
                 await _dispatch(
@@ -472,6 +606,9 @@ async def start_watch() -> None:
                 cycle_count = 0
                 session_ref[0] = session
 
+            if cycle_count % 10 == 0:
+                await db.cleanup_watch_data()
+
             # Sleep until next cycle (interruptible by shutdown signal or commands)
             await _interruptible_sleep(
                 db,
@@ -502,15 +639,21 @@ async def _run_cycle(
     emitter: WatchEventEmitter | None = None,
     cycle: int = 0,
     max_tool_calls: int = 0,
-) -> tuple[str, int]:
+    max_identical_actions: int = 0,
+    max_remote_actions: int = 0,
+) -> tuple[str, int, int, list[str], int]:
     """Inject a prompt and collect the agent's response.
 
     Returns:
-        A tuple of (response_text, tool_call_count).
+        A tuple of (response_text, tool_call_count, blocked_count, cooldown_signatures, remote_tool_count).
     """
     message = types.Content(parts=[types.Part(text=prompt)])
     response_parts: list[str] = []
     tool_count = 0
+    blocked_count = 0
+    remote_tool_count = 0
+    signature_counts: dict[str, int] = defaultdict(int)
+    cooldown_signatures: list[str] = []
 
     async for event in runner.run_async(
         user_id=app_config.user_id,
@@ -524,21 +667,40 @@ async def _run_cycle(
                 continue
             if part.function_call:
                 tool_count += 1
+                call_args = dict(part.function_call.args or {})
+                signature = action_signature(part.function_call.name, call_args)
+                signature_counts[signature] += 1
+                if signature_counts[signature] > 1:
+                    cooldown_signatures.append(signature)
+                if call_args.get("host", "local") != "local":
+                    remote_tool_count += 1
                 if emitter:
-                    await emitter.emit_tool_call(cycle, part.function_call.name, dict(part.function_call.args or {}))
+                    await emitter.emit_tool_call(cycle, part.function_call.name, call_args)
+                if max_identical_actions and signature_counts[signature] > max_identical_actions:
+                    blocked_count += 1
+                    response_parts.append(
+                        f"\n[Cycle stopped: repeated action signature exceeded limit ({max_identical_actions})]"
+                    )
+                    return "".join(response_parts), tool_count, blocked_count, cooldown_signatures, remote_tool_count
+                if max_remote_actions and remote_tool_count > max_remote_actions:
+                    blocked_count += 1
+                    response_parts.append(f"\n[Cycle stopped: reached {max_remote_actions} remote action limit]")
+                    return "".join(response_parts), tool_count, blocked_count, cooldown_signatures, remote_tool_count
                 if max_tool_calls and tool_count >= max_tool_calls:
                     logger.warning("Cycle %d hit tool call limit (%d)", cycle, max_tool_calls)
                     response_parts.append(f"\n[Cycle stopped: reached {max_tool_calls} tool call limit]")
-                    return "".join(response_parts), tool_count
+                    return "".join(response_parts), tool_count, blocked_count, cooldown_signatures, remote_tool_count
             elif part.function_response and emitter:
                 output = str(part.function_response.response) if part.function_response.response else ""
+                if "[BLOCKED]" in output or "[DENIED]" in output:
+                    blocked_count += 1
                 await emitter.emit_tool_result(cycle, part.function_response.name or "", output)
             elif part.text and not part.function_call and not part.function_response:
                 response_parts.append(part.text)
                 if emitter:
                     await emitter.emit_token(cycle, part.text)
 
-    return "".join(response_parts), tool_count
+    return "".join(response_parts), tool_count, blocked_count, cooldown_signatures, remote_tool_count
 
 
 def _prune_session_history(runner: InMemoryRunner, session, max_events: int) -> int:
@@ -576,6 +738,61 @@ async def _dispatch(notifier: NotificationRouter, category: str, summary: str) -
         await notifier.dispatch(category=category, summary=summary)
     except Exception:
         logger.debug("Failed to dispatch %s notification", category, exc_info=True)
+
+
+async def _persist_watch_metrics(db: DatabaseService, outcome: dict) -> None:
+    total_actions = int(await db.get_watch_state("total_actions") or "0")
+    total_blocked = int(await db.get_watch_state("total_blocked") or "0")
+    total_errors = int(await db.get_watch_state("total_errors") or "0")
+    total_resolved = int(await db.get_watch_state("total_resolved") or "0")
+    total_escalated = int(await db.get_watch_state("total_escalated") or "0")
+    totals = {
+        "total_actions": total_actions + int(outcome.get("tool_count", 0)),
+        "total_blocked": total_blocked + int(outcome.get("blocked_count", 0)),
+        "total_errors": total_errors + (1 if outcome.get("cycle_status") != "ok" else 0),
+        "total_resolved": total_resolved + (1 if outcome.get("resolved") else 0),
+        "total_escalated": total_escalated + (1 if outcome.get("escalated") else 0),
+    }
+    for key, value in totals.items():
+        await db.set_watch_state(key, str(value))
+    await db.set_watch_state("last_outcome", json.dumps(outcome))
+
+
+async def _dispatch_outcome_notifications(
+    db: DatabaseService,
+    notifier: NotificationRouter,
+    cycle: int,
+    outcome: dict,
+) -> None:
+    incident_count = int(outcome.get("incident_count", 0))
+    if incident_count > 0:
+        incident_fingerprint = str(outcome.get("incident_fingerprint", "n/a"))
+        previous = await db.get_watch_state("last_notified_incident")
+        if previous != incident_fingerprint:
+            await _dispatch(
+                notifier,
+                "watch.incident_detected",
+                f"Cycle {cycle}: detected {incident_count} incident(s) ({incident_fingerprint}).",
+            )
+            await db.set_watch_state("last_notified_incident", incident_fingerprint)
+    if int(outcome.get("tool_count", 0)) > 0:
+        await _dispatch(
+            notifier,
+            "watch.remediation",
+            f"Cycle {cycle}: executed {outcome.get('tool_count', 0)} remediation action(s).",
+        )
+    if outcome.get("resolved"):
+        await _dispatch(notifier, "watch.verification", f"Cycle {cycle}: remediation verified as resolved.")
+    if outcome.get("escalated"):
+        await _dispatch(notifier, "watch.escalation", f"Cycle {cycle}: escalation required for unresolved issue.")
+    if cycle % 6 == 0:
+        summary = (
+            f"Cycle {cycle} digest: actions={await db.get_watch_state('total_actions') or '0'}, "
+            f"blocked={await db.get_watch_state('total_blocked') or '0'}, "
+            f"resolved={await db.get_watch_state('total_resolved') or '0'}, "
+            f"escalated={await db.get_watch_state('total_escalated') or '0'}."
+        )
+        await _dispatch(notifier, "watch.digest", summary)
 
 
 async def get_watch_status() -> dict[str, str] | None:

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -74,6 +74,30 @@ _WATCH_LIVE_KEYS = frozenset(
     }
 )
 
+_WATCH_ROUTING_TIMEOUT_SECONDS = 15
+_WATCH_ROUTING_MAX_LLM_CALLS = 4
+_WATCH_ROUTING_LLM_TIMEOUT_SECONDS = 6.0
+
+
+def _validated_live_watch_updates(
+    payload: dict,
+    watch_config: WatchConfig,
+) -> tuple[dict, int | None]:
+    """Validate and normalize live watch config updates before applying them."""
+    updates = {key: payload[key] for key in _WATCH_LIVE_KEYS if key in payload}
+    if updates:
+        candidate = watch_config.model_dump()
+        candidate.update(updates)
+        validated = WatchConfig.model_validate(candidate)
+        updates = {key: getattr(validated, key) for key in updates}
+
+    risk_tolerance: int | None = None
+    if "risk_tolerance" in payload:
+        risk_tolerance = int(payload["risk_tolerance"])
+        if not 1 <= risk_tolerance <= 5:
+            raise ValueError("risk_tolerance must be between 1 and 5")
+    return updates, risk_tolerance
+
 
 async def _poll_commands(
     db: DatabaseService,
@@ -95,13 +119,15 @@ async def _poll_commands(
                 await db.update_watch_command_status(cmd_id, "completed")
             elif command == "update_config" and watch_config is not None:
                 payload = json.loads(cmd["payload"] or "{}")
-                for key in _WATCH_LIVE_KEYS:
-                    if key in payload:
-                        setattr(watch_config, key, payload[key])
-                if "interval_minutes" in payload:
-                    await db.set_watch_state("interval_minutes", str(payload["interval_minutes"]))
-                if "risk_tolerance" in payload and risk_evaluator is not None:
-                    threshold = int(payload["risk_tolerance"])
+                updates, risk_tolerance = _validated_live_watch_updates(payload, watch_config)
+
+                for key, value in updates.items():
+                    setattr(watch_config, key, value)
+                if "interval_minutes" in updates:
+                    await db.set_watch_state("interval_minutes", str(updates["interval_minutes"]))
+
+                if risk_tolerance is not None and risk_evaluator is not None:
+                    threshold = risk_tolerance
                     risk_evaluator.rule_gate.threshold = threshold
                     if session_state_template is not None:
                         session_state_template["risk_tolerance"] = threshold
@@ -424,10 +450,15 @@ async def start_watch() -> None:
                 "generic": 0,
             }
             try:
-                playbooks, playbook_selections = await route_playbooks_for_incidents(
-                    incidents,
-                    playbook_skills,
-                    llm_config=llm_config,
+                playbooks, playbook_selections = await asyncio.wait_for(
+                    route_playbooks_for_incidents(
+                        incidents,
+                        playbook_skills,
+                        llm_config=llm_config,
+                        max_llm_calls=_WATCH_ROUTING_MAX_LLM_CALLS,
+                        llm_timeout_seconds=_WATCH_ROUTING_LLM_TIMEOUT_SECONDS,
+                    ),
+                    timeout=_WATCH_ROUTING_TIMEOUT_SECONDS,
                 )
             except Exception:
                 logger.debug("Playbook routing failed; using generic fallback", exc_info=True)

--- a/src/squire/watch_autonomy.py
+++ b/src/squire/watch_autonomy.py
@@ -1,0 +1,208 @@
+"""Autonomy helpers for watch mode lifecycle and outcome tracking."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class Incident:
+    """Detected incident from snapshot telemetry."""
+
+    key: str
+    severity: str
+    title: str
+    detail: str
+    host: str = "local"
+
+
+def detect_incidents(snapshot: dict[str, dict]) -> list[Incident]:
+    """Detect high-value incidents from multi-host snapshot data."""
+    incidents: list[Incident] = []
+
+    for host, host_snapshot in snapshot.items():
+        error = (host_snapshot or {}).get("error")
+        if error:
+            incidents.append(
+                Incident(
+                    key=f"host-unreachable:{host}",
+                    severity="high",
+                    title="Host unreachable",
+                    detail=str(error),
+                    host=host,
+                )
+            )
+            continue
+
+        disk_raw = str((host_snapshot or {}).get("disk_usage_raw", ""))
+        disk_percent = _extract_max_percent(disk_raw)
+        if disk_percent >= 90:
+            incidents.append(
+                Incident(
+                    key=f"disk-pressure:{host}",
+                    severity="high",
+                    title="Disk pressure",
+                    detail=f"Observed disk usage at {disk_percent:.0f}%",
+                    host=host,
+                )
+            )
+        elif disk_percent >= 80:
+            incidents.append(
+                Incident(
+                    key=f"disk-warning:{host}",
+                    severity="medium",
+                    title="Disk usage warning",
+                    detail=f"Observed disk usage at {disk_percent:.0f}%",
+                    host=host,
+                )
+            )
+
+        for container in (host_snapshot or {}).get("containers", []) or []:
+            state = str(container.get("state", "")).lower()
+            status = str(container.get("status", "")).lower()
+            name = str(container.get("name", "unknown"))
+            if any(flag in state for flag in ("restarting", "dead", "exited")) or "unhealthy" in status:
+                incidents.append(
+                    Incident(
+                        key=f"container-unhealthy:{host}:{name}",
+                        severity="high",
+                        title="Container unhealthy",
+                        detail=f"{name} is in state='{state or status}'",
+                        host=host,
+                    )
+                )
+
+    return incidents
+
+
+def build_cycle_contract_prompt(
+    base_prompt: str,
+    incidents: list[Incident],
+    playbook_instructions: list[str],
+    blocked_signatures: list[str],
+) -> str:
+    """Compose a strict contract prompt for autonomous watch cycles."""
+    sections = [base_prompt.strip()]
+    sections.append(
+        
+            "You are operating in strict autonomous watch mode. Follow this exact lifecycle:\n"
+            "1) Detect incidents and prioritize by severity.\n"
+            "2) Produce RCA hypotheses with confidence.\n"
+            "3) Execute only bounded, low-blast-radius remediation actions.\n"
+            "4) Verify outcomes with fresh checks.\n"
+            "5) Escalate unresolved issues with explicit reason."
+        
+    )
+    if incidents:
+        lines = [f"- [{inc.severity}] {inc.title} ({inc.host}) :: {inc.detail}" for inc in incidents]
+        sections.append("Detected incidents:\n" + "\n".join(lines))
+    else:
+        sections.append("Detected incidents:\n- none; run proactive health checks and report status.")
+
+    if playbook_instructions:
+        sections.append(
+            "Autonomous playbooks to apply (only when relevant):\n" + "\n\n".join(playbook_instructions)
+        )
+
+    if blocked_signatures:
+        blocked = "\n".join(f"- {signature}" for signature in blocked_signatures)
+        sections.append(
+            "Do not repeat these recent actions (cooldown active):\n"
+            f"{blocked}\n"
+            "Choose lower-risk alternatives or escalate."
+        )
+
+    sections.append(
+        
+            "Format your final response with these sections:\n"
+            "## Incident Summary\n"
+            "## RCA Hypotheses\n"
+            "## Action Plan and Actions Taken\n"
+            "## Verification Results\n"
+            "## Escalation"
+        
+    )
+    return "\n\n".join(sections)
+
+
+def parse_contract_sections(text: str) -> dict[str, str]:
+    """Extract canonical contract sections from markdown response text."""
+    pattern = re.compile(r"^##\s+(.+?)\s*$", flags=re.MULTILINE)
+    headers = list(pattern.finditer(text))
+    if not headers:
+        return {}
+
+    sections: dict[str, str] = {}
+    for idx, match in enumerate(headers):
+        title = match.group(1).strip().lower()
+        start = match.end()
+        end = headers[idx + 1].start() if idx + 1 < len(headers) else len(text)
+        sections[title] = text[start:end].strip()
+    return sections
+
+
+def build_cycle_outcome(
+    incidents: list[Incident],
+    sections: dict[str, str],
+    *,
+    tool_count: int,
+    blocked_count: int,
+    cycle_status: str,
+) -> dict:
+    """Build structured cycle outcome for persistence and UI."""
+    escalation = sections.get("escalation", "")
+    verification = sections.get("verification results", "")
+    action_text = sections.get("action plan and actions taken", "")
+
+    resolved = bool(verification) and "unresolved" not in verification.lower() and "failed" not in verification.lower()
+    escalated = bool(escalation) and escalation.lower() not in {"none", "n/a", "no escalation"}
+    issue_key = dominant_incident_key(incidents)
+
+    return {
+        "incident_count": len(incidents),
+        "incident_key": issue_key,
+        "resolved": resolved and cycle_status == "ok",
+        "escalated": escalated or cycle_status != "ok",
+        "blocked_count": blocked_count,
+        "tool_count": tool_count,
+        "cycle_status": cycle_status,
+        "rca": sections.get("rca hypotheses", "")[:600],
+        "verification": verification[:600],
+        "actions": action_text[:600],
+        "escalation": escalation[:600],
+    }
+
+
+def dominant_incident_key(incidents: list[Incident]) -> str | None:
+    """Stable key for deduplicating repeated notifications."""
+    if not incidents:
+        return None
+    ordered = sorted(inc.key for inc in incidents)
+    raw = "|".join(ordered)
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def action_signature(tool_name: str, args: dict) -> str:
+    """Normalize a tool call into a short stable signature."""
+    focus = {
+        "action": args.get("action"),
+        "host": args.get("host", "local"),
+        "name": args.get("name"),
+        "service": args.get("service"),
+        "container": args.get("container"),
+        "stack": args.get("stack"),
+        "command": args.get("command"),
+    }
+    encoded = json.dumps(focus, sort_keys=True, default=str)
+    digest = hashlib.sha1(encoded.encode("utf-8")).hexdigest()[:10]
+    return f"{tool_name}:{digest}"
+
+
+def _extract_max_percent(disk_usage_raw: str) -> float:
+    matches = re.findall(r"(\d{1,3})%", disk_usage_raw)
+    if not matches:
+        return 0.0
+    return max(float(m) for m in matches)

--- a/src/squire/watch_autonomy.py
+++ b/src/squire/watch_autonomy.py
@@ -7,6 +7,13 @@ import json
 import re
 from dataclasses import dataclass
 
+INCIDENT_FAMILY_CATALOG: dict[str, str] = {
+    "container-unhealthy:": "Container is unhealthy/restarting/dead/exited.",
+    "disk-pressure:": "Disk usage is critically high.",
+    "disk-warning:": "Disk usage is elevated.",
+    "host-unreachable:": "Host snapshot could not be collected.",
+}
+
 
 @dataclass(slots=True)
 class Incident:
@@ -87,14 +94,12 @@ def build_cycle_contract_prompt(
     """Compose a strict contract prompt for autonomous watch cycles."""
     sections = [base_prompt.strip()]
     sections.append(
-        
-            "You are operating in strict autonomous watch mode. Follow this exact lifecycle:\n"
-            "1) Detect incidents and prioritize by severity.\n"
-            "2) Produce RCA hypotheses with confidence.\n"
-            "3) Execute only bounded, low-blast-radius remediation actions.\n"
-            "4) Verify outcomes with fresh checks.\n"
-            "5) Escalate unresolved issues with explicit reason."
-        
+        "You are operating in strict autonomous watch mode. Follow this exact lifecycle:\n"
+        "1) Detect incidents and prioritize by severity.\n"
+        "2) Produce RCA hypotheses with confidence.\n"
+        "3) Execute only bounded, low-blast-radius remediation actions.\n"
+        "4) Verify outcomes with fresh checks.\n"
+        "5) Escalate unresolved issues with explicit reason."
     )
     if incidents:
         lines = [f"- [{inc.severity}] {inc.title} ({inc.host}) :: {inc.detail}" for inc in incidents]
@@ -103,9 +108,7 @@ def build_cycle_contract_prompt(
         sections.append("Detected incidents:\n- none; run proactive health checks and report status.")
 
     if playbook_instructions:
-        sections.append(
-            "Autonomous playbooks to apply (only when relevant):\n" + "\n\n".join(playbook_instructions)
-        )
+        sections.append("Autonomous playbooks to apply (only when relevant):\n" + "\n\n".join(playbook_instructions))
 
     if blocked_signatures:
         blocked = "\n".join(f"- {signature}" for signature in blocked_signatures)
@@ -116,14 +119,12 @@ def build_cycle_contract_prompt(
         )
 
     sections.append(
-        
-            "Format your final response with these sections:\n"
-            "## Incident Summary\n"
-            "## RCA Hypotheses\n"
-            "## Action Plan and Actions Taken\n"
-            "## Verification Results\n"
-            "## Escalation"
-        
+        "Format your final response with these sections:\n"
+        "## Incident Summary\n"
+        "## RCA Hypotheses\n"
+        "## Action Plan and Actions Taken\n"
+        "## Verification Results\n"
+        "## Escalation"
     )
     return "\n\n".join(sections)
 
@@ -158,7 +159,7 @@ def build_cycle_outcome(
     action_text = sections.get("action plan and actions taken", "")
 
     resolved = bool(verification) and "unresolved" not in verification.lower() and "failed" not in verification.lower()
-    escalated = bool(escalation) and escalation.lower() not in {"none", "n/a", "no escalation"}
+    escalated = bool(escalation) and not _is_non_escalation_text(escalation)
     issue_key = dominant_incident_key(incidents)
 
     return {
@@ -206,3 +207,30 @@ def _extract_max_percent(disk_usage_raw: str) -> float:
     if not matches:
         return 0.0
     return max(float(m) for m in matches)
+
+
+def _is_non_escalation_text(text: str) -> bool:
+    """Return True when escalation text explicitly means no escalation needed."""
+    normalized = re.sub(r"[*_`>#-]", " ", text.lower())
+    normalized = re.sub(r"\s+", " ", normalized).strip(" .:")
+    if not normalized:
+        return True
+
+    markers = (
+        "none",
+        "n/a",
+        "na",
+        "no escalation",
+        "not required",
+        "not needed",
+        "no further action",
+    )
+    if normalized in markers:
+        return True
+    return any(normalized.startswith(f"{marker} ") or normalized.startswith(f"{marker}:") for marker in markers)
+
+
+def severity_rank(severity: str) -> int:
+    """Sort helper for deterministic incident ordering."""
+    ranks = {"high": 0, "medium": 1, "low": 2}
+    return ranks.get(severity.lower(), 3)

--- a/src/squire/watch_emitter.py
+++ b/src/squire/watch_emitter.py
@@ -27,7 +27,15 @@ class WatchEventEmitter:
     async def emit_cycle_start(self, cycle: int, session_id: str) -> None:
         await self._emit(cycle, "cycle_start", json.dumps({"session_id": session_id}))
 
-    async def emit_cycle_end(self, cycle: int, status: str, duration_seconds: float, tool_count: int) -> None:
+    async def emit_cycle_end(
+        self,
+        cycle: int,
+        status: str,
+        duration_seconds: float,
+        tool_count: int,
+        blocked_count: int = 0,
+        outcome: dict | None = None,
+    ) -> None:
         await self._emit(
             cycle,
             "cycle_end",
@@ -36,6 +44,8 @@ class WatchEventEmitter:
                     "status": status,
                     "duration_seconds": duration_seconds,
                     "tool_count": tool_count,
+                    "blocked_count": blocked_count,
+                    "outcome": outcome or {},
                 }
             ),
         )
@@ -84,6 +94,34 @@ class WatchEventEmitter:
                 {
                     "old_session_id": old_session_id,
                     "new_session_id": new_session_id,
+                }
+            ),
+        )
+
+    async def emit_phase(self, cycle: int, phase: str, summary: str, details: str | None = None) -> None:
+        await self._emit(
+            cycle,
+            "phase",
+            json.dumps(
+                {
+                    "phase": phase,
+                    "summary": summary,
+                    "details": details or "",
+                }
+            ),
+        )
+
+    async def emit_incident(self, cycle: int, key: str, severity: str, title: str, detail: str, host: str) -> None:
+        await self._emit(
+            cycle,
+            "incident",
+            json.dumps(
+                {
+                    "key": key,
+                    "severity": severity,
+                    "title": title,
+                    "detail": detail,
+                    "host": host,
                 }
             ),
         )

--- a/src/squire/watch_playbooks/__init__.py
+++ b/src/squire/watch_playbooks/__init__.py
@@ -1,55 +1,15 @@
-"""Opinionated autonomous playbooks for watch mode incidents."""
+"""Watch playbook routing primitives."""
 
-from __future__ import annotations
+from .router import (
+    GENERIC_FALLBACK_PLAYBOOK,
+    PlaybookSelection,
+    RouterThresholds,
+    route_playbooks_for_incidents,
+)
 
-from ..watch_autonomy import Incident
-
-
-def select_playbooks(incidents: list[Incident]) -> list[str]:
-    """Return bounded playbook instructions based on detected incidents."""
-    selected: list[str] = []
-    keys = {incident.key for incident in incidents}
-
-    if any(key.startswith("container-unhealthy:") for key in keys):
-        selected.append(
-            
-                "### Playbook: Container Recovery\n"
-                "- Inspect failing container logs before restart.\n"
-                "- Prefer single-container restart over full stack restart.\n"
-                "- Do not restart the same container more than once per cycle.\n"
-                "- Verify post-restart health (state/status) and report delta."
-            
-        )
-
-    if any(key.startswith("disk-pressure:") or key.startswith("disk-warning:") for key in keys):
-        selected.append(
-            
-                "### Playbook: Disk Pressure\n"
-                "- Identify top disk consumers first (safe diagnostics).\n"
-                "- Prefer low-risk cleanup (`docker_cleanup:df`, `prune_images`) before broad destructive actions.\n"
-                "- Avoid deleting active volumes or unknown data paths.\n"
-                "- Verify free space improvement after each action."
-            
-        )
-
-    if any(key.startswith("host-unreachable:") for key in keys):
-        selected.append(
-            
-                "### Playbook: Host Reachability\n"
-                "- Run network diagnostics to isolate DNS/routing/host-down signals.\n"
-                "- Avoid repeated restart attempts on unreachable hosts.\n"
-                "- If host remains unreachable, escalate with likely cause and next manual step."
-            
-        )
-
-    if not selected:
-        selected.append(
-            
-                "### Playbook: Preventive Health Sweep\n"
-                "- Check container health and key services.\n"
-                "- Investigate anomalies with logs before action.\n"
-                "- Execute only minimal corrective actions with clear verification."
-            
-        )
-
-    return selected
+__all__ = [
+    "GENERIC_FALLBACK_PLAYBOOK",
+    "PlaybookSelection",
+    "RouterThresholds",
+    "route_playbooks_for_incidents",
+]

--- a/src/squire/watch_playbooks/__init__.py
+++ b/src/squire/watch_playbooks/__init__.py
@@ -1,0 +1,55 @@
+"""Opinionated autonomous playbooks for watch mode incidents."""
+
+from __future__ import annotations
+
+from ..watch_autonomy import Incident
+
+
+def select_playbooks(incidents: list[Incident]) -> list[str]:
+    """Return bounded playbook instructions based on detected incidents."""
+    selected: list[str] = []
+    keys = {incident.key for incident in incidents}
+
+    if any(key.startswith("container-unhealthy:") for key in keys):
+        selected.append(
+            
+                "### Playbook: Container Recovery\n"
+                "- Inspect failing container logs before restart.\n"
+                "- Prefer single-container restart over full stack restart.\n"
+                "- Do not restart the same container more than once per cycle.\n"
+                "- Verify post-restart health (state/status) and report delta."
+            
+        )
+
+    if any(key.startswith("disk-pressure:") or key.startswith("disk-warning:") for key in keys):
+        selected.append(
+            
+                "### Playbook: Disk Pressure\n"
+                "- Identify top disk consumers first (safe diagnostics).\n"
+                "- Prefer low-risk cleanup (`docker_cleanup:df`, `prune_images`) before broad destructive actions.\n"
+                "- Avoid deleting active volumes or unknown data paths.\n"
+                "- Verify free space improvement after each action."
+            
+        )
+
+    if any(key.startswith("host-unreachable:") for key in keys):
+        selected.append(
+            
+                "### Playbook: Host Reachability\n"
+                "- Run network diagnostics to isolate DNS/routing/host-down signals.\n"
+                "- Avoid repeated restart attempts on unreachable hosts.\n"
+                "- If host remains unreachable, escalate with likely cause and next manual step."
+            
+        )
+
+    if not selected:
+        selected.append(
+            
+                "### Playbook: Preventive Health Sweep\n"
+                "- Check container health and key services.\n"
+                "- Investigate anomalies with logs before action.\n"
+                "- Execute only minimal corrective actions with clear verification."
+            
+        )
+
+    return selected

--- a/src/squire/watch_playbooks/router.py
+++ b/src/squire/watch_playbooks/router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -53,17 +54,28 @@ async def route_playbooks_for_incidents(
     max_selected_playbooks: int = 3,
     semantic_candidate_cap: int = 10,
     prompt_char_budget: int = 6000,
+    max_llm_calls: int = 6,
+    llm_timeout_seconds: float = 8.0,
 ) -> tuple[list[str], list[PlaybookSelection]]:
     """Route one playbook per incident; return merged prompt blocks and selection trace."""
     thresholds = thresholds or RouterThresholds()
     ordered_incidents = sorted(incidents, key=lambda inc: (severity_rank(inc.severity), inc.key))
     selections: list[PlaybookSelection] = []
+    llm_calls_remaining = max(0, max_llm_calls)
 
     for incident in ordered_incidents:
         deterministic = _deterministic_candidates(incident, playbook_skills)
         if len(deterministic) == 1:
             skill = deterministic[0]
-            confidence, reasoning = await _plausibility_check(incident, skill, llm_config)
+            active_llm_config = llm_config if llm_calls_remaining > 0 else None
+            if active_llm_config is not None:
+                llm_calls_remaining -= 1
+            confidence, reasoning = await _plausibility_check(
+                incident,
+                skill,
+                active_llm_config,
+                llm_timeout_seconds=llm_timeout_seconds,
+            )
             if confidence >= thresholds.single_match_plausibility_min:
                 selections.append(
                     PlaybookSelection(
@@ -81,11 +93,15 @@ async def route_playbooks_for_incidents(
             continue
 
         if len(deterministic) > 1:
+            active_llm_config = llm_config if llm_calls_remaining > 0 else None
+            if active_llm_config is not None:
+                llm_calls_remaining -= 1
             picked, confidence, reasoning = await _llm_choose_best(
                 incident,
                 deterministic,
-                llm_config=llm_config,
+                llm_config=active_llm_config,
                 mode="tie_break",
+                llm_timeout_seconds=llm_timeout_seconds,
             )
             if picked is not None and confidence >= thresholds.tie_break_min_confidence:
                 selections.append(
@@ -108,11 +124,15 @@ async def route_playbooks_for_incidents(
             selections.append(_generic_selection(incident, 0, 0.0, "No host-compatible semantic candidates"))
             continue
 
+        active_llm_config = llm_config if llm_calls_remaining > 0 else None
+        if active_llm_config is not None:
+            llm_calls_remaining -= 1
         picked, confidence, reasoning = await _llm_choose_best(
             incident,
             semantic_candidates,
-            llm_config=llm_config,
+            llm_config=active_llm_config,
             mode="semantic",
+            llm_timeout_seconds=llm_timeout_seconds,
         )
         if picked is not None and confidence >= thresholds.semantic_min_confidence:
             selections.append(
@@ -204,7 +224,13 @@ def _merge_selected_playbooks(
     return merged
 
 
-async def _plausibility_check(incident: Incident, skill: Skill, llm_config: LLMConfig | None) -> tuple[float, str]:
+async def _plausibility_check(
+    incident: Incident,
+    skill: Skill,
+    llm_config: LLMConfig | None,
+    *,
+    llm_timeout_seconds: float,
+) -> tuple[float, str]:
     if llm_config is None:
         return _heuristic_similarity(incident, skill), "Heuristic plausibility"
     prompt = (
@@ -213,7 +239,7 @@ async def _plausibility_check(incident: Incident, skill: Skill, llm_config: LLMC
         f"Playbook: name={skill.name}, description={skill.description}\n"
         'Return JSON: {"confidence": <0-1>, "reasoning": "..."}'
     )
-    data = await _llm_json(prompt, llm_config)
+    data = await _llm_json(prompt, llm_config, timeout_seconds=llm_timeout_seconds)
     confidence = _safe_confidence(data.get("confidence")) if data else _heuristic_similarity(incident, skill)
     reasoning = str(data.get("reasoning", "LLM plausibility")) if data else "Heuristic plausibility fallback"
     return confidence, reasoning
@@ -225,6 +251,7 @@ async def _llm_choose_best(
     *,
     llm_config: LLMConfig | None,
     mode: Literal["tie_break", "semantic"],
+    llm_timeout_seconds: float,
 ) -> tuple[Skill | None, float, str]:
     if not candidates:
         return None, 0.0, "No candidates"
@@ -243,7 +270,7 @@ async def _llm_choose_best(
         + "\n".join(candidate_lines)
         + '\nReturn JSON: {"index": <int>, "confidence": <0-1>, "reasoning": "..."}'
     )
-    data = await _llm_json(prompt, llm_config)
+    data = await _llm_json(prompt, llm_config, timeout_seconds=llm_timeout_seconds)
     if not data:
         best = max(candidates, key=lambda s: _heuristic_similarity(incident, s))
         return best, _heuristic_similarity(incident, best), f"Heuristic {mode} fallback"
@@ -272,20 +299,23 @@ def _safe_confidence(value) -> float:
         return 0.0
 
 
-async def _llm_json(prompt: str, llm_config: LLMConfig) -> dict | None:
+async def _llm_json(prompt: str, llm_config: LLMConfig, *, timeout_seconds: float) -> dict | None:
     kwargs: dict = {}
     if llm_config.api_base:
         kwargs["api_base"] = llm_config.api_base
     try:
-        response = await acompletion(
-            model=llm_config.model,
-            messages=[
-                {"role": "system", "content": "Return only valid JSON."},
-                {"role": "user", "content": prompt},
-            ],
-            temperature=0,
-            max_tokens=300,
-            **kwargs,
+        response = await asyncio.wait_for(
+            acompletion(
+                model=llm_config.model,
+                messages=[
+                    {"role": "system", "content": "Return only valid JSON."},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0,
+                max_tokens=300,
+                **kwargs,
+            ),
+            timeout=max(0.1, timeout_seconds),
         )
     except Exception:
         logger.debug("LLM JSON helper failed", exc_info=True)

--- a/src/squire/watch_playbooks/router.py
+++ b/src/squire/watch_playbooks/router.py
@@ -1,0 +1,305 @@
+"""Dynamic watch playbook router with deterministic and LLM-assisted selection."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from litellm import acompletion
+
+from ..config import LLMConfig
+from ..skills import Skill
+from ..watch_autonomy import Incident, severity_rank
+
+logger = logging.getLogger(__name__)
+
+PlaybookPath = Literal["deterministic_single", "tie_break", "semantic", "generic"]
+
+GENERIC_FALLBACK_PLAYBOOK = (
+    "### Playbook: Default Watch Triage\n"
+    "- Validate the signal with targeted diagnostics before taking action.\n"
+    "- Prefer read-only checks and minimal-blast-radius operations.\n"
+    "- If confidence is low or issue remains unresolved, escalate with clear manual next steps."
+)
+
+
+@dataclass(slots=True)
+class RouterThresholds:
+    single_match_plausibility_min: float = 0.45
+    tie_break_min_confidence: float = 0.60
+    semantic_min_confidence: float = 0.55
+
+
+@dataclass(slots=True)
+class PlaybookSelection:
+    incident: Incident
+    candidate_count: int
+    selected_playbook: str | None
+    path_taken: PlaybookPath
+    confidence: float
+    reasoning: str
+    instructions: str
+
+
+async def route_playbooks_for_incidents(
+    incidents: list[Incident],
+    playbook_skills: list[Skill],
+    *,
+    llm_config: LLMConfig | None = None,
+    thresholds: RouterThresholds | None = None,
+    max_selected_playbooks: int = 3,
+    semantic_candidate_cap: int = 10,
+    prompt_char_budget: int = 6000,
+) -> tuple[list[str], list[PlaybookSelection]]:
+    """Route one playbook per incident; return merged prompt blocks and selection trace."""
+    thresholds = thresholds or RouterThresholds()
+    ordered_incidents = sorted(incidents, key=lambda inc: (severity_rank(inc.severity), inc.key))
+    selections: list[PlaybookSelection] = []
+
+    for incident in ordered_incidents:
+        deterministic = _deterministic_candidates(incident, playbook_skills)
+        if len(deterministic) == 1:
+            skill = deterministic[0]
+            confidence, reasoning = await _plausibility_check(incident, skill, llm_config)
+            if confidence >= thresholds.single_match_plausibility_min:
+                selections.append(
+                    PlaybookSelection(
+                        incident=incident,
+                        candidate_count=1,
+                        selected_playbook=skill.name,
+                        path_taken="deterministic_single",
+                        confidence=confidence,
+                        reasoning=reasoning,
+                        instructions=skill.instructions,
+                    )
+                )
+            else:
+                selections.append(_generic_selection(incident, 1, confidence, "Plausibility check below threshold"))
+            continue
+
+        if len(deterministic) > 1:
+            picked, confidence, reasoning = await _llm_choose_best(
+                incident,
+                deterministic,
+                llm_config=llm_config,
+                mode="tie_break",
+            )
+            if picked is not None and confidence >= thresholds.tie_break_min_confidence:
+                selections.append(
+                    PlaybookSelection(
+                        incident=incident,
+                        candidate_count=len(deterministic),
+                        selected_playbook=picked.name,
+                        path_taken="tie_break",
+                        confidence=confidence,
+                        reasoning=reasoning,
+                        instructions=picked.instructions,
+                    )
+                )
+            else:
+                selections.append(_generic_selection(incident, len(deterministic), confidence, reasoning))
+            continue
+
+        semantic_candidates = _semantic_candidates(incident, playbook_skills, semantic_candidate_cap)
+        if not semantic_candidates:
+            selections.append(_generic_selection(incident, 0, 0.0, "No host-compatible semantic candidates"))
+            continue
+
+        picked, confidence, reasoning = await _llm_choose_best(
+            incident,
+            semantic_candidates,
+            llm_config=llm_config,
+            mode="semantic",
+        )
+        if picked is not None and confidence >= thresholds.semantic_min_confidence:
+            selections.append(
+                PlaybookSelection(
+                    incident=incident,
+                    candidate_count=len(semantic_candidates),
+                    selected_playbook=picked.name,
+                    path_taken="semantic",
+                    confidence=confidence,
+                    reasoning=reasoning,
+                    instructions=picked.instructions,
+                )
+            )
+        else:
+            selections.append(_generic_selection(incident, len(semantic_candidates), confidence, reasoning))
+
+    merged_instructions = _merge_selected_playbooks(
+        selections,
+        max_selected_playbooks=max_selected_playbooks,
+        prompt_char_budget=prompt_char_budget,
+    )
+    return merged_instructions, selections
+
+
+def _deterministic_candidates(incident: Incident, playbook_skills: list[Skill]) -> list[Skill]:
+    return [
+        skill
+        for skill in playbook_skills
+        if _host_compatible(skill.hosts, incident.host)
+        and any(incident.key.startswith(prefix) for prefix in skill.incident_keys)
+    ]
+
+
+def _semantic_candidates(incident: Incident, playbook_skills: list[Skill], cap: int) -> list[Skill]:
+    compatible = [skill for skill in playbook_skills if _host_compatible(skill.hosts, incident.host)]
+    compatible.sort(key=lambda s: s.name)
+    return compatible[:cap]
+
+
+def _host_compatible(hosts: list[str], incident_host: str) -> bool:
+    return "all" in hosts or incident_host in hosts
+
+
+def _generic_selection(
+    incident: Incident, candidate_count: int, confidence: float, reasoning: str
+) -> PlaybookSelection:
+    return PlaybookSelection(
+        incident=incident,
+        candidate_count=candidate_count,
+        selected_playbook=None,
+        path_taken="generic",
+        confidence=max(0.0, min(confidence, 1.0)),
+        reasoning=reasoning,
+        instructions=GENERIC_FALLBACK_PLAYBOOK,
+    )
+
+
+def _merge_selected_playbooks(
+    selections: list[PlaybookSelection],
+    *,
+    max_selected_playbooks: int,
+    prompt_char_budget: int,
+) -> list[str]:
+    by_name: dict[str, dict] = {}
+    for selection in selections:
+        name = selection.selected_playbook or "__generic__"
+        if name not in by_name:
+            by_name[name] = {
+                "instructions": selection.instructions,
+                "incident_keys": [],
+            }
+        by_name[name]["incident_keys"].append(selection.incident.key)
+
+    merged: list[str] = []
+    used_chars = 0
+    for name in sorted(by_name):
+        if len(merged) >= max_selected_playbooks:
+            break
+        item = by_name[name]
+        if name == "__generic__":
+            block = item["instructions"]
+        else:
+            header = f"### Playbook: {name} (selected for: {', '.join(item['incident_keys'])})"
+            block = f"{header}\n{item['instructions']}"
+        if used_chars + len(block) > prompt_char_budget:
+            break
+        merged.append(block)
+        used_chars += len(block)
+    return merged
+
+
+async def _plausibility_check(incident: Incident, skill: Skill, llm_config: LLMConfig | None) -> tuple[float, str]:
+    if llm_config is None:
+        return _heuristic_similarity(incident, skill), "Heuristic plausibility"
+    prompt = (
+        "Score how plausible this playbook is for the incident from 0 to 1.\n"
+        f"Incident: key={incident.key}, title={incident.title}, detail={incident.detail}\n"
+        f"Playbook: name={skill.name}, description={skill.description}\n"
+        'Return JSON: {"confidence": <0-1>, "reasoning": "..."}'
+    )
+    data = await _llm_json(prompt, llm_config)
+    confidence = _safe_confidence(data.get("confidence")) if data else _heuristic_similarity(incident, skill)
+    reasoning = str(data.get("reasoning", "LLM plausibility")) if data else "Heuristic plausibility fallback"
+    return confidence, reasoning
+
+
+async def _llm_choose_best(
+    incident: Incident,
+    candidates: list[Skill],
+    *,
+    llm_config: LLMConfig | None,
+    mode: Literal["tie_break", "semantic"],
+) -> tuple[Skill | None, float, str]:
+    if not candidates:
+        return None, 0.0, "No candidates"
+    if llm_config is None:
+        best = max(candidates, key=lambda s: _heuristic_similarity(incident, s))
+        return best, _heuristic_similarity(incident, best), f"Heuristic {mode} fallback"
+
+    candidate_lines = [
+        f"- {idx}: {c.name} | desc={c.description} | keys={','.join(c.incident_keys)} | hosts={','.join(c.hosts)}"
+        for idx, c in enumerate(candidates)
+    ]
+    prompt = (
+        f"Choose the best playbook for mode={mode}.\n"
+        f"Incident key={incident.key}, severity={incident.severity}, host={incident.host}, detail={incident.detail}\n"
+        "Candidates:\n"
+        + "\n".join(candidate_lines)
+        + '\nReturn JSON: {"index": <int>, "confidence": <0-1>, "reasoning": "..."}'
+    )
+    data = await _llm_json(prompt, llm_config)
+    if not data:
+        best = max(candidates, key=lambda s: _heuristic_similarity(incident, s))
+        return best, _heuristic_similarity(incident, best), f"Heuristic {mode} fallback"
+    idx = data.get("index")
+    confidence = _safe_confidence(data.get("confidence"))
+    reasoning = str(data.get("reasoning", f"LLM {mode}"))
+    if not isinstance(idx, int) or idx < 0 or idx >= len(candidates):
+        return None, confidence, "LLM returned invalid index"
+    return candidates[idx], confidence, reasoning
+
+
+def _heuristic_similarity(incident: Incident, skill: Skill) -> float:
+    incident_text = f"{incident.key} {incident.title} {incident.detail}".lower()
+    skill_text = f"{skill.name} {skill.description} {skill.instructions}".lower()
+    tokens = {t for t in re.split(r"[^a-z0-9]+", incident_text) if len(t) > 2}
+    if not tokens:
+        return 0.2
+    overlap = sum(1 for t in tokens if t in skill_text)
+    return max(0.0, min(1.0, overlap / max(3, len(tokens))))
+
+
+def _safe_confidence(value) -> float:
+    try:
+        return max(0.0, min(1.0, float(value)))
+    except Exception:
+        return 0.0
+
+
+async def _llm_json(prompt: str, llm_config: LLMConfig) -> dict | None:
+    kwargs: dict = {}
+    if llm_config.api_base:
+        kwargs["api_base"] = llm_config.api_base
+    try:
+        response = await acompletion(
+            model=llm_config.model,
+            messages=[
+                {"role": "system", "content": "Return only valid JSON."},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0,
+            max_tokens=300,
+            **kwargs,
+        )
+    except Exception:
+        logger.debug("LLM JSON helper failed", exc_info=True)
+        return None
+    content = response.choices[0].message.content if response and response.choices else ""
+    if not content:
+        return None
+    try:
+        return json.loads(content)
+    except Exception:
+        match = re.search(r"\{.*\}", content, re.DOTALL)
+        if not match:
+            return None
+        try:
+            return json.loads(match.group(0))
+        except Exception:
+            return None

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -17,9 +17,10 @@ def _make_skill(**kwargs) -> Skill:
     defaults = {
         "name": "test-skill",
         "description": "A test skill",
-        "host": "all",
+        "hosts": ["all"],
         "trigger": "manual",
         "enabled": True,
+        "incident_keys": [],
         "instructions": "Check the status of all containers.",
     }
     defaults.update(kwargs)
@@ -34,7 +35,7 @@ class TestSaveAndGet:
         assert loaded is not None
         assert loaded.name == "test-skill"
         assert loaded.description == "A test skill"
-        assert loaded.host == "all"
+        assert loaded.hosts == ["all"]
         assert loaded.trigger == "manual"
         assert loaded.enabled is True
         assert loaded.instructions == "Check the status of all containers."
@@ -128,15 +129,16 @@ class TestParsing:
 
     def test_metadata_roundtrip(self, skill_service):
         """Squire-specific fields survive a save/load cycle via metadata."""
-        skill = _make_skill(host="prod-01", trigger="watch", enabled=False)
+        skill = _make_skill(hosts=["prod-01"], trigger="watch", enabled=False, incident_keys=["disk-pressure:"])
         skill_service.save_skill(skill)
         loaded = skill_service.get_skill("test-skill")
-        assert loaded.host == "prod-01"
+        assert loaded.hosts == ["prod-01"]
         assert loaded.trigger == "watch"
         assert loaded.enabled is False
+        assert loaded.incident_keys == ["disk-pressure:"]
 
     def test_default_metadata_omitted(self, skill_service, tmp_path):
-        """When host/trigger/enabled are defaults, metadata key is omitted."""
+        """When hosts/trigger/enabled are defaults, metadata key is omitted."""
         skill = _make_skill()
         skill_service.save_skill(skill)
         content = (tmp_path / "test-skill" / "SKILL.md").read_text()
@@ -144,15 +146,33 @@ class TestParsing:
 
     def test_spec_compliant_frontmatter(self, skill_service, tmp_path):
         """Rendered SKILL.md has name/description at top level, custom fields under metadata."""
-        skill = _make_skill(host="nas", trigger="watch")
+        skill = _make_skill(hosts=["nas"], trigger="watch")
         skill_service.save_skill(skill)
         content = (tmp_path / "test-skill" / "SKILL.md").read_text()
         assert content.startswith("---\n")
         assert "name: test-skill\n" in content
         assert "description: A test skill\n" in content
         assert "metadata:\n" in content
-        assert "  host: nas\n" in content
+        assert "  hosts:\n" in content
+        assert "  - nas\n" in content
         assert "  trigger: watch\n" in content
+
+    def test_legacy_host_metadata_is_retrofitted_to_hosts(self, skill_service, tmp_path):
+        skill_dir = tmp_path / "legacy-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: legacy-skill\n"
+            "description: legacy\n"
+            "metadata:\n"
+            "  host: remote-1\n"
+            "  trigger: watch\n"
+            "---\n\n"
+            "Run checks."
+        )
+        loaded = skill_service.get_skill("legacy-skill")
+        assert loaded is not None
+        assert loaded.hosts == ["remote-1"]
 
 
 class TestNameValidation:

--- a/tests/test_skills_api.py
+++ b/tests/test_skills_api.py
@@ -1,0 +1,136 @@
+"""Tests for skills API router helpers."""
+
+import pytest
+from fastapi import HTTPException
+
+from squire.api.routers.skills import (
+    bootstrap_watch_playbooks,
+    create_skill,
+    dry_run_playbook_routing,
+    list_incident_families,
+    update_skill,
+)
+from squire.api.schemas import PlaybookDryRunRequest, SkillCreate, SkillUpdate
+from squire.skills import SkillService
+
+
+@pytest.fixture
+def skills_service(tmp_path):
+    return SkillService(tmp_path)
+
+
+def test_incident_family_catalog_exposed():
+    families = list_incident_families()
+    prefixes = {entry["prefix"] for entry in families}
+    assert "disk-pressure:" in prefixes
+    assert "container-unhealthy:" in prefixes
+
+
+def test_create_skill_rejects_unknown_incident_prefix(skills_service):
+    with pytest.raises(HTTPException) as exc_info:
+        create_skill(
+            SkillCreate(
+                name="bad-prefix",
+                description="desc",
+                trigger="watch",
+                hosts=["all"],
+                incident_keys=["custom-prefix:"],
+                instructions="Do stuff",
+            ),
+            skills_service=skills_service,
+        )
+    assert exc_info.value.status_code == 422
+
+
+def test_create_skill_accepts_custom_prefix_when_toggle_set(skills_service):
+    result = create_skill(
+        SkillCreate(
+            name="custom-prefix",
+            description="desc",
+            trigger="watch",
+            hosts=["all"],
+            incident_keys=["custom-prefix:"],
+            allow_custom_incident_prefixes=True,
+            instructions="Do stuff",
+        ),
+        skills_service=skills_service,
+    )
+    assert result.incident_keys == ["custom-prefix:"]
+
+
+def test_update_skill_validates_incident_prefix(skills_service):
+    create_skill(
+        SkillCreate(
+            name="to-update",
+            description="desc",
+            trigger="watch",
+            hosts=["all"],
+            incident_keys=["disk-pressure:"],
+            instructions="Do stuff",
+        ),
+        skills_service=skills_service,
+    )
+    with pytest.raises(HTTPException):
+        update_skill(
+            "to-update",
+            SkillUpdate(incident_keys=["bad-prefix:"]),
+            skills_service=skills_service,
+        )
+
+
+def test_bootstrap_starter_playbooks(skills_service):
+    result = bootstrap_watch_playbooks(skills_service=skills_service)
+    assert "recover-container-unhealthy" in result["created"] or "recover-container-unhealthy" in result["skipped"]
+    assert "triage-disk-pressure" in result["created"] or "triage-disk-pressure" in result["skipped"]
+
+
+@pytest.mark.asyncio
+async def test_dry_run_contract_fields(skills_service, monkeypatch):
+    create_skill(
+        SkillCreate(
+            name="triage-disk-pressure",
+            description="disk",
+            trigger="watch",
+            hosts=["all"],
+            incident_keys=["disk-pressure:"],
+            instructions="Do disk triage",
+        ),
+        skills_service=skills_service,
+    )
+
+    async def _fake_router(*args, **kwargs):
+        from squire.watch_autonomy import Incident
+        from squire.watch_playbooks.router import PlaybookSelection
+
+        incident = Incident(key="disk-pressure:local", severity="high", title="disk", detail="95%", host="local")
+        selection = PlaybookSelection(
+            incident=incident,
+            candidate_count=1,
+            selected_playbook="triage-disk-pressure",
+            path_taken="deterministic_single",
+            confidence=0.9,
+            reasoning="deterministic match",
+            instructions="Do disk triage",
+        )
+        return ["playbook"], [selection]
+
+    monkeypatch.setattr("squire.api.routers.skills.route_playbooks_for_incidents", _fake_router)
+    response = await dry_run_playbook_routing(
+        PlaybookDryRunRequest(
+            incidents=[
+                {
+                    "key": "disk-pressure:local",
+                    "severity": "high",
+                    "host": "local",
+                    "title": "disk",
+                    "detail": "95%",
+                }
+            ]
+        ),
+        skills_service=skills_service,
+        llm_config=None,
+    )
+    assert len(response["selections"]) == 1
+    row = response["selections"][0]
+    assert row.path_taken == "deterministic_single"
+    assert row.selected_playbook == "triage-disk-pressure"

--- a/tests/test_skills_api.py
+++ b/tests/test_skills_api.py
@@ -2,6 +2,7 @@
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from squire.api.routers.skills import (
     bootstrap_watch_playbooks,
@@ -134,3 +135,19 @@ async def test_dry_run_contract_fields(skills_service, monkeypatch):
     row = response["selections"][0]
     assert row.path_taken == "deterministic_single"
     assert row.selected_playbook == "triage-disk-pressure"
+
+
+def test_dry_run_request_rejects_too_many_incidents():
+    with pytest.raises(ValidationError):
+        PlaybookDryRunRequest(
+            incidents=[
+                {
+                    "key": f"disk-pressure:host-{idx}",
+                    "severity": "high",
+                    "host": "local",
+                    "title": "disk",
+                    "detail": "95%",
+                }
+                for idx in range(26)
+            ]
+        )

--- a/tests/test_watch_autonomy.py
+++ b/tests/test_watch_autonomy.py
@@ -1,5 +1,6 @@
 """Tests for watch autonomy helpers."""
 
+from squire.skills import Skill
 from squire.watch_autonomy import (
     Incident,
     build_cycle_contract_prompt,
@@ -7,7 +8,7 @@ from squire.watch_autonomy import (
     detect_incidents,
     parse_contract_sections,
 )
-from squire.watch_playbooks import select_playbooks
+from squire.watch_playbooks import route_playbooks_for_incidents
 
 
 def test_detect_incidents_container_and_disk():
@@ -55,12 +56,52 @@ none
     assert outcome["escalated"] is False
 
 
-def test_select_playbooks_for_incidents():
+def test_markdown_none_escalation_is_not_escalated():
+    response = """
+## Incident Summary
+Disk check completed.
+
+## RCA Hypotheses
+False positive from mount parsing.
+
+## Action Plan and Actions Taken
+Ran diagnostics only.
+
+## Verification Results
+Healthy.
+
+## Escalation
+**None**: no further action required.
+"""
+    sections = parse_contract_sections(response)
+    outcome = build_cycle_outcome([], sections, tool_count=1, blocked_count=0, cycle_status="ok")
+    assert outcome["escalated"] is False
+
+
+async def test_select_playbooks_for_incidents():
     incidents = [
         Incident(key="container-unhealthy:local:api", severity="high", title="Container unhealthy", detail="x"),
         Incident(key="host-unreachable:node-1", severity="high", title="Host unreachable", detail="x", host="node-1"),
     ]
-    playbooks = select_playbooks(incidents)
+    playbook_skills = [
+        Skill(
+            name="container-recovery",
+            description="Recover unhealthy containers",
+            trigger="watch",
+            hosts=["all"],
+            incident_keys=["container-unhealthy:"],
+            instructions="Container Recovery",
+        ),
+        Skill(
+            name="host-reachability",
+            description="Handle unreachable hosts",
+            trigger="watch",
+            hosts=["node-1"],
+            incident_keys=["host-unreachable:"],
+            instructions="Host Reachability",
+        ),
+    ]
+    playbooks, _ = await route_playbooks_for_incidents(incidents, playbook_skills)
     joined = "\n".join(playbooks)
-    assert "Container Recovery" in joined
-    assert "Host Reachability" in joined
+    assert "container-recovery" in joined
+    assert "host-reachability" in joined

--- a/tests/test_watch_autonomy.py
+++ b/tests/test_watch_autonomy.py
@@ -1,0 +1,66 @@
+"""Tests for watch autonomy helpers."""
+
+from squire.watch_autonomy import (
+    Incident,
+    build_cycle_contract_prompt,
+    build_cycle_outcome,
+    detect_incidents,
+    parse_contract_sections,
+)
+from squire.watch_playbooks import select_playbooks
+
+
+def test_detect_incidents_container_and_disk():
+    snapshot = {
+        "local": {
+            "disk_usage_raw": "/dev/disk1 100G 94G 6G 94% /",
+            "containers": [{"name": "api", "state": "restarting", "status": "unhealthy"}],
+        }
+    }
+    incidents = detect_incidents(snapshot)
+    keys = {i.key for i in incidents}
+    assert any(key.startswith("disk-pressure:local") for key in keys)
+    assert any(key.startswith("container-unhealthy:local:api") for key in keys)
+
+
+def test_build_prompt_includes_contract_and_blocks():
+    incidents = [Incident(key="x", severity="high", title="Host unreachable", detail="timeout", host="node-1")]
+    prompt = build_cycle_contract_prompt("Base check", incidents, ["### Playbook"], ["docker_compose:abc"])
+    assert "strict autonomous watch mode" in prompt
+    assert "## Incident Summary" in prompt
+    assert "Do not repeat these recent actions" in prompt
+
+
+def test_parse_sections_and_outcome():
+    response = """
+## Incident Summary
+Container unhealthy.
+
+## RCA Hypotheses
+Crash loop from config drift.
+
+## Action Plan and Actions Taken
+Restarted container once.
+
+## Verification Results
+Container healthy after restart.
+
+## Escalation
+none
+"""
+    sections = parse_contract_sections(response)
+    outcome = build_cycle_outcome([], sections, tool_count=1, blocked_count=0, cycle_status="ok")
+    assert sections["incident summary"].startswith("Container unhealthy")
+    assert outcome["resolved"] is True
+    assert outcome["escalated"] is False
+
+
+def test_select_playbooks_for_incidents():
+    incidents = [
+        Incident(key="container-unhealthy:local:api", severity="high", title="Container unhealthy", detail="x"),
+        Incident(key="host-unreachable:node-1", severity="high", title="Host unreachable", detail="x", host="node-1"),
+    ]
+    playbooks = select_playbooks(incidents)
+    joined = "\n".join(playbooks)
+    assert "Container Recovery" in joined
+    assert "Host Reachability" in joined

--- a/tests/test_watch_config.py
+++ b/tests/test_watch_config.py
@@ -31,6 +31,12 @@ class TestWatchConfigDefaults:
         c = WatchConfig()
         assert c.max_context_events == 40
 
+    def test_default_action_safety_bounds(self):
+        c = WatchConfig()
+        assert c.max_identical_actions_per_cycle == 2
+        assert c.blocked_action_cooldown_cycles == 3
+        assert c.max_remote_actions_per_cycle == 4
+
     def test_override_interval(self):
         c = WatchConfig(interval_minutes=10)
         assert c.interval_minutes == 10

--- a/tests/test_watch_emitter.py
+++ b/tests/test_watch_emitter.py
@@ -36,13 +36,22 @@ async def test_emit_tool_call(db):
 @pytest.mark.asyncio
 async def test_emit_cycle_end_includes_stats(db):
     emitter = WatchEventEmitter(db)
-    await emitter.emit_cycle_end(cycle=1, status="ok", duration_seconds=5.2, tool_count=3)
+    await emitter.emit_cycle_end(
+        cycle=1,
+        status="ok",
+        duration_seconds=5.2,
+        tool_count=3,
+        blocked_count=1,
+        outcome={"incident_count": 2},
+    )
 
     events = await db.get_watch_events_since(0)
     content = json.loads(events[0]["content"])
     assert content["status"] == "ok"
     assert content["duration_seconds"] == 5.2
     assert content["tool_count"] == 3
+    assert content["blocked_count"] == 1
+    assert content["outcome"]["incident_count"] == 2
 
 
 @pytest.mark.asyncio
@@ -71,3 +80,14 @@ async def test_emit_approval_request(db):
     content = json.loads(events[0]["content"])
     assert content["request_id"] == "req-1"
     assert content["risk_level"] == 4
+
+
+@pytest.mark.asyncio
+async def test_emit_phase_and_incident(db):
+    emitter = WatchEventEmitter(db)
+    await emitter.emit_phase(1, "detect", "Detected incident", details="details")
+    await emitter.emit_incident(1, "key1", "high", "Disk pressure", "95%", "local")
+
+    events = await db.get_watch_events_since(0)
+    assert events[0]["type"] == "phase"
+    assert events[1]["type"] == "incident"

--- a/tests/test_watch_loop.py
+++ b/tests/test_watch_loop.py
@@ -75,6 +75,33 @@ async def test_poll_commands_update_config(db):
 
 
 @pytest.mark.asyncio
+async def test_poll_commands_update_config_rejects_invalid_safety_values(db):
+    """Invalid live safety updates should fail and keep existing values."""
+    from squire.config import WatchConfig
+    from squire.watch import _poll_commands
+
+    shutdown = asyncio.Event()
+    config = WatchConfig()
+    initial_identical_limit = config.max_identical_actions_per_cycle
+
+    cmd_id = await db.insert_watch_command(
+        "update_config",
+        payload=json.dumps({"max_identical_actions_per_cycle": 0}),
+    )
+    await _poll_commands(db, shutdown, watch_config=config)
+
+    assert config.max_identical_actions_per_cycle == initial_identical_limit
+    pending = await db.get_pending_watch_commands()
+    assert len(pending) == 0
+
+    conn = await db._get_conn()  # noqa: SLF001 - test verifies command status persistence
+    cursor = await conn.execute("SELECT status, error FROM watch_commands WHERE id = ?", (cmd_id,))
+    row = await cursor.fetchone()
+    assert row["status"] == "failed"
+    assert "max_identical_actions_per_cycle" in (row["error"] or "")
+
+
+@pytest.mark.asyncio
 async def test_poll_commands_unknown_fails(db):
     """Unknown commands should be marked as failed."""
     from squire.watch import _poll_commands

--- a/tests/test_watch_playbook_router.py
+++ b/tests/test_watch_playbook_router.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from squire.config import LLMConfig
 from squire.skills import Skill
 from squire.watch_autonomy import Incident
 from squire.watch_playbooks.router import RouterThresholds, route_playbooks_for_incidents
@@ -103,3 +104,25 @@ async def test_playbook_merge_caps_selected_count():
         max_selected_playbooks=2,
     )
     assert len(prompt_playbooks) == 2
+
+
+@pytest.mark.asyncio
+async def test_llm_budget_zero_skips_llm_calls(monkeypatch):
+    incident = Incident(key="disk-pressure:local", severity="high", title="Disk pressure", detail="95% used", host="local")
+    skills = [_skill("triage-disk", incident_keys=["disk-pressure:"], description="Handle disk pressure incidents")]
+
+    async def _fail_if_called(*args, **kwargs):
+        raise AssertionError("LLM helper should not be called when max_llm_calls=0")
+
+    monkeypatch.setattr("squire.watch_playbooks.router._llm_json", _fail_if_called)
+    prompt_playbooks, selections = await route_playbooks_for_incidents(
+        incidents=[incident],
+        playbook_skills=skills,
+        llm_config=LLMConfig(model="test-model"),
+        max_llm_calls=0,
+        thresholds=RouterThresholds(single_match_plausibility_min=0.0),
+    )
+
+    assert selections[0].selected_playbook == "triage-disk"
+    assert selections[0].path_taken == "deterministic_single"
+    assert any("triage-disk" in block for block in prompt_playbooks)

--- a/tests/test_watch_playbook_router.py
+++ b/tests/test_watch_playbook_router.py
@@ -1,0 +1,105 @@
+"""Tests for dynamic watch playbook routing."""
+
+import pytest
+
+from squire.skills import Skill
+from squire.watch_autonomy import Incident
+from squire.watch_playbooks.router import RouterThresholds, route_playbooks_for_incidents
+
+
+def _skill(name: str, *, incident_keys: list[str], description: str, hosts: list[str] | None = None) -> Skill:
+    return Skill(
+        name=name,
+        description=description,
+        trigger="watch",
+        hosts=hosts or ["all"],
+        incident_keys=incident_keys,
+        instructions=f"Instructions for {name}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_deterministic_single_selected():
+    incident = Incident(
+        key="disk-pressure:local", severity="high", title="Disk pressure", detail="95% used", host="local"
+    )
+    skills = [_skill("triage-disk", incident_keys=["disk-pressure:"], description="Handle disk pressure incidents")]
+
+    prompt_playbooks, selections = await route_playbooks_for_incidents(incidents=[incident], playbook_skills=skills)
+
+    assert selections[0].path_taken == "deterministic_single"
+    assert selections[0].selected_playbook == "triage-disk"
+    assert any("triage-disk" in block for block in prompt_playbooks)
+
+
+@pytest.mark.asyncio
+async def test_tie_break_low_confidence_falls_back_to_generic(monkeypatch):
+    incident = Incident(
+        key="container-unhealthy:local:api",
+        severity="high",
+        title="Container unhealthy",
+        detail="api restarting",
+        host="local",
+    )
+    skills = [
+        _skill("candidate-a", incident_keys=["container-unhealthy:"], description="Container health"),
+        _skill("candidate-b", incident_keys=["container-unhealthy:"], description="Container fallback"),
+    ]
+
+    async def _fake_choose(*args, **kwargs):
+        return skills[0], 0.2, "not confident"
+
+    monkeypatch.setattr("squire.watch_playbooks.router._llm_choose_best", _fake_choose)
+    prompt_playbooks, selections = await route_playbooks_for_incidents(incidents=[incident], playbook_skills=skills)
+
+    assert selections[0].path_taken == "generic"
+    assert selections[0].selected_playbook is None
+    assert any("Default Watch Triage" in block for block in prompt_playbooks)
+
+
+@pytest.mark.asyncio
+async def test_semantic_fallback_when_no_deterministic(monkeypatch):
+    incident = Incident(
+        key="unknown-incident:local", severity="medium", title="Unknown", detail="something odd", host="local"
+    )
+    skills = [_skill("semantic-choice", incident_keys=["disk-pressure:"], description="something odd pattern matcher")]
+
+    async def _fake_choose(*args, **kwargs):
+        return skills[0], 0.9, "semantic match"
+
+    monkeypatch.setattr("squire.watch_playbooks.router._llm_choose_best", _fake_choose)
+    prompt_playbooks, selections = await route_playbooks_for_incidents(incidents=[incident], playbook_skills=skills)
+
+    assert selections[0].path_taken == "semantic"
+    assert selections[0].selected_playbook == "semantic-choice"
+    assert any("semantic-choice" in block for block in prompt_playbooks)
+
+
+@pytest.mark.asyncio
+async def test_playbook_merge_caps_selected_count():
+    incidents = [
+        Incident(key="disk-pressure:local", severity="high", title="Disk pressure", detail="95%", host="local"),
+        Incident(key="disk-warning:local", severity="medium", title="Disk warning", detail="82%", host="local"),
+        Incident(
+            key="container-unhealthy:local:web",
+            severity="high",
+            title="Container unhealthy",
+            detail="web unhealthy",
+            host="local",
+        ),
+        Incident(
+            key="host-unreachable:node1", severity="high", title="Host unreachable", detail="timeout", host="node1"
+        ),
+    ]
+    skills = [
+        _skill("disk", incident_keys=["disk-pressure:", "disk-warning:"], description="Disk handling"),
+        _skill("container", incident_keys=["container-unhealthy:"], description="Container handling"),
+        _skill("host", incident_keys=["host-unreachable:"], description="Host handling", hosts=["node1"]),
+    ]
+    prompt_playbooks, _ = await route_playbooks_for_incidents(
+        incidents=incidents,
+        playbook_skills=skills,
+        thresholds=RouterThresholds(single_match_plausibility_min=0.0),
+        max_selected_playbooks=2,
+    )
+    assert len(prompt_playbooks) == 2

--- a/tests/test_watch_playbook_router.py
+++ b/tests/test_watch_playbook_router.py
@@ -108,7 +108,9 @@ async def test_playbook_merge_caps_selected_count():
 
 @pytest.mark.asyncio
 async def test_llm_budget_zero_skips_llm_calls(monkeypatch):
-    incident = Incident(key="disk-pressure:local", severity="high", title="Disk pressure", detail="95% used", host="local")
+    incident = Incident(
+        key="disk-pressure:local", severity="high", title="Disk pressure", detail="95% used", host="local"
+    )
     skills = [_skill("triage-disk", incident_keys=["disk-pressure:"], description="Handle disk pressure incidents")]
 
     async def _fail_if_called(*args, **kwargs):

--- a/web/src/app/skills/page.tsx
+++ b/web/src/app/skills/page.tsx
@@ -14,9 +14,19 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { SkillForm } from "@/components/skills/skill-form";
 import {
   ListChecks,
+  Loader2,
   Plus,
   Pencil,
   Trash2,
@@ -24,22 +34,36 @@ import {
   ToggleLeft,
   ToggleRight,
 } from "lucide-react";
-import type { Skill } from "@/lib/types";
+import type { HostInfo, IncidentFamilyInfo, PlaybookDryRunSelection, Skill } from "@/lib/types";
 
 export default function SkillsPage() {
   const router = useRouter();
   const { data: skills, mutate } = useSWR("/api/skills", () =>
     apiGet<Skill[]>("/api/skills")
   );
+  const { data: incidentFamilies } = useSWR("/api/skills/incident-families", () =>
+    apiGet<IncidentFamilyInfo[]>("/api/skills/incident-families")
+  );
+  const { data: hosts } = useSWR("/api/hosts", () => apiGet<HostInfo[]>("/api/hosts"));
 
   const [formOpen, setFormOpen] = useState(false);
   const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
+  const [dryRunKey, setDryRunKey] = useState("disk-pressure:local");
+  const [dryRunHost, setDryRunHost] = useState("local");
+  const availableHostNames = Array.from(
+    new Set(["local", ...((hosts ?? []).map((h) => h.name).filter(Boolean))])
+  ).sort((a, b) => (a === "local" ? -1 : b === "local" ? 1 : a.localeCompare(b)));
+
+  const [dryRunResult, setDryRunResult] = useState<PlaybookDryRunSelection | null>(null);
+  const [isDryRunning, setIsDryRunning] = useState(false);
 
   const handleCreate = async (data: {
     name: string;
     description: string;
-    host: string;
+    hosts: string[];
     trigger: string;
+    incident_keys: string[];
+    allow_custom_incident_prefixes: boolean;
     instructions: string;
   }) => {
     await apiPost("/api/skills", data);
@@ -50,8 +74,10 @@ export default function SkillsPage() {
   const handleUpdate = async (data: {
     name: string;
     description: string;
-    host: string;
+    hosts: string[];
     trigger: string;
+    incident_keys: string[];
+    allow_custom_incident_prefixes: boolean;
     instructions: string;
   }) => {
     const { name, ...rest } = data;
@@ -80,6 +106,45 @@ export default function SkillsPage() {
     );
   };
 
+  const handleBootstrapPlaybooks = async () => {
+    await apiPost("/api/skills/bootstrap-watch-playbooks");
+    mutate();
+  };
+
+  const handleDryRun = async () => {
+    setIsDryRunning(true);
+    try {
+      const response = await apiPost<{ selections: PlaybookDryRunSelection[] }>("/api/skills/playbooks/dry-run", {
+        incidents: [
+          {
+            key: dryRunKey,
+            host: dryRunHost,
+            severity: "high",
+            title: dryRunKey,
+            detail: "",
+          },
+        ],
+      });
+      setDryRunResult(response.selections[0] ?? null);
+    } finally {
+      setIsDryRunning(false);
+    }
+  };
+
+  const conflictEntries = (() => {
+    if (!skills) return [];
+    const map = new Map<string, string[]>();
+    for (const skill of skills) {
+      if (skill.trigger !== "watch" || !skill.enabled) continue;
+      for (const key of skill.incident_keys || []) {
+        const list = map.get(key) ?? [];
+        list.push(skill.name);
+        map.set(key, list);
+      }
+    }
+    return Array.from(map.entries()).filter(([, names]) => names.length > 1);
+  })();
+
   return (
     <div className="space-y-6 animate-fade-in-up">
       <div className="flex items-center justify-between">
@@ -89,15 +154,84 @@ export default function SkillsPage() {
             <Badge variant="secondary">{skills.length}</Badge>
           )}
         </div>
-        <Button size="sm" onClick={() => setFormOpen(true)}>
-          <Plus className="h-4 w-4 mr-2" />
-          New Skill
-        </Button>
+        <div className="flex gap-2">
+          <Button size="sm" variant="outline" onClick={handleBootstrapPlaybooks}>
+            Install Starter Watch Playbooks
+          </Button>
+          <Button size="sm" onClick={() => setFormOpen(true)}>
+            <Plus className="h-4 w-4 mr-2" />
+            New Skill
+          </Button>
+        </div>
       </div>
       <p className="text-sm text-muted-foreground">
         Define instructions for Squire to follow. Skills can be executed manually
         or attached to watch mode for automated checks.
       </p>
+
+      {conflictEntries.length > 0 && (
+        <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm">
+          <p className="font-medium mb-1">Routing conflicts detected</p>
+          {conflictEntries.map(([key, names]) => (
+            <p key={key} className="text-muted-foreground">
+              <code>{key}</code>: {names.join(", ")}
+            </p>
+          ))}
+        </div>
+      )}
+
+      <div className="w-full max-w-4xl mx-auto rounded-md border border-primary/30 bg-primary/5 p-4 space-y-3">
+        <p className="font-medium text-sm text-primary">Playbook Router Dry Run</p>
+        <div className="grid grid-cols-1 md:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_auto] gap-3 items-start">
+          <div className="space-y-1">
+            <Label htmlFor="dry-run-incident-key" className="text-xs text-muted-foreground">Incident Key</Label>
+            <Input
+              id="dry-run-incident-key"
+              value={dryRunKey}
+              onChange={(e) => setDryRunKey(e.target.value)}
+              placeholder="disk-pressure:local"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="dry-run-host" className="text-xs text-muted-foreground">Host</Label>
+            <Select value={dryRunHost} onValueChange={(v) => setDryRunHost(v ?? "local")}>
+              <SelectTrigger id="dry-run-host" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {availableHostNames.map((hostName) => (
+                  <SelectItem key={hostName} value={hostName}>
+                    {hostName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs opacity-0 select-none">Run</Label>
+            <Button
+              variant="default"
+              onClick={handleDryRun}
+              disabled={isDryRunning}
+              className="w-full md:w-auto min-w-36 px-6 whitespace-nowrap bg-primary text-primary-foreground hover:bg-primary/90"
+            >
+              {isDryRunning ? (
+                <>
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  Running...
+                </>
+              ) : (
+                "Run Dry Run"
+              )}
+            </Button>
+          </div>
+        </div>
+        {dryRunResult && (
+          <pre className="text-xs bg-card border border-primary/20 rounded-md p-2 overflow-x-auto">
+{JSON.stringify(dryRunResult, null, 2)}
+          </pre>
+        )}
+      </div>
 
       {!skills || skills.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-muted-foreground gap-3">
@@ -113,8 +247,9 @@ export default function SkillsPage() {
             <TableRow>
               <TableHead>Name</TableHead>
               <TableHead>Description</TableHead>
-              <TableHead>Host</TableHead>
+              <TableHead>Hosts</TableHead>
               <TableHead>Trigger</TableHead>
+              <TableHead>Incident Keys</TableHead>
               <TableHead>Status</TableHead>
               <TableHead />
             </TableRow>
@@ -126,11 +261,14 @@ export default function SkillsPage() {
                 <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
                   {s.description || "-"}
                 </TableCell>
-                <TableCell className="text-sm">{s.host}</TableCell>
+                <TableCell className="text-sm">{(s.hosts || []).join(", ")}</TableCell>
                 <TableCell>
                   <Badge variant={s.trigger === "watch" ? "secondary" : "outline"}>
                     {s.trigger}
                   </Badge>
+                </TableCell>
+                <TableCell className="text-xs text-muted-foreground max-w-xs truncate">
+                  {(s.incident_keys || []).join(", ") || "—"}
                 </TableCell>
                 <TableCell>
                   <Badge variant={s.enabled ? "default" : "outline"}>
@@ -188,6 +326,8 @@ export default function SkillsPage() {
         open={formOpen}
         onOpenChange={setFormOpen}
         onSubmit={handleCreate}
+        incidentFamilies={incidentFamilies ?? []}
+        availableHosts={hosts ?? []}
       />
 
       {editingSkill && (
@@ -198,6 +338,8 @@ export default function SkillsPage() {
           }}
           onSubmit={handleUpdate}
           skill={editingSkill}
+          incidentFamilies={incidentFamilies ?? []}
+          availableHosts={hosts ?? []}
         />
       )}
     </div>

--- a/web/src/app/watch/page.tsx
+++ b/web/src/app/watch/page.tsx
@@ -17,7 +17,7 @@ export default function WatchPage() {
   const { data: status, mutate } = useSWR(
     "/api/watch/status",
     () => apiGet<WatchStatus>("/api/watch/status"),
-    { refreshInterval: 3000 }
+    { refreshInterval: (latestData?: WatchStatus) => (latestData?.status === "running" ? 2000 : 5000) }
   );
 
   const isRunning = status?.status === "running";

--- a/web/src/components/skills/skill-form.tsx
+++ b/web/src/components/skills/skill-form.tsx
@@ -20,7 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { Skill } from "@/lib/types";
+import type { HostInfo, IncidentFamilyInfo, Skill } from "@/lib/types";
 
 interface SkillFormProps {
   open: boolean;
@@ -28,18 +28,25 @@ interface SkillFormProps {
   onSubmit: (data: {
     name: string;
     description: string;
-    host: string;
+    hosts: string[];
     trigger: string;
+    incident_keys: string[];
+    allow_custom_incident_prefixes: boolean;
     instructions: string;
   }) => void;
   skill?: Skill | null;
+  incidentFamilies: IncidentFamilyInfo[];
+  availableHosts: HostInfo[];
 }
 
-export function SkillForm({ open, onOpenChange, onSubmit, skill }: SkillFormProps) {
+export function SkillForm({ open, onOpenChange, onSubmit, skill, incidentFamilies, availableHosts }: SkillFormProps) {
   const [name, setName] = useState(skill?.name ?? "");
   const [description, setDescription] = useState(skill?.description ?? "");
-  const [host, setHost] = useState(skill?.host ?? "all");
+  const [selectedHost, setSelectedHost] = useState(skill?.hosts?.[0] ?? "all");
   const [trigger, setTrigger] = useState(skill?.trigger ?? "manual");
+  const [incidentKeys, setIncidentKeys] = useState<string[]>(skill?.incident_keys ?? []);
+  const [customIncidentKeys, setCustomIncidentKeys] = useState("");
+  const [allowCustomIncidentPrefixes, setAllowCustomIncidentPrefixes] = useState(false);
   const [instructions, setInstructions] = useState(skill?.instructions ?? "");
 
   const isEdit = !!skill;
@@ -51,11 +58,18 @@ export function SkillForm({ open, onOpenChange, onSubmit, skill }: SkillFormProp
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!isNameValid || !description.trim() || !instructions.trim()) return;
+    const extraIncidentKeys = customIncidentKeys
+      .split(",")
+      .map((k) => k.trim())
+      .filter(Boolean);
+    const mergedIncidentKeys = Array.from(new Set([...incidentKeys, ...extraIncidentKeys]));
     onSubmit({
       name: name.trim(),
       description: description.trim(),
-      host,
+      hosts: [selectedHost || "all"],
       trigger,
+      incident_keys: trigger === "watch" ? mergedIncidentKeys : [],
+      allow_custom_incident_prefixes: trigger === "watch" ? allowCustomIncidentPrefixes : false,
       instructions: instructions.trim(),
     });
   };
@@ -105,11 +119,23 @@ export function SkillForm({ open, onOpenChange, onSubmit, skill }: SkillFormProp
             <div className="flex gap-4">
               <div className="space-y-2 flex-1">
                 <Label>Host</Label>
-                <Input
-                  value={host}
-                  onChange={(e) => setHost(e.target.value)}
-                  placeholder="all"
-                />
+                <Select value={selectedHost} onValueChange={(v) => setSelectedHost(v ?? "all")}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">all</SelectItem>
+                    <SelectItem value="local">local</SelectItem>
+                    {(availableHosts ?? [])
+                      .filter((h) => h.name !== "local")
+                      .map((h) => (
+                        <SelectItem key={h.name} value={h.name}>
+                          {h.name}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">Choose a specific host or `all`.</p>
               </div>
               <div className="space-y-2 flex-1">
                 <Label>Trigger</Label>
@@ -124,6 +150,55 @@ export function SkillForm({ open, onOpenChange, onSubmit, skill }: SkillFormProp
                 </Select>
               </div>
             </div>
+
+            {trigger === "watch" && (
+              <div className="space-y-2">
+                <Label>Incident Families (Playbook Routing)</Label>
+                <div className="rounded-md border p-3 space-y-2 max-h-40 overflow-y-auto">
+                  {incidentFamilies.map((family) => {
+                    const checked = incidentKeys.includes(family.prefix);
+                    return (
+                      <label key={family.prefix} className="flex items-start gap-2 text-sm cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={(e) => {
+                            if (e.target.checked) {
+                              setIncidentKeys((prev) => [...prev, family.prefix]);
+                            } else {
+                              setIncidentKeys((prev) => prev.filter((k) => k !== family.prefix));
+                            }
+                          }}
+                        />
+                        <span>
+                          <code>{family.prefix}</code> — {family.description}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  A watch skill becomes a playbook candidate when at least one incident family is selected.
+                </p>
+                <div className="space-y-2">
+                  <Label htmlFor="custom-incident-keys">Custom Incident Prefixes (advanced)</Label>
+                  <Input
+                    id="custom-incident-keys"
+                    value={customIncidentKeys}
+                    onChange={(e) => setCustomIncidentKeys(e.target.value)}
+                    placeholder="power-event:, network-latency:"
+                  />
+                  <label className="text-xs text-muted-foreground flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={allowCustomIncidentPrefixes}
+                      onChange={(e) => setAllowCustomIncidentPrefixes(e.target.checked)}
+                    />
+                    Allow non-catalog prefixes for this save
+                  </label>
+                </div>
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="skill-instructions">Instructions</Label>

--- a/web/src/components/watch/watch-config-drawer.tsx
+++ b/web/src/components/watch/watch-config-drawer.tsx
@@ -39,6 +39,9 @@ export function WatchConfigDrawer({ open, onOpenChange }: WatchConfigDrawerProps
   const [interval, setInterval_] = useState(5);
   const [risk, setRisk] = useState(3);
   const [prompt, setPrompt] = useState("");
+  const [maxIdenticalActions, setMaxIdenticalActions] = useState(2);
+  const [blockedCooldown, setBlockedCooldown] = useState(3);
+  const [maxRemoteActions, setMaxRemoteActions] = useState(4);
   const [prevConfig, setPrevConfig] = useState(config);
 
   if (config && config !== prevConfig) {
@@ -46,6 +49,9 @@ export function WatchConfigDrawer({ open, onOpenChange }: WatchConfigDrawerProps
     setInterval_(config.interval_minutes);
     setRisk(config.risk_tolerance ?? 3);
     setPrompt(config.checkin_prompt);
+    setMaxIdenticalActions(config.max_identical_actions_per_cycle);
+    setBlockedCooldown(config.blocked_action_cooldown_cycles);
+    setMaxRemoteActions(config.max_remote_actions_per_cycle);
   }
 
   const handleApply = async () => {
@@ -53,6 +59,9 @@ export function WatchConfigDrawer({ open, onOpenChange }: WatchConfigDrawerProps
       interval_minutes: interval,
       risk_tolerance: risk,
       checkin_prompt: prompt,
+      max_identical_actions_per_cycle: maxIdenticalActions,
+      blocked_action_cooldown_cycles: blockedCooldown,
+      max_remote_actions_per_cycle: maxRemoteActions,
     });
     onOpenChange(false);
   };
@@ -96,6 +105,33 @@ export function WatchConfigDrawer({ open, onOpenChange }: WatchConfigDrawerProps
               rows={4}
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Max identical actions per cycle</Label>
+            <Input
+              type="number"
+              min={1}
+              value={maxIdenticalActions}
+              onChange={(e) => setMaxIdenticalActions(parseInt(e.target.value) || 1)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Blocked action cooldown (cycles)</Label>
+            <Input
+              type="number"
+              min={1}
+              value={blockedCooldown}
+              onChange={(e) => setBlockedCooldown(parseInt(e.target.value) || 1)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Max remote actions per cycle</Label>
+            <Input
+              type="number"
+              min={1}
+              value={maxRemoteActions}
+              onChange={(e) => setMaxRemoteActions(parseInt(e.target.value) || 1)}
             />
           </div>
         </div>

--- a/web/src/components/watch/watch-cycle-history.tsx
+++ b/web/src/components/watch/watch-cycle-history.tsx
@@ -47,6 +47,18 @@ function CycleDetail({ cycle }: { cycle: number }) {
             );
           case "token":
             return <span key={event.id}>{event.content}</span>;
+          case "incident":
+            return (
+              <div key={event.id} className="text-orange-500">
+                ⚠ {(content.severity as string)?.toUpperCase()} {(content.title as string)} ({content.host as string})
+              </div>
+            );
+          case "phase":
+            return (
+              <div key={event.id} className="text-blue-500">
+                ◇ {(content.phase as string)}: {(content.summary as string)}
+              </div>
+            );
           case "cycle_start":
           case "cycle_end":
             return null;
@@ -175,7 +187,11 @@ export function WatchCycleHistory() {
                   {cycle.started_at ? new Date(cycle.started_at).toLocaleTimeString() : "—"}
                 </span>
                 <span className="text-muted-foreground text-xs">{cycle.tool_count} tools</span>
+                <span className="text-muted-foreground text-xs">{cycle.blocked_count || 0} blocked</span>
+                <span className="text-muted-foreground text-xs">{cycle.incident_count || 0} incidents</span>
                 <Badge variant={statusColor} className="text-xs">{cycle.status}</Badge>
+                {cycle.resolved && <Badge variant="secondary" className="text-xs">resolved</Badge>}
+                {cycle.escalated && <Badge variant="destructive" className="text-xs">escalated</Badge>}
                 {cycle.duration_seconds && (
                   <span className="text-muted-foreground text-xs ml-auto">{cycle.duration_seconds.toFixed(1)}s</span>
                 )}

--- a/web/src/components/watch/watch-live-stream.tsx
+++ b/web/src/components/watch/watch-live-stream.tsx
@@ -33,12 +33,28 @@ function EventRow({ event }: { event: WatchEvent }) {
     case "cycle_end": {
       const status = (content.status as string) || "unknown";
       const duration = content.duration_seconds as number;
+      const blocked = (content.blocked_count as number) || 0;
+      const incidentCount = ((content.outcome as Record<string, unknown>)?.incident_count as number) || 0;
       return (
         <div className="text-primary font-medium py-1">
-          ── Cycle {event.cycle} ended ({status}{duration ? `, ${duration.toFixed(1)}s` : ""}) ──
+          ── Cycle {event.cycle} ended ({status}{duration ? `, ${duration.toFixed(1)}s` : ""}, incidents:{" "}
+          {incidentCount}, blocked: {blocked}) ──
         </div>
       );
     }
+    case "incident":
+      return (
+        <div className="py-0.5 text-orange-500">
+          ⚠ {(content.severity as string)?.toUpperCase()} {(content.title as string)} ({content.host as string}) -{" "}
+          {content.detail as string}
+        </div>
+      );
+    case "phase":
+      return (
+        <div className="py-0.5 text-blue-500">
+          ◇ {(content.phase as string)}: {(content.summary as string)}
+        </div>
+      );
     case "tool_call":
       return (
         <div className="py-0.5">

--- a/web/src/components/watch/watch-stats-card.tsx
+++ b/web/src/components/watch/watch-stats-card.tsx
@@ -18,6 +18,10 @@ function formatUptime(startedAt: string | null | undefined): string {
 
 export function WatchStatsCard({ status }: WatchStatsCardProps) {
   const isRunning = status?.status === "running";
+  const totalActions = Number(status?.total_actions || 0);
+  const totalBlocked = Number(status?.total_blocked || 0);
+  const totalResolved = Number(status?.total_resolved || 0);
+  const totalEscalated = Number(status?.total_escalated || 0);
 
   return (
     <Card>
@@ -39,6 +43,22 @@ export function WatchStatsCard({ status }: WatchStatsCardProps) {
           <div>
             <span className="text-muted-foreground">Interval</span>
             <p>{status?.interval_minutes || "5"}m</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Actions</span>
+            <p>{totalActions}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Blocked</span>
+            <p>{totalBlocked}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Resolved</span>
+            <p>{totalResolved}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Escalated</span>
+            <p>{totalEscalated}</p>
           </div>
         </div>
       </CardContent>

--- a/web/src/components/watch/watch-status-card.tsx
+++ b/web/src/components/watch/watch-status-card.tsx
@@ -20,6 +20,15 @@ export function WatchStatusCard({ status, onConfigure, onRefresh }: WatchStatusC
   const cycle = status?.cycle ? parseInt(status.cycle) : 0;
   const interval = status?.interval_minutes ? parseInt(status.interval_minutes) : 5;
   const riskTolerance = status?.risk_tolerance || "—";
+  let lastOutcomeText = "";
+  if (status?.last_outcome) {
+    try {
+      const parsed = JSON.parse(status.last_outcome) as { resolved?: boolean; escalated?: boolean; incident_count?: number };
+      lastOutcomeText = `Last outcome: ${parsed.incident_count ?? 0} incidents, ${parsed.resolved ? "resolved" : parsed.escalated ? "escalated" : "monitoring"}`;
+    } catch {
+      lastOutcomeText = "";
+    }
+  }
 
   const pollUntilStatus = async (target: string, maxAttempts = 15) => {
     for (let i = 0; i < maxAttempts; i++) {
@@ -67,6 +76,7 @@ export function WatchStatusCard({ status, onConfigure, onRefresh }: WatchStatusC
             <>
               <p>Cycle {cycle} · Every {interval} min · Risk tolerance: {riskTolerance}</p>
               {status?.pid && <p className="text-xs">PID {status.pid}</p>}
+              {lastOutcomeText && <p className="text-xs">{lastOutcomeText}</p>}
             </>
           ) : (
             <>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -99,10 +99,33 @@ export interface AlertRuleCreate {
 export interface Skill {
   name: string;
   description: string;
-  host: string;
+  hosts: string[];
   trigger: string;
   enabled: boolean;
+  incident_keys: string[];
   instructions: string;
+}
+
+export interface IncidentFamilyInfo {
+  prefix: string;
+  description: string;
+}
+
+export interface PlaybookDryRunIncident {
+  key: string;
+  severity: string;
+  host: string;
+  title: string;
+  detail: string;
+}
+
+export interface PlaybookDryRunSelection {
+  incident: PlaybookDryRunIncident;
+  candidate_count: number;
+  selected_playbook: string | null;
+  path_taken: "deterministic_single" | "tie_break" | "semantic" | "generic";
+  confidence: number;
+  reasoning: string;
 }
 
 export interface EventInfo {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -126,6 +126,12 @@ export interface WatchStatus {
   session_id?: string | null;
   last_response?: string | null;
   pid?: string | null;
+  total_actions?: string | null;
+  total_blocked?: string | null;
+  total_errors?: string | null;
+  total_resolved?: string | null;
+  total_escalated?: string | null;
+  last_outcome?: string | null;
 }
 
 // Watch event from watch_events table
@@ -145,6 +151,11 @@ export interface WatchCycle {
   status: string;
   duration_seconds: number | null;
   tool_count: number;
+  blocked_count?: number;
+  incident_count?: number;
+  resolved?: boolean;
+  escalated?: boolean;
+  incident_key?: string | null;
   event_count: number;
 }
 
@@ -158,6 +169,9 @@ export interface WatchConfigResponse {
   notify_on_blocked: boolean;
   cycles_per_session: number;
   max_context_events: number;
+  max_identical_actions_per_cycle: number;
+  blocked_action_cooldown_cycles: number;
+  max_remote_actions_per_cycle: number;
   risk_tolerance: number | null;
 }
 
@@ -171,6 +185,9 @@ export interface WatchConfigUpdate {
   notify_on_blocked?: boolean;
   cycles_per_session?: number;
   max_context_events?: number;
+  max_identical_actions_per_cycle?: number;
+  blocked_action_cooldown_cycles?: number;
+  max_remote_actions_per_cycle?: number;
   risk_tolerance?: number;
 }
 


### PR DESCRIPTION
## Problem

Watch mode had solid loop mechanics but lacked a reliable autonomy framework for incident handling. It did not enforce a structured detect/RCA/remediate/verify/escalate cycle, had limited anti-flapping safeguards, and exposed only coarse telemetry in the API/UI, making it harder to trust as a primary autonomous homelab operator.

## Context

The goal for this branch is strict-autonomy watch behavior (no human-in-the-loop approvals) with stronger self-healing and clearer operator visibility. Existing docs and UX around watch behavior had drifted in places, and the watch surface needed better outcome-level evidence (resolved vs escalated, blocked counts, incident fingerprints) to support day-to-day supervision.

## Solution

Implemented a structured watch autonomy stack centered on explicit cycle contracts, bounded execution safety, and richer observability:

- Added autonomy helpers for incident detection, contract prompt shaping, response section parsing, and structured outcome generation.
- Added playbook selection for common incidents (container unhealthy, disk pressure, host unreachable, preventive sweep) and injected playbooks into cycle context.
- Extended watch eventing with `incident` and `phase` events, and enriched `cycle_end` payloads with blocked counts and outcome details.
- Added strict runtime safety controls: repeated-action suppression, cooldown signatures, and remote-action caps; wired cooldown blocking into the risk gate.
- Upgraded watch notifications to high-signal categories (`watch.incident_detected`, `watch.remediation`, `watch.verification`, `watch.escalation`, `watch.digest`) with fingerprint deduping.
- Extended backend schemas/API and frontend watch UI to show autonomy telemetry and new safety controls.
- Aligned docs/example config/changelog with strict-autonomy defaults and new watch fields.

Trade-off: this keeps watch mode strictly autonomous rather than introducing supervised approval gating, favoring deterministic unattended behavior and clear escalation paths.

## Testing

### Unit tests

- Added `tests/test_watch_autonomy.py` covering incident detection, contract prompt composition, section parsing/outcome mapping, and playbook selection.
- Extended `tests/test_watch_config.py` for new watch safety defaults.
- Extended `tests/test_watch_emitter.py` for enriched cycle-end payload and new phase/incident events.

### Integration tests

- Ran existing watch API/loop/database coverage:
  - `tests/test_watch_loop.py`
  - `tests/test_api_watch.py`
  - `tests/test_database_watch.py`
- Frontend build/type validation via Next.js production build.

### Test results

- `uv run pytest tests/test_watch_autonomy.py tests/test_watch_config.py tests/test_watch_emitter.py tests/test_watch_loop.py tests/test_api_watch.py tests/test_database_watch.py`
  - Result: **39 passed, 0 failed**
- `make lint`
  - Result: **All checks passed**
- `npm --prefix web run lint`
  - Result: **Passed**
- `npm --prefix web run build`
  - Result: **Compiled + TypeScript passed; static routes generated**

## Reviewer Validation

1. Run backend verification:
   - `uv run pytest tests/test_watch_autonomy.py tests/test_watch_config.py tests/test_watch_emitter.py tests/test_watch_loop.py tests/test_api_watch.py tests/test_database_watch.py`
   - Expect 39 passing tests.
2. Validate lint/build gates:
   - `make lint`
   - `npm --prefix web run lint && npm --prefix web run build`
   - Expect no lint/type/build errors.
3. Verify runtime behavior in watch UI:
   - Start web/watch, open `/watch`, and confirm `incident`/`phase` stream events, enriched cycle history (blocked/incidents/resolved/escalated), and new config controls (`max_identical_actions_per_cycle`, cooldown cycles, remote action cap).

## TODOs / Follow-Ups

- Service-down/systemd-specific playbooks can be expanded further with deeper host/service registries and host-aware verification heuristics.
- Add end-to-end browser automation for watch UI telemetry rendering and live websocket assertions.

Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)