### PR TITLE
feat: track token usage across chat and watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Token telemetry:** Provider-reported token usage is now captured per assistant response in chat/watch, aggregated per session/watch session, and exposed in watch cycle summaries (`input`, `output`, `total`)
+- **Web visibility:** Session History, chat message history, Watch stats, and Watch cycle history now display token usage metrics
+
+### Changed
+
+- **API schemas:** Session/message/watch status and watch cycle payloads now include token usage fields for downstream clients
+
 ## [0.15.0] — 2026-04-11
 
 ### Added

--- a/src/squire/api/routers/chat.py
+++ b/src/squire/api/routers/chat.py
@@ -47,6 +47,18 @@ def _strip_raw_tool_calls(text: str) -> str:
     return cleaned
 
 
+def _extract_token_usage_from_event(event: Any) -> tuple[int | None, int | None, int | None]:
+    """Extract provider-reported token usage from an ADK event."""
+    usage = getattr(event, "usage_metadata", None)
+    if not usage:
+        return None, None, None
+    return (
+        getattr(usage, "prompt_token_count", None),
+        getattr(usage, "candidates_token_count", None),
+        getattr(usage, "total_token_count", None),
+    )
+
+
 class WebApprovalBridge:
     """WebSocket-based approval provider for the risk gate.
 
@@ -391,7 +403,7 @@ async def _stream_response(
         prev_response = ""
 
         for turn in range(max_turns):
-            turn_response, tools_used = await _run_single_turn(
+            turn_response, tools_used, input_tokens, output_tokens, total_tokens = await _run_single_turn(
                 websocket=websocket,
                 runner=runner,
                 session=session,
@@ -403,7 +415,14 @@ async def _stream_response(
 
             # Persist assistant response
             if db and turn_response:
-                await db.save_message(session_id=session.id, role="assistant", content=turn_response)
+                await db.save_message(
+                    session_id=session.id,
+                    role="assistant",
+                    content=turn_response,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
+                )
                 await db.update_session_active(session.id)
 
             # If this is not a skill session or we've exhausted turns, stop.
@@ -451,17 +470,20 @@ async def _run_single_turn(
     user_text: str,
     app_config,
     db,
-) -> tuple[str, bool]:
+) -> tuple[str, bool, int | None, int | None, int | None]:
     """Run one agent turn and stream events over the WebSocket.
 
     Returns:
-        A tuple of (response_text, tools_were_called).
+        A tuple of (response_text, tools_were_called, input_tokens, output_tokens, total_tokens).
     """
     message = types.Content(parts=[types.Part(text=user_text)])
     response_parts: list[str] = []
     run_config = RunConfig(streaming_mode=StreamingMode.SSE)
     final_text = ""
     tools_called = False
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
 
     async for event in runner.run_async(
         user_id=app_config.user_id,
@@ -469,6 +491,14 @@ async def _run_single_turn(
         new_message=message,
         run_config=run_config,
     ):
+        event_input_tokens, event_output_tokens, event_total_tokens = _extract_token_usage_from_event(event)
+        if event_input_tokens is not None:
+            input_tokens = event_input_tokens
+        if event_output_tokens is not None:
+            output_tokens = event_output_tokens
+        if event_total_tokens is not None:
+            total_tokens = event_total_tokens
+
         if not event.content or not event.content.parts:
             continue
 
@@ -532,4 +562,4 @@ async def _run_single_turn(
                         await websocket.send_json({"type": "token", "content": delta})
 
     raw = final_text or "".join(response_parts)
-    return _strip_raw_tool_calls(raw), tools_called
+    return _strip_raw_tool_calls(raw), tools_called, input_tokens, output_tokens, total_tokens

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -84,6 +84,9 @@ class SessionInfo(BaseModel):
     created_at: str
     last_active: str
     preview: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
 
 
 class MessageInfo(BaseModel):
@@ -94,6 +97,9 @@ class MessageInfo(BaseModel):
     content: str | None = None
     tool_calls_json: str | None = None
     tool_call_id: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
 
 
 # --- Alerts ---
@@ -350,6 +356,9 @@ class WatchStatusResponse(BaseModel):
     total_errors: str | None = None
     total_resolved: str | None = None
     total_escalated: str | None = None
+    total_input_tokens: str | None = None
+    total_output_tokens: str | None = None
+    total_tokens: str | None = None
     last_outcome: str | None = None
 
 

--- a/src/squire/database/service.py
+++ b/src/squire/database/service.py
@@ -58,7 +58,10 @@ CREATE TABLE IF NOT EXISTS conversations (
     role            TEXT NOT NULL,
     content         TEXT,
     tool_calls_json TEXT,
-    tool_call_id    TEXT
+    tool_call_id    TEXT,
+    input_tokens    INTEGER,
+    output_tokens   INTEGER,
+    total_tokens    INTEGER
 )
 """
 
@@ -208,7 +211,19 @@ class DatabaseService:
             _CREATE_MANAGED_HOSTS,
         ):
             await self._conn.execute(stmt)
+        await self._ensure_conversation_token_columns()
         await self._conn.commit()
+
+    async def _ensure_conversation_token_columns(self) -> None:
+        """Add conversation token columns for existing databases."""
+        if self._conn is None:
+            raise RuntimeError("Database connection not initialized")
+        cursor = await self._conn.execute("PRAGMA table_info(conversations)")
+        rows = await cursor.fetchall()
+        existing_columns = {row[1] for row in rows}
+        for column in ("input_tokens", "output_tokens", "total_tokens"):
+            if column not in existing_columns:
+                await self._conn.execute(f"ALTER TABLE conversations ADD COLUMN {column} INTEGER")
 
     # --- Snapshots ---
 
@@ -318,16 +333,29 @@ class DatabaseService:
         content: str | None = None,
         tool_calls_json: str | None = None,
         tool_call_id: str | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        total_tokens: int | None = None,
     ) -> None:
         """Persist a single conversation message."""
         conn = await self._get_conn()
         now = datetime.now(UTC).isoformat()
         await conn.execute(
             """
-            INSERT INTO conversations (session_id, timestamp, role, content, tool_calls_json, tool_call_id)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO conversations (
+                session_id,
+                timestamp,
+                role,
+                content,
+                tool_calls_json,
+                tool_call_id,
+                input_tokens,
+                output_tokens,
+                total_tokens
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (session_id, now, role, content, tool_calls_json, tool_call_id),
+            (session_id, now, role, content, tool_calls_json, tool_call_id, input_tokens, output_tokens, total_tokens),
         )
         await conn.commit()
 
@@ -345,7 +373,18 @@ class DatabaseService:
         """List recent chat sessions."""
         conn = await self._get_conn()
         cursor = await conn.execute(
-            "SELECT * FROM sessions ORDER BY last_active DESC LIMIT ?",
+            """
+            SELECT
+                s.*,
+                COALESCE(SUM(c.input_tokens), 0) AS input_tokens,
+                COALESCE(SUM(c.output_tokens), 0) AS output_tokens,
+                COALESCE(SUM(c.total_tokens), 0) AS total_tokens
+            FROM sessions s
+            LEFT JOIN conversations c ON c.session_id = s.session_id
+            GROUP BY s.session_id
+            ORDER BY s.last_active DESC
+            LIMIT ?
+            """,
             (limit,),
         )
         rows = await cursor.fetchall()
@@ -557,6 +596,9 @@ class DatabaseService:
                     "duration_seconds": end_content.get("duration_seconds"),
                     "tool_count": end_content.get("tool_count", 0),
                     "blocked_count": end_content.get("blocked_count", 0),
+                    "input_tokens": end_content.get("input_tokens"),
+                    "output_tokens": end_content.get("output_tokens"),
+                    "total_tokens": end_content.get("total_tokens"),
                     "incident_count": ((end_content.get("outcome") or {}).get("incident_count", 0)),
                     "resolved": ((end_content.get("outcome") or {}).get("resolved", False)),
                     "escalated": ((end_content.get("outcome") or {}).get("escalated", False)),

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -79,6 +79,18 @@ _WATCH_ROUTING_MAX_LLM_CALLS = 4
 _WATCH_ROUTING_LLM_TIMEOUT_SECONDS = 6.0
 
 
+def _extract_token_usage_from_event(event) -> tuple[int | None, int | None, int | None]:
+    """Extract provider-reported token counts from a watch-cycle event."""
+    usage = getattr(event, "usage_metadata", None)
+    if not usage:
+        return None, None, None
+    return (
+        getattr(usage, "prompt_token_count", None),
+        getattr(usage, "candidates_token_count", None),
+        getattr(usage, "total_token_count", None),
+    )
+
+
 def _validated_live_watch_updates(
     payload: dict,
     watch_config: WatchConfig,
@@ -335,6 +347,9 @@ async def start_watch() -> None:
             "total_errors": "0",
             "total_resolved": "0",
             "total_escalated": "0",
+            "total_input_tokens": "0",
+            "total_output_tokens": "0",
+            "total_tokens": "0",
             "playbook_deterministic_match": "0",
             "playbook_semantic_match": "0",
             "playbook_generic_fallback": "0",
@@ -502,6 +517,9 @@ async def start_watch() -> None:
             cycle_start_time = datetime.now(UTC)
             await emitter.emit_cycle_start(cycle_count, session.id)
             cycle_tool_count = 0
+            cycle_input_tokens: int | None = None
+            cycle_output_tokens: int | None = None
+            cycle_total_tokens: int | None = None
             response_text = ""
             try:
                 await emitter.emit_phase(
@@ -516,6 +534,9 @@ async def start_watch() -> None:
                     blocked_count,
                     cycle_signatures,
                     remote_tool_count,
+                    cycle_input_tokens,
+                    cycle_output_tokens,
+                    cycle_total_tokens,
                 ) = await asyncio.wait_for(
                     _run_cycle(
                         runner,
@@ -533,7 +554,14 @@ async def start_watch() -> None:
                 )
                 last_cycle_error = None
                 if response_text:
-                    await db.save_message(session_id=session.id, role="assistant", content=response_text)
+                    await db.save_message(
+                        session_id=session.id,
+                        role="assistant",
+                        content=response_text,
+                        input_tokens=cycle_input_tokens,
+                        output_tokens=cycle_output_tokens,
+                        total_tokens=cycle_total_tokens,
+                    )
                     await db.set_watch_state("last_response", response_text[:500])
                     logger.info("Cycle %d:\n%s", cycle_count, response_text)
 
@@ -561,6 +589,9 @@ async def start_watch() -> None:
                 )
                 outcome["playbook_selection"] = playbook_path_counts
                 outcome["remote_tool_count"] = remote_tool_count
+                outcome["input_tokens"] = cycle_input_tokens
+                outcome["output_tokens"] = cycle_output_tokens
+                outcome["total_tokens"] = cycle_total_tokens
                 issue_key = dominant_incident_key(incidents)
                 if issue_key:
                     outcome["incident_fingerprint"] = issue_key
@@ -590,6 +621,9 @@ async def start_watch() -> None:
                 await _dispatch(notifier, "watch.error", f"Watch cycle {cycle_count} timed out.")
                 blocked_count = 0
                 cycle_tool_count = 0
+                cycle_input_tokens = None
+                cycle_output_tokens = None
+                cycle_total_tokens = None
                 outcome = build_cycle_outcome(
                     incidents,
                     {},
@@ -598,6 +632,9 @@ async def start_watch() -> None:
                     cycle_status="error",
                 )
                 outcome["playbook_selection"] = playbook_path_counts
+                outcome["input_tokens"] = cycle_input_tokens
+                outcome["output_tokens"] = cycle_output_tokens
+                outcome["total_tokens"] = cycle_total_tokens
             except Exception as e:
                 last_cycle_error = f"{type(e).__name__}: {e}"
                 logger.error("Cycle %d failed: %s", cycle_count, e, exc_info=True)
@@ -605,6 +642,9 @@ async def start_watch() -> None:
                 await _dispatch(notifier, "watch.error", f"Watch cycle {cycle_count} failed.")
                 blocked_count = 0
                 cycle_tool_count = 0
+                cycle_input_tokens = None
+                cycle_output_tokens = None
+                cycle_total_tokens = None
                 outcome = build_cycle_outcome(
                     incidents,
                     {},
@@ -613,6 +653,9 @@ async def start_watch() -> None:
                     cycle_status="error",
                 )
                 outcome["playbook_selection"] = playbook_path_counts
+                outcome["input_tokens"] = cycle_input_tokens
+                outcome["output_tokens"] = cycle_output_tokens
+                outcome["total_tokens"] = cycle_total_tokens
 
             cycle_duration = (datetime.now(UTC) - cycle_start_time).total_seconds()
             cycle_status = "ok" if last_cycle_error is None else "error"
@@ -624,6 +667,9 @@ async def start_watch() -> None:
                 tool_count=cycle_tool_count,
                 blocked_count=blocked_count,
                 outcome=outcome,
+                input_tokens=cycle_input_tokens,
+                output_tokens=cycle_output_tokens,
+                total_tokens=cycle_total_tokens,
             )
             await _persist_watch_metrics(db, outcome)
             await _dispatch_outcome_notifications(db, notifier, cycle_count, outcome)
@@ -714,17 +760,29 @@ async def _run_cycle(
     max_tool_calls: int = 0,
     max_identical_actions: int = 0,
     max_remote_actions: int = 0,
-) -> tuple[str, int, int, list[str], int]:
+) -> tuple[str, int, int, list[str], int, int | None, int | None, int | None]:
     """Inject a prompt and collect the agent's response.
 
     Returns:
-        A tuple of (response_text, tool_call_count, blocked_count, cooldown_signatures, remote_tool_count).
+        A tuple of (
+            response_text,
+            tool_call_count,
+            blocked_count,
+            cooldown_signatures,
+            remote_tool_count,
+            input_tokens,
+            output_tokens,
+            total_tokens,
+        ).
     """
     message = types.Content(parts=[types.Part(text=prompt)])
     response_parts: list[str] = []
     tool_count = 0
     blocked_count = 0
     remote_tool_count = 0
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
     signature_counts: dict[str, int] = defaultdict(int)
     cooldown_signatures: list[str] = []
 
@@ -733,6 +791,14 @@ async def _run_cycle(
         session_id=session.id,
         new_message=message,
     ):
+        event_input_tokens, event_output_tokens, event_total_tokens = _extract_token_usage_from_event(event)
+        if event_input_tokens is not None:
+            input_tokens = event_input_tokens
+        if event_output_tokens is not None:
+            output_tokens = event_output_tokens
+        if event_total_tokens is not None:
+            total_tokens = event_total_tokens
+
         if not event.content or not event.content.parts:
             continue
         for part in event.content.parts:
@@ -754,15 +820,42 @@ async def _run_cycle(
                     response_parts.append(
                         f"\n[Cycle stopped: repeated action signature exceeded limit ({max_identical_actions})]"
                     )
-                    return "".join(response_parts), tool_count, blocked_count, cooldown_signatures, remote_tool_count
+                    return (
+                        "".join(response_parts),
+                        tool_count,
+                        blocked_count,
+                        cooldown_signatures,
+                        remote_tool_count,
+                        input_tokens,
+                        output_tokens,
+                        total_tokens,
+                    )
                 if max_remote_actions and remote_tool_count > max_remote_actions:
                     blocked_count += 1
                     response_parts.append(f"\n[Cycle stopped: reached {max_remote_actions} remote action limit]")
-                    return "".join(response_parts), tool_count, blocked_count, cooldown_signatures, remote_tool_count
+                    return (
+                        "".join(response_parts),
+                        tool_count,
+                        blocked_count,
+                        cooldown_signatures,
+                        remote_tool_count,
+                        input_tokens,
+                        output_tokens,
+                        total_tokens,
+                    )
                 if max_tool_calls and tool_count >= max_tool_calls:
                     logger.warning("Cycle %d hit tool call limit (%d)", cycle, max_tool_calls)
                     response_parts.append(f"\n[Cycle stopped: reached {max_tool_calls} tool call limit]")
-                    return "".join(response_parts), tool_count, blocked_count, cooldown_signatures, remote_tool_count
+                    return (
+                        "".join(response_parts),
+                        tool_count,
+                        blocked_count,
+                        cooldown_signatures,
+                        remote_tool_count,
+                        input_tokens,
+                        output_tokens,
+                        total_tokens,
+                    )
             elif part.function_response and emitter:
                 output = str(part.function_response.response) if part.function_response.response else ""
                 if "[BLOCKED]" in output or "[DENIED]" in output:
@@ -773,7 +866,16 @@ async def _run_cycle(
                 if emitter:
                     await emitter.emit_token(cycle, part.text)
 
-    return "".join(response_parts), tool_count, blocked_count, cooldown_signatures, remote_tool_count
+    return (
+        "".join(response_parts),
+        tool_count,
+        blocked_count,
+        cooldown_signatures,
+        remote_tool_count,
+        input_tokens,
+        output_tokens,
+        total_tokens,
+    )
 
 
 def _prune_session_history(runner: InMemoryRunner, session, max_events: int) -> int:
@@ -819,6 +921,9 @@ async def _persist_watch_metrics(db: DatabaseService, outcome: dict) -> None:
     total_errors = int(await db.get_watch_state("total_errors") or "0")
     total_resolved = int(await db.get_watch_state("total_resolved") or "0")
     total_escalated = int(await db.get_watch_state("total_escalated") or "0")
+    total_input_tokens = int(await db.get_watch_state("total_input_tokens") or "0")
+    total_output_tokens = int(await db.get_watch_state("total_output_tokens") or "0")
+    total_tokens = int(await db.get_watch_state("total_tokens") or "0")
     total_playbook_deterministic = int(await db.get_watch_state("playbook_deterministic_match") or "0")
     total_playbook_semantic = int(await db.get_watch_state("playbook_semantic_match") or "0")
     total_playbook_generic = int(await db.get_watch_state("playbook_generic_fallback") or "0")
@@ -829,6 +934,9 @@ async def _persist_watch_metrics(db: DatabaseService, outcome: dict) -> None:
         "total_errors": total_errors + (1 if outcome.get("cycle_status") != "ok" else 0),
         "total_resolved": total_resolved + (1 if outcome.get("resolved") else 0),
         "total_escalated": total_escalated + (1 if outcome.get("escalated") else 0),
+        "total_input_tokens": total_input_tokens + int(outcome.get("input_tokens") or 0),
+        "total_output_tokens": total_output_tokens + int(outcome.get("output_tokens") or 0),
+        "total_tokens": total_tokens + int(outcome.get("total_tokens") or 0),
         "playbook_deterministic_match": total_playbook_deterministic
         + int(playbook_selection.get("deterministic_single", 0))
         + int(playbook_selection.get("tie_break", 0)),

--- a/src/squire/watch_emitter.py
+++ b/src/squire/watch_emitter.py
@@ -35,6 +35,9 @@ class WatchEventEmitter:
         tool_count: int,
         blocked_count: int = 0,
         outcome: dict | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        total_tokens: int | None = None,
     ) -> None:
         await self._emit(
             cycle,
@@ -46,6 +49,9 @@ class WatchEventEmitter:
                     "tool_count": tool_count,
                     "blocked_count": blocked_count,
                     "outcome": outcome or {},
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": total_tokens,
                 }
             ),
         )

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -1,0 +1,32 @@
+"""Tests for chat token usage extraction."""
+
+from types import SimpleNamespace
+
+from google.genai import types
+
+from squire.api.routers.chat import _extract_token_usage_from_event
+
+
+def test_extract_token_usage_from_event_with_usage_metadata():
+    usage = types.GenerateContentResponseUsageMetadata(
+        prompt_token_count=31,
+        candidates_token_count=19,
+        total_token_count=50,
+    )
+    event = SimpleNamespace(usage_metadata=usage)
+
+    input_tokens, output_tokens, total_tokens = _extract_token_usage_from_event(event)
+
+    assert input_tokens == 31
+    assert output_tokens == 19
+    assert total_tokens == 50
+
+
+def test_extract_token_usage_from_event_without_usage_metadata():
+    event = SimpleNamespace(usage_metadata=None)
+
+    input_tokens, output_tokens, total_tokens = _extract_token_usage_from_event(event)
+
+    assert input_tokens is None
+    assert output_tokens is None
+    assert total_tokens is None

--- a/tests/test_api_watch.py
+++ b/tests/test_api_watch.py
@@ -21,9 +21,15 @@ async def test_watch_status(db):
 
     await db.set_watch_state("status", "running")
     await db.set_watch_state("cycle", "5")
+    await db.set_watch_state("total_input_tokens", "120")
+    await db.set_watch_state("total_output_tokens", "75")
+    await db.set_watch_state("total_tokens", "195")
     result = await watch_status(db=db)
     assert result.status == "running"
     assert result.cycle == "5"
+    assert result.total_input_tokens == "120"
+    assert result.total_output_tokens == "75"
+    assert result.total_tokens == "195"
 
 
 @pytest.mark.asyncio
@@ -59,11 +65,27 @@ async def test_watch_cycles(db):
     from squire.api.routers.watch import watch_cycles
 
     await db.insert_watch_event(1, "cycle_start", json.dumps({"session_id": "s1"}))
-    await db.insert_watch_event(1, "cycle_end", json.dumps({"status": "ok", "duration_seconds": 5, "tool_count": 2}))
+    await db.insert_watch_event(
+        1,
+        "cycle_end",
+        json.dumps(
+            {
+                "status": "ok",
+                "duration_seconds": 5,
+                "tool_count": 2,
+                "input_tokens": 50,
+                "output_tokens": 20,
+                "total_tokens": 70,
+            }
+        ),
+    )
 
     result = await watch_cycles(page=1, per_page=10, db=db)
     assert len(result) == 1
     assert result[0]["cycle"] == 1
+    assert result[0]["input_tokens"] == 50
+    assert result[0]["output_tokens"] == 20
+    assert result[0]["total_tokens"] == 70
 
 
 @pytest.mark.asyncio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -27,12 +27,22 @@ async def test_session_lifecycle(db):
 async def test_message_persistence(db):
     await db.create_session("sess-2")
     await db.save_message(session_id="sess-2", role="user", content="hello")
-    await db.save_message(session_id="sess-2", role="assistant", content="hi there")
+    await db.save_message(
+        session_id="sess-2",
+        role="assistant",
+        content="hi there",
+        input_tokens=12,
+        output_tokens=9,
+        total_tokens=21,
+    )
 
     msgs = await db.get_messages("sess-2")
     assert len(msgs) == 2
     assert msgs[0]["role"] == "user"
     assert msgs[1]["content"] == "hi there"
+    assert msgs[1]["input_tokens"] == 12
+    assert msgs[1]["output_tokens"] == 9
+    assert msgs[1]["total_tokens"] == 21
 
 
 @pytest.mark.asyncio
@@ -99,3 +109,46 @@ async def test_delete_all_sessions(db):
 async def test_delete_all_sessions_empty(db):
     count = await db.delete_all_sessions()
     assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_includes_token_totals(db):
+    await db.create_session("sess-tokens")
+    await db.save_message(
+        session_id="sess-tokens",
+        role="assistant",
+        content="first",
+        input_tokens=10,
+        output_tokens=8,
+        total_tokens=18,
+    )
+    await db.save_message(
+        session_id="sess-tokens",
+        role="assistant",
+        content="second",
+        input_tokens=5,
+        output_tokens=7,
+        total_tokens=12,
+    )
+
+    sessions = await db.list_sessions()
+    session = next(s for s in sessions if s["session_id"] == "sess-tokens")
+    assert session["input_tokens"] == 15
+    assert session["output_tokens"] == 15
+    assert session["total_tokens"] == 30
+
+
+@pytest.mark.asyncio
+async def test_watch_cycles_include_token_counts(db):
+    await db.insert_watch_event(1, "cycle_start", '{"session_id":"sess-w"}')
+    await db.insert_watch_event(
+        1,
+        "cycle_end",
+        '{"status":"ok","duration_seconds":2.5,"tool_count":1,"input_tokens":42,"output_tokens":17,"total_tokens":59}',
+    )
+
+    cycles = await db.get_watch_cycles(page=1, per_page=10)
+    assert len(cycles) == 1
+    assert cycles[0]["input_tokens"] == 42
+    assert cycles[0]["output_tokens"] == 17
+    assert cycles[0]["total_tokens"] == 59

--- a/tests/test_watch_tokens.py
+++ b/tests/test_watch_tokens.py
@@ -1,0 +1,62 @@
+"""Tests for watch mode token usage tracking."""
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from google.genai import types
+
+from squire.database.service import DatabaseService
+from squire.watch import _extract_token_usage_from_event, _persist_watch_metrics
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    db = DatabaseService(tmp_path / "test.db")
+    yield db
+    await db.close()
+
+
+def test_extract_token_usage_from_event_with_usage_metadata():
+    usage = types.GenerateContentResponseUsageMetadata(
+        prompt_token_count=14,
+        candidates_token_count=6,
+        total_token_count=20,
+    )
+    event = SimpleNamespace(usage_metadata=usage)
+
+    input_tokens, output_tokens, total_tokens = _extract_token_usage_from_event(event)
+
+    assert input_tokens == 14
+    assert output_tokens == 6
+    assert total_tokens == 20
+
+
+@pytest.mark.asyncio
+async def test_persist_watch_metrics_accumulates_token_totals(db):
+    await _persist_watch_metrics(
+        db,
+        {
+            "tool_count": 1,
+            "blocked_count": 0,
+            "cycle_status": "ok",
+            "input_tokens": 40,
+            "output_tokens": 11,
+            "total_tokens": 51,
+        },
+    )
+    await _persist_watch_metrics(
+        db,
+        {
+            "tool_count": 0,
+            "blocked_count": 1,
+            "cycle_status": "error",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+        },
+    )
+
+    assert await db.get_watch_state("total_input_tokens") == "50"
+    assert await db.get_watch_state("total_output_tokens") == "16"
+    assert await db.get_watch_state("total_tokens") == "66"

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -158,6 +158,9 @@ function ChatPageInner() {
             id: nextId(),
             role: m.role as "user" | "assistant",
             content: m.content!,
+            inputTokens: m.input_tokens,
+            outputTokens: m.output_tokens,
+            totalTokens: m.total_tokens,
           }));
         setMessages(prior);
       })

--- a/web/src/app/sessions/page.tsx
+++ b/web/src/app/sessions/page.tsx
@@ -71,6 +71,9 @@ export default function SessionsPage() {
               <TableHead>Created</TableHead>
               <TableHead>Last Active</TableHead>
               <TableHead>Preview</TableHead>
+              <TableHead className="text-right">Input Tokens</TableHead>
+              <TableHead className="text-right">Output Tokens</TableHead>
+              <TableHead className="text-right">Total Tokens</TableHead>
               <TableHead />
             </TableRow>
           </TableHeader>
@@ -89,6 +92,9 @@ export default function SessionsPage() {
                 <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
                   {s.preview || "-"}
                 </TableCell>
+                <TableCell className="text-sm text-right">{s.input_tokens.toLocaleString()}</TableCell>
+                <TableCell className="text-sm text-right">{s.output_tokens.toLocaleString()}</TableCell>
+                <TableCell className="text-sm text-right">{s.total_tokens.toLocaleString()}</TableCell>
                 <TableCell className="flex gap-1">
                   <Link href={`/chat?session=${s.session_id}`}>
                     <Button variant="ghost" size="icon" title="Resume">

--- a/web/src/components/chat/message-bubble.tsx
+++ b/web/src/components/chat/message-bubble.tsx
@@ -58,7 +58,7 @@ interface MessageBubbleProps {
 }
 
 export function MessageBubble({ message }: MessageBubbleProps) {
-  const { role, content, toolName, isStreaming } = message;
+  const { role, content, toolName, isStreaming, inputTokens, outputTokens, totalTokens } = message;
 
   const cleanContent =
     role === "assistant" ? stripRawToolCalls(stripSkillMarkers(content)) : content;
@@ -126,28 +126,35 @@ export function MessageBubble({ message }: MessageBubbleProps) {
         {isUser ? (
           <span className="whitespace-pre-wrap">{content}</span>
         ) : (
-          <div className="chat-prose">
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                code({ className, children, ...props }) {
-                  const isBlock = className?.includes("language-");
-                  if (isBlock) {
-                    return <CodeBlock className={className}>{children}</CodeBlock>;
-                  }
-                  return (
-                    <code {...props}>
-                      {children}
-                    </code>
-                  );
-                },
-                pre({ children }) {
-                  return <>{children}</>;
-                },
-              }}
-            >
-              {cleanContent}
-            </ReactMarkdown>
+          <div className="space-y-2">
+            <div className="chat-prose">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  code({ className, children, ...props }) {
+                    const isBlock = className?.includes("language-");
+                    if (isBlock) {
+                      return <CodeBlock className={className}>{children}</CodeBlock>;
+                    }
+                    return (
+                      <code {...props}>
+                        {children}
+                      </code>
+                    );
+                  },
+                  pre({ children }) {
+                    return <>{children}</>;
+                  },
+                }}
+              >
+                {cleanContent}
+              </ReactMarkdown>
+            </div>
+            {(inputTokens !== undefined || outputTokens !== undefined || totalTokens !== undefined) && (
+              <div className="text-[11px] text-muted-foreground">
+                tokens in/out/total: {inputTokens ?? "—"} / {outputTokens ?? "—"} / {totalTokens ?? "—"}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/web/src/components/chat/message-list.tsx
+++ b/web/src/components/chat/message-list.tsx
@@ -13,6 +13,9 @@ export interface ChatMessage {
   content: string;
   toolName?: string;
   isStreaming?: boolean;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  totalTokens?: number | null;
 }
 
 export type AgentState = "thinking" | "tool" | "streaming" | null;

--- a/web/src/components/watch/watch-cycle-history.tsx
+++ b/web/src/components/watch/watch-cycle-history.tsx
@@ -188,6 +188,9 @@ export function WatchCycleHistory() {
                 </span>
                 <span className="text-muted-foreground text-xs">{cycle.tool_count} tools</span>
                 <span className="text-muted-foreground text-xs">{cycle.blocked_count || 0} blocked</span>
+                <span className="text-muted-foreground text-xs">
+                  {cycle.input_tokens ?? "—"}/{cycle.output_tokens ?? "—"}/{cycle.total_tokens ?? "—"} tokens
+                </span>
                 <span className="text-muted-foreground text-xs">{cycle.incident_count || 0} incidents</span>
                 <Badge variant={statusColor} className="text-xs">{cycle.status}</Badge>
                 {cycle.resolved && <Badge variant="secondary" className="text-xs">resolved</Badge>}

--- a/web/src/components/watch/watch-stats-card.tsx
+++ b/web/src/components/watch/watch-stats-card.tsx
@@ -22,6 +22,9 @@ export function WatchStatsCard({ status }: WatchStatsCardProps) {
   const totalBlocked = Number(status?.total_blocked || 0);
   const totalResolved = Number(status?.total_resolved || 0);
   const totalEscalated = Number(status?.total_escalated || 0);
+  const totalInputTokens = Number(status?.total_input_tokens || 0);
+  const totalOutputTokens = Number(status?.total_output_tokens || 0);
+  const totalTokens = Number(status?.total_tokens || 0);
 
   return (
     <Card>
@@ -59,6 +62,18 @@ export function WatchStatsCard({ status }: WatchStatsCardProps) {
           <div>
             <span className="text-muted-foreground">Escalated</span>
             <p>{totalEscalated}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Input Tokens</span>
+            <p>{totalInputTokens.toLocaleString()}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Output Tokens</span>
+            <p>{totalOutputTokens.toLocaleString()}</p>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Total Tokens</span>
+            <p>{totalTokens.toLocaleString()}</p>
           </div>
         </div>
       </CardContent>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -64,6 +64,9 @@ export interface SessionInfo {
   created_at: string;
   last_active: string;
   preview: string;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
 }
 
 export interface MessageInfo {
@@ -74,6 +77,9 @@ export interface MessageInfo {
   content?: string;
   tool_calls_json?: string;
   tool_call_id?: string;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  total_tokens?: number | null;
 }
 
 export interface AlertRule {
@@ -154,6 +160,9 @@ export interface WatchStatus {
   total_errors?: string | null;
   total_resolved?: string | null;
   total_escalated?: string | null;
+  total_input_tokens?: string | null;
+  total_output_tokens?: string | null;
+  total_tokens?: string | null;
   last_outcome?: string | null;
 }
 
@@ -175,6 +184,9 @@ export interface WatchCycle {
   duration_seconds: number | null;
   tool_count: number;
   blocked_count?: number;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  total_tokens?: number | null;
   incident_count?: number;
   resolved?: boolean;
   escalated?: boolean;


### PR DESCRIPTION
## Problem

Squire did not capture or expose provider-reported token usage, so operators had no visibility into token consumption per response, per session, or per watch cycle.

## Context

Issue #103 requests token usage tracking across chat responses, chat sessions, watch sessions, and watch cycles. Without this telemetry, usage/cost analysis and operational monitoring are incomplete.

Closes #103.

## Solution

Added end-to-end token usage tracking using provider-reported metadata only. Chat and watch flows now extract usage from ADK events, persist token counts on assistant messages, aggregate totals at session/watch-session level, and include cycle-level token metrics in watch cycle summaries. API schemas and frontend types were updated, and UI surfaces now display token usage in sessions, chat history, watch stats, and watch cycle history.

## Testing

### Unit tests
- Added `tests/test_api_chat.py` to validate chat usage extraction behavior.
- Added `tests/test_watch_tokens.py` to validate watch usage extraction and cumulative watch token metrics.
- Updated `tests/test_database.py` for token persistence, session aggregates, and watch-cycle token summary fields.
- Updated `tests/test_api_watch.py` for watch status/cycle token fields.

### Integration tests
- Ran full repository test suite.

### Test results
- `make lint` -> pass
- `make test` -> pass (`423 passed, 3 warnings`)

## Reviewer Validation

1. Run `make lint` and `make test`.
2. Open Session History and confirm input/output/total token columns populate per session.
3. Open a chat session from history and confirm assistant messages render token in/out/total metadata.
4. Open Watch page and confirm session token totals appear in stats and per-cycle token counts appear in cycle history.
5. Verify existing DB files upgrade automatically by running app against a pre-change DB and confirming no migration errors.

## TODOs / Follow-Ups

None — this PR is self-contained.

Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)