### PR TITLE
feat: add provider-backed LLM model dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Watch playbooks (user-managed):** Added dynamic playbook routing from Skills metadata (`incident_keys` + `hosts`) with deterministic matching, single-match plausibility checks, LLM tie-break for overlaps, semantic fallback for unmatched incidents, and generic fallback on low confidence
 - **Skills API/UI:** Added incident family catalog endpoint, router dry-run simulation endpoint, starter playbook bootstrap endpoint, conflict preview UI, and watch-playbook metadata editing (`hosts`, `incident_keys`)
 - **Watch telemetry:** Added playbook selection phase events and counters for deterministic/semantic/generic routing paths
+- **Web LLM model selection:** Chat header and Configuration > LLM now use provider-backed model dropdowns instead of free-text model entry; chat changes still persist and auto-reconnect the current session
 
 ### Changed
 

--- a/src/squire/api/routers/config.py
+++ b/src/squire/api/routers/config.py
@@ -24,6 +24,7 @@ from ..schemas import (
     ConfigSectionMeta,
     GuardrailsConfigUpdate,
     LLMConfigUpdate,
+    LLMModelsResponse,
     NotificationsConfigUpdate,
     SkillsConfigUpdate,
     WatchConfigPatch,
@@ -138,6 +139,49 @@ async def get_config(
         hosts=host_configs,
         toml_path=str(toml_path) if toml_path else None,
     )
+
+
+@router.get("/llm/models", response_model=LLMModelsResponse)
+async def get_llm_models(llm_config=Depends(get_llm_config)):
+    """List available models for the active provider."""
+    import litellm
+
+    current_model = llm_config.model
+    provider = "unknown"
+    resolved_api_base = llm_config.api_base
+    error: str | None = None
+
+    try:
+        _, provider, _, resolved_api_base = litellm.get_llm_provider(model=current_model, api_base=llm_config.api_base)
+    except Exception:
+        if "/" in current_model:
+            provider = current_model.split("/", 1)[0]
+
+    try:
+        discovered = litellm.get_valid_models(
+            check_provider_endpoint=True,
+            custom_llm_provider=provider if provider != "unknown" else None,
+            api_base=resolved_api_base,
+        )
+    except Exception as exc:
+        discovered = []
+        error = str(exc)
+
+    provider_prefix = f"{provider}/" if provider != "unknown" else ""
+    normalized: list[str] = []
+    for item in discovered:
+        if not isinstance(item, str):
+            continue
+        name = item.strip()
+        if not name:
+            continue
+        if "/" in name or not provider_prefix:
+            normalized.append(name)
+        else:
+            normalized.append(f"{provider_prefix}{name}")
+
+    models = sorted(set(normalized + [current_model]))
+    return LLMModelsResponse(provider=provider, current_model=current_model, models=models, error=error)
 
 
 # --- PATCH ---

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -281,6 +281,13 @@ class LLMConfigUpdate(BaseModel):
     max_tokens: int | None = None
 
 
+class LLMModelsResponse(BaseModel):
+    provider: str
+    current_model: str
+    models: list[str]
+    error: str | None = None
+
+
 class WatchConfigPatch(BaseModel):
     interval_minutes: int | None = Field(default=None, ge=1)
     max_tool_calls_per_cycle: int | None = Field(default=None, ge=1)

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -65,6 +65,48 @@ class TestGetConfig:
         assert result.toml_path == str(toml_file)
 
 
+@pytest.mark.usefixtures("_setup_deps")
+class TestGetLlmModels:
+    async def test_returns_provider_models(self, monkeypatch):
+        from squire.api.routers.config import get_llm_models
+
+        def _fake_get_llm_provider(model: str, api_base=None):
+            return ("gpt-4o-mini", "openai", None, api_base)
+
+        def _fake_get_valid_models(**kwargs):
+            assert kwargs["custom_llm_provider"] == "openai"
+            return ["gpt-4o-mini", "gpt-4.1-mini"]
+
+        monkeypatch.setattr("litellm.get_llm_provider", _fake_get_llm_provider)
+        monkeypatch.setattr("litellm.get_valid_models", _fake_get_valid_models)
+        monkeypatch.setattr(deps, "llm_config", LLMConfig(model="openai/gpt-4o-mini"))
+
+        result = await get_llm_models(llm_config=deps.llm_config)
+        assert result.provider == "openai"
+        assert result.current_model == "openai/gpt-4o-mini"
+        assert "openai/gpt-4o-mini" in result.models
+        assert "openai/gpt-4.1-mini" in result.models
+        assert result.error is None
+
+    async def test_includes_current_model_when_discovery_fails(self, monkeypatch):
+        from squire.api.routers.config import get_llm_models
+
+        def _fake_get_llm_provider(model: str, api_base=None):
+            return ("llama3.2:3b", "ollama_chat", None, api_base)
+
+        def _fake_get_valid_models(**kwargs):
+            raise RuntimeError("provider unavailable")
+
+        monkeypatch.setattr("litellm.get_llm_provider", _fake_get_llm_provider)
+        monkeypatch.setattr("litellm.get_valid_models", _fake_get_valid_models)
+        monkeypatch.setattr(deps, "llm_config", LLMConfig(model="ollama_chat/llama3.2:3b"))
+
+        result = await get_llm_models(llm_config=deps.llm_config)
+        assert result.provider == "ollama_chat"
+        assert result.models == ["ollama_chat/llama3.2:3b"]
+        assert result.error == "provider unavailable"
+
+
 # --- PATCH /api/config/{section} ---
 
 

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -3,15 +3,16 @@
 /* eslint-disable @next/next/no-img-element */
 import { Suspense, startTransition, useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { apiGet, apiPost } from "@/lib/api";
+import { apiGet, apiPatch, apiPost } from "@/lib/api";
 import { useWebSocket } from "@/hooks/use-websocket";
 import { MessageList, type ChatMessage, type AgentState } from "@/components/chat/message-list";
 import { ChatInput, type ChatInputHandle } from "@/components/chat/chat-input";
 import { ApprovalDialog } from "@/components/chat/approval-dialog";
-import type { MessageInfo, WsApprovalRequest } from "@/lib/types";
+import type { ConfigDetailResponse, LLMModelsResponse, MessageInfo, WsApprovalRequest } from "@/lib/types";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { SquarePen } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Check, Loader2, SquarePen } from "lucide-react";
 
 const SESSION_KEY = "squire_chat_session";
 
@@ -20,6 +21,18 @@ const suggestions = [
   "Check containers",
   "List alerts",
 ];
+
+function configErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) return "Failed to update model.";
+  const body = error.message.match(/^API error \d+: (.*)$/)?.[1];
+  if (!body) return error.message;
+  try {
+    const parsed = JSON.parse(body) as { detail?: string };
+    return parsed.detail ?? error.message;
+  } catch {
+    return error.message;
+  }
+}
 
 export default function ChatPage() {
   return (
@@ -108,6 +121,13 @@ function ChatPageInner() {
     useState<WsApprovalRequest | null>(null);
   const [agentState, setAgentState] = useState<AgentState>(null);
   const [activeToolName, setActiveToolName] = useState<string | undefined>();
+  const [activeModel, setActiveModel] = useState("");
+  const [selectedModel, setSelectedModel] = useState("");
+  const [modelOptions, setModelOptions] = useState<string[]>([]);
+  const [modelProvider, setModelProvider] = useState<string>("");
+  const [modelLoading, setModelLoading] = useState(true);
+  const [modelSaving, setModelSaving] = useState(false);
+  const [modelError, setModelError] = useState<string | null>(null);
 
   // Track streaming state with a ref to avoid closure staleness
   const chatInputRef = useRef<ChatInputHandle>(null);
@@ -147,7 +167,37 @@ function ChatPageInner() {
   }, [sessionId]);
 
   const wsQueryParams = skillName ? { skill: skillName } : undefined;
-  const { status, send, setOnMessage } = useWebSocket(sessionId, wsQueryParams);
+  const { status, send, setOnMessage, reconnect } = useWebSocket(sessionId, wsQueryParams);
+
+  useEffect(() => {
+    let cancelled = false;
+    setModelLoading(true);
+    Promise.all([
+      apiGet<ConfigDetailResponse>("/api/config"),
+      apiGet<LLMModelsResponse>("/api/config/llm/models"),
+    ])
+      .then(([config, modelsResponse]) => {
+        if (cancelled) return;
+        const model = String(config.llm?.values?.model ?? modelsResponse.current_model ?? "");
+        setActiveModel(model);
+        setSelectedModel(model);
+        setModelProvider(modelsResponse.provider);
+        setModelOptions(Array.from(new Set([...(modelsResponse.models ?? []), model])).sort());
+        if (modelsResponse.error) {
+          setModelError(`Model provider lookup failed: ${modelsResponse.error}`);
+        }
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setModelError(configErrorMessage(error));
+      })
+      .finally(() => {
+        if (!cancelled) setModelLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Handle incoming WS messages
   useEffect(() => {
@@ -342,6 +392,44 @@ function ChatPageInner() {
     requestAnimationFrame(() => chatInputRef.current?.focus());
   }, [router]);
 
+  const handleSaveModel = useCallback(async () => {
+    const candidate = selectedModel.trim();
+    if (!candidate) {
+      setModelError("Model cannot be empty.");
+      return;
+    }
+    if (candidate === activeModel) {
+      setModelError(null);
+      return;
+    }
+
+    setModelSaving(true);
+    setModelError(null);
+    try {
+      await apiPatch("/api/config/llm?persist=true", { model: candidate });
+      setActiveModel(candidate);
+      setSelectedModel(candidate);
+      reconnect();
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: nextId(),
+          role: "system",
+          content: `Model switched to ${candidate}. Reconnected this chat to use the new model.`,
+        },
+      ]);
+    } catch (error) {
+      const message = configErrorMessage(error);
+      if (message.includes("Cannot update env-var-overridden fields")) {
+        setModelError("Model is locked by SQUIRE_LLM_MODEL. Update the environment variable to change it.");
+      } else {
+        setModelError(message);
+      }
+    } finally {
+      setModelSaving(false);
+    }
+  }, [activeModel, reconnect, selectedModel]);
+
   if (!sessionId) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -357,10 +445,51 @@ function ChatPageInner() {
       <div className="flex items-center gap-2 px-4 py-2 border-b border-border/60 shrink-0 bg-card/80">
         <h1 className="text-base font-display font-semibold">Chat</h1>
         <ConnectionDot status={status} />
+        <div className="ml-3 flex items-center gap-2 min-w-0">
+          <span className="text-xs text-muted-foreground">
+            Model{modelProvider ? ` (${modelProvider})` : ""}
+          </span>
+          {modelLoading ? (
+            <Skeleton className="h-6 w-40" />
+          ) : (
+            <>
+              <Select value={selectedModel} onValueChange={(value) => setSelectedModel(value ?? "")}>
+                <SelectTrigger
+                  className="h-8 w-[20rem] min-w-40 text-xs font-mono"
+                  aria-label="Active model"
+                  disabled={modelSaving || modelOptions.length === 0}
+                >
+                  <SelectValue placeholder="No models available" />
+                </SelectTrigger>
+                <SelectContent>
+                  {modelOptions.map((model) => (
+                    <SelectItem key={model} value={model} className="font-mono text-xs">
+                      {model}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={handleSaveModel}
+                disabled={modelSaving || !selectedModel || selectedModel === activeModel}
+                aria-label="Save model"
+              >
+                {modelSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+              </Button>
+            </>
+          )}
+        </div>
         <Button variant="ghost" size="icon" onClick={handleNewChat} className="ml-auto">
           <SquarePen className="h-4 w-4" />
         </Button>
       </div>
+      {modelError && (
+        <div className="px-4 py-1 border-b border-border/40 text-xs text-destructive bg-destructive/5">
+          {modelError}
+        </div>
+      )}
 
       {hasMessages ? (
         <MessageList messages={messages} agentState={agentState} activeToolName={activeToolName} onStop={handleStop} />

--- a/web/src/components/config/llm-config-form.tsx
+++ b/web/src/components/config/llm-config-form.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from "react";
 import { Lock, Loader2, RotateCcw, Save } from "lucide-react";
-import { apiPatch } from "@/lib/api";
+import { apiGet, apiPatch } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import {
   Tooltip,
   TooltipContent,
@@ -13,6 +14,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { LLMModelsResponse } from "@/lib/types";
 import { ConfigHint, ConfigIntro } from "./config-help";
 
 interface LLMConfigFormProps {
@@ -47,6 +49,10 @@ function apiBaseFromValues(v: unknown): string {
 
 export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMConfigFormProps) {
   const [model, setModel] = useState(String(values.model ?? ""));
+  const [modelOptions, setModelOptions] = useState<string[]>([]);
+  const [modelProvider, setModelProvider] = useState<string>("");
+  const [modelsLoading, setModelsLoading] = useState(true);
+  const [modelLookupError, setModelLookupError] = useState<string | null>(null);
   const [temperature, setTemperature] = useState(Number(values.temperature ?? 0.2));
   const [maxTokens, setMaxTokens] = useState(Number(values.max_tokens ?? 4096));
   const [apiBase, setApiBase] = useState(() => apiBaseFromValues(values.api_base));
@@ -59,6 +65,33 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
     setTemperature(Number(values.temperature ?? 0.2));
     setMaxTokens(Number(values.max_tokens ?? 4096));
     setApiBase(apiBaseFromValues(values.api_base));
+  }, [values.api_base, values.max_tokens, values.model, values.temperature]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setModelsLoading(true);
+    setModelLookupError(null);
+    apiGet<LLMModelsResponse>("/api/config/llm/models")
+      .then((result) => {
+        if (cancelled) return;
+        setModelProvider(result.provider ?? "");
+        const current = String(values.model ?? "");
+        setModelOptions(Array.from(new Set([...(result.models ?? []), current])).filter(Boolean).sort());
+        if (result.error) {
+          setModelLookupError(`Provider model lookup failed: ${result.error}`);
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setModelLookupError(err instanceof Error ? err.message : "Failed to load provider models.");
+        setModelOptions([String(values.model ?? "")].filter(Boolean));
+      })
+      .finally(() => {
+        if (!cancelled) setModelsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [values]);
 
   const isLocked = (field: string) => envOverrides.includes(field);
@@ -117,19 +150,33 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
         </ConfigIntro>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
-            <Label>Model</Label>
+            <Label>Model{modelProvider ? ` (${modelProvider})` : ""}</Label>
             {isLocked("model") && <EnvLock field="model" prefix="SQUIRE_LLM_" />}
           </div>
-          <Input
-            value={model}
-            onChange={(e) => setModel(e.target.value)}
-            disabled={isLocked("model")}
-            placeholder="e.g. ollama_chat/llama3.1:8b"
-          />
+          {modelsLoading ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              Loading provider models...
+            </div>
+          ) : (
+            <Select value={model} onValueChange={(value) => setModel(value ?? "")}>
+              <SelectTrigger className="w-full font-mono text-xs" disabled={isLocked("model") || modelOptions.length === 0}>
+                <SelectValue placeholder="No models available" />
+              </SelectTrigger>
+              <SelectContent>
+                {modelOptions.map((option) => (
+                  <SelectItem key={option} value={option} className="font-mono text-xs">
+                    {option}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
           <ConfigHint>
-            LiteLLM string such as <code>ollama_chat/...</code> or <code>gemini/...</code>. Must match a provider you
-            have credentials or local runtime for.
+            Models are loaded from the active provider. Selecting one saves the LiteLLM id (for example{" "}
+            <code>ollama_chat/...</code> or <code>gemini/...</code>).
           </ConfigHint>
+          {modelLookupError && <p className="text-xs text-muted-foreground">{modelLookupError}</p>}
         </div>
 
         <div className="space-y-2">

--- a/web/src/hooks/use-websocket.ts
+++ b/web/src/hooks/use-websocket.ts
@@ -12,6 +12,7 @@ const BASE_DELAY_MS = 1000;
 export function useWebSocket(sessionId: string | null, queryParams?: Record<string, string>) {
   const wsRef = useRef<WebSocket | null>(null);
   const [status, setStatus] = useState<WsStatus>("disconnected");
+  const [reconnectToken, setReconnectToken] = useState(0);
   const onMessageRef = useRef<((msg: WsServerMessage) => void) | null>(null);
   const retriesRef = useRef(0);
   const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -84,7 +85,7 @@ export function useWebSocket(sessionId: string | null, queryParams?: Record<stri
       wsRef.current?.close();
       wsRef.current = null;
     };
-  }, [sessionId, queryString]);
+  }, [sessionId, queryString, reconnectToken]);
 
   const send = useCallback(
     (data: Record<string, unknown>) => {
@@ -102,5 +103,17 @@ export function useWebSocket(sessionId: string | null, queryParams?: Record<stri
     []
   );
 
-  return { status, send, setOnMessage };
+  const reconnect = useCallback(() => {
+    retriesRef.current = 0;
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+    intentionalCloseRef.current = true;
+    wsRef.current?.close();
+    wsRef.current = null;
+    setReconnectToken((prev) => prev + 1);
+  }, []);
+
+  return { status, send, setOnMessage, reconnect };
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -268,6 +268,13 @@ export interface ConfigDetailResponse {
   toml_path: string | null;
 }
 
+export interface LLMModelsResponse {
+  provider: string;
+  current_model: string;
+  models: string[];
+  error?: string | null;
+}
+
 // WebSocket message types
 export interface WsToken {
   type: "token";


### PR DESCRIPTION
## Problem

Users could not reliably pick valid models in chat or configuration because model entry required free-text LiteLLM identifiers and offered no provider-aware model discovery.

## Context

Issue #99 requested in-chat model visibility and quick updates. This follow-up extends that by sourcing model choices from the active provider so users can select valid models directly in both chat and config UI.

Closes #99

## Solution

Added a new backend endpoint (`GET /api/config/llm/models`) that resolves the active provider and returns provider-scoped model options plus the current model fallback. Updated chat and Configuration > LLM UIs to use provider-backed dropdowns, retained persisted model updates, and kept chat websocket reconnect behavior so changes apply to the active session.

## Testing

### Unit tests
- `uv run pytest tests/test_config_api.py`
  - Added `TestGetLlmModels` coverage for successful provider model discovery and fallback behavior when discovery fails.

### Integration tests
- Manual integration not run in browser automation for this PR.

### Test results
- `uv run pytest tests/test_config_api.py` → `21 passed`
- `make lint` → `All checks passed`
- `npm --prefix web run lint` → pass
- `npm --prefix web run build` → pass

## Reviewer Validation

1. Run `uv run pytest tests/test_config_api.py` and confirm `TestGetLlmModels` passes.
2. Open chat UI and verify the model control is a dropdown populated from provider models.
3. Open `Configuration > LLM` and verify the model field is the same provider-backed dropdown and saves successfully.

## TODOs / Follow-Ups

- None — this PR is self-contained.

Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)