### PR TITLE
feat: agent host hints, URL-state UI persistence, chat skill loop fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agent instructions:** Shared guidance for host-scoped tools (default `host`, which host tool output describes, consistency across Docker calls, daemon vs remote confusion, anti-retry after repeated identical failures) on the root Squire agent, Monitor, Container, and router; Container agent now includes `docker_ps` for discovery without a Monitor handoff (also on Monitor for read-only observation).
+- **Docker errors:** When Docker fails on `local` (missing CLI, unreachable daemon, or socket/connect errors), Docker tool error text appends a short hint about passing `host=` consistently and lists other configured hosts when available.
+- **Sessions filter by watch run:** `GET /api/sessions` now accepts an optional `watch_id` query param that joins through `watch_sessions` to restrict results to chat sessions initiated by that watch.
+- **Watch Explorer → Sessions handoff:** Watch Explorer now has an "Open in Sessions" button on the selected run that navigates to `/sessions?watch_id=<id>` with a filter chip and clear button on the Sessions page.
+- **Shared URL-state hook:** New `useUrlState` / `useUrlStateSet` / `useUrlStateNumber` hooks in `web/src/hooks/use-url-state.ts` that sync component state with URL search params, modeled after the existing Watch Explorer pattern.
+
+### Changed
+
+- **Multi-agent tests:** Sub-agent tool uniqueness is asserted per specialist; the same tool may appear on more than one sub-agent when intentionally shared.
+- **Chat model dropdown:** Chat header dropdown now auto-sizes to fit the longest available model name (with min/max caps) instead of a hardcoded 20rem width, so long model ids no longer clip and the layout stays stable across selections.
+- **UI state preservation:** Config tabs, Notifications tabs, Watch tabs, Tools filters/sort/expanded rows, and Activity filters are now backed by URL search params and survive navigation away and back. The sidebar also remembers the last full URL visited within each top-level section (via sessionStorage), so clicking `Config` after visiting another page returns the user to the same tab (e.g. Guardrails) they left.
+
+### Fixed
+
+- **Chat skill loop:** WebSocket skill auto-continue no longer runs up to 15 text-only turns when the model stops calling tools; `[SKILL COMPLETE]` is honored from accumulated assistant text even on a final text-only turn.
+- **Skill lookup:** `SkillService.get_skill` (and `delete_skill`) now resolve skills by directory slug, case-insensitive directory match, or declared frontmatter `name`, so chat `?skill=` and the API match how skills are listed; WebSocket skill query params are trimmed.
+- **Chat skills:** Session state built when the WebSocket opens (including `active_skill`) is now passed as ADK `state_delta` on each `run_async` call. The runner reloads chat sessions from SQLite, so in-memory `session.state.update` alone never applied skill instructions to the model.
+
 ## [0.17.0] — 2026-04-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Chat skill loop:** WebSocket skill auto-continue no longer runs up to 15 text-only turns when the model stops calling tools; `[SKILL COMPLETE]` is honored from accumulated assistant text even on a final text-only turn.
 - **Skill lookup:** `SkillService.get_skill` (and `delete_skill`) now resolve skills by directory slug, case-insensitive directory match, or declared frontmatter `name`, so chat `?skill=` and the API match how skills are listed; WebSocket skill query params are trimmed.
 - **Chat skills:** Session state built when the WebSocket opens (including `active_skill`) is now passed as ADK `state_delta` on each `run_async` call. The runner reloads chat sessions from SQLite, so in-memory `session.state.update` alone never applied skill instructions to the model.
+- **DB init race:** `DatabaseService._get_conn` now only flips its ready flag once schema creation has fully completed, so concurrent first callers can no longer observe a partially-built database (e.g. a missing `watch_approvals` table) — fixes a flaky `test_approval_denied` failure on Python 3.13 CI.
 
 ## [0.17.0] — 2026-04-12
 

--- a/src/squire/agents/container_agent.py
+++ b/src/squire/agents/container_agent.py
@@ -1,6 +1,6 @@
 """Container sub-agent — container lifecycle management.
 
-Tools: docker_logs, docker_compose, docker_container, docker_image, docker_cleanup,
+Tools: docker_ps, docker_logs, docker_compose, docker_container, docker_image, docker_cleanup,
 docker_volume, docker_network
 """
 

--- a/src/squire/api/routers/chat.py
+++ b/src/squire/api/routers/chat.py
@@ -199,6 +199,10 @@ async def chat_websocket(
     # Read skill name from query params directly (more reliable than
     # FastAPI parameter injection for WebSocket endpoints).
     skill_name = websocket.query_params.get("skill") or None
+    if skill_name is not None:
+        skill_name = skill_name.strip()
+        if not skill_name:
+            skill_name = None
 
     from ..app import get_latest_snapshot
 
@@ -380,6 +384,7 @@ async def chat_websocket(
                         app_config=app_config,
                         db=db,
                         notifier=notifier,
+                        session_state=session_state,
                         skill_active=skill_active,
                         stop_requested=stream_stop_event,
                     )
@@ -409,14 +414,22 @@ async def _stream_response(
     app_config,
     db,
     notifier,
+    session_state: dict[str, Any],
     skill_active: bool = False,
     stop_requested: asyncio.Event | None = None,
 ) -> None:
     """Run the agent and stream response tokens over WebSocket.
 
+    ``session_state`` is passed as ADK ``state_delta`` on each turn so snapshot,
+    guardrails, and ``active_skill`` are persisted with the user message. The
+    runner reloads sessions from SQLite; in-memory updates alone are not enough.
+
     When ``skill_active`` is set, the agent is automatically re-prompted
     after each turn so it works through the skill instructions without the
-    user having to send "continue" manually.
+    user having to send "continue" manually. Auto-continue stops when the
+    model responds without calling tools (nothing left to chain), when
+    ``[SKILL COMPLETE]`` appears, on verbatim repetition, or when turns are
+    exhausted.
     """
     max_turns = 15 if skill_active else 1
     current_text = user_text
@@ -436,6 +449,7 @@ async def _stream_response(
                 app_config=app_config,
                 db=db,
                 stop_requested=stop_requested,
+                state_delta=session_state,
             )
             if stop_requested is not None and stop_requested.is_set():
                 if not completion_sent:
@@ -466,13 +480,19 @@ async def _stream_response(
 
             all_response_text += "\n" + turn_response
 
-            # Stop if [SKILL COMPLETE] marker detected (only when tools were used).
-            if tools_used and _is_skill_complete(all_response_text):
+            # Stop if [SKILL COMPLETE] appears in accumulated assistant text for this skill run.
+            if _is_skill_complete(all_response_text):
                 break
 
             # Safety: stop if the agent repeated itself verbatim.
             if turn > 0 and turn_response == prev_response:
                 break
+
+            # Stop when this turn did not invoke tools — the follow-up prompt only
+            # exists to chain further tool work; text-only replies mean done or stuck.
+            if not tools_used:
+                break
+
             prev_response = turn_response
 
             current_text = "Continue executing the skill. Use your tools."
@@ -511,8 +531,12 @@ async def _run_single_turn(
     app_config,
     db,
     stop_requested: asyncio.Event | None = None,
+    state_delta: dict[str, Any] | None = None,
 ) -> tuple[str, bool, int | None, int | None, int | None]:
     """Run one agent turn and stream events over the WebSocket.
+
+    ``state_delta`` is merged into the durable ADK session with the user
+    message (see ``Runner.run_async``).
 
     Returns:
         A tuple of (response_text, tools_were_called, input_tokens, output_tokens, total_tokens).
@@ -531,6 +555,7 @@ async def _run_single_turn(
         session_id=session.id,
         new_message=message,
         run_config=run_config,
+        state_delta=state_delta,
     ):
         if stop_requested is not None and stop_requested.is_set():
             break

--- a/src/squire/api/routers/sessions.py
+++ b/src/squire/api/routers/sessions.py
@@ -14,10 +14,11 @@ logger = logging.getLogger(__name__)
 @router.get("", response_model=list[SessionInfo])
 async def list_sessions(
     limit: int = Query(20, ge=1, le=100),
+    watch_id: str | None = Query(None, description="Filter to sessions initiated by this watch run"),
     db=Depends(get_db),
 ):
-    """List recent chat sessions."""
-    rows = await db.list_sessions(limit=limit)
+    """List recent chat sessions, optionally filtered to a watch run."""
+    rows = await db.list_sessions(limit=limit, watch_id=watch_id)
     return [SessionInfo(**r) for r in rows]
 
 

--- a/src/squire/database/service.py
+++ b/src/squire/database/service.py
@@ -568,24 +568,47 @@ class DatabaseService:
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 
-    async def list_sessions(self, limit: int = 20) -> list[dict]:
-        """List recent chat sessions."""
+    async def list_sessions(self, limit: int = 20, watch_id: str | None = None) -> list[dict]:
+        """List recent chat sessions.
+
+        When ``watch_id`` is provided, restricts results to sessions that were
+        initiated by that watch run (joined through ``watch_sessions.adk_session_id``).
+        """
         conn = await self._get_conn()
-        cursor = await conn.execute(
-            """
-            SELECT
-                s.*,
-                COALESCE(SUM(c.input_tokens), 0) AS input_tokens,
-                COALESCE(SUM(c.output_tokens), 0) AS output_tokens,
-                COALESCE(SUM(c.total_tokens), 0) AS total_tokens
-            FROM sessions s
-            LEFT JOIN conversations c ON c.session_id = s.session_id
-            GROUP BY s.session_id
-            ORDER BY s.last_active DESC
-            LIMIT ?
-            """,
-            (limit,),
-        )
+        if watch_id:
+            cursor = await conn.execute(
+                """
+                SELECT
+                    s.*,
+                    COALESCE(SUM(c.input_tokens), 0) AS input_tokens,
+                    COALESCE(SUM(c.output_tokens), 0) AS output_tokens,
+                    COALESCE(SUM(c.total_tokens), 0) AS total_tokens
+                FROM sessions s
+                INNER JOIN watch_sessions ws ON ws.adk_session_id = s.session_id
+                LEFT JOIN conversations c ON c.session_id = s.session_id
+                WHERE ws.watch_id = ?
+                GROUP BY s.session_id
+                ORDER BY s.last_active DESC
+                LIMIT ?
+                """,
+                (watch_id, limit),
+            )
+        else:
+            cursor = await conn.execute(
+                """
+                SELECT
+                    s.*,
+                    COALESCE(SUM(c.input_tokens), 0) AS input_tokens,
+                    COALESCE(SUM(c.output_tokens), 0) AS output_tokens,
+                    COALESCE(SUM(c.total_tokens), 0) AS total_tokens
+                FROM sessions s
+                LEFT JOIN conversations c ON c.session_id = s.session_id
+                GROUP BY s.session_id
+                ORDER BY s.last_active DESC
+                LIMIT ?
+                """,
+                (limit,),
+            )
         rows = await cursor.fetchall()
         return [dict(row) for row in rows]
 

--- a/src/squire/database/service.py
+++ b/src/squire/database/service.py
@@ -296,24 +296,30 @@ class DatabaseService:
         self._db_path = db_path
         self._conn: aiosqlite.Connection | None = None
         self._conn_lock = asyncio.Lock()
+        self._initialized = False
 
     async def _get_conn(self) -> aiosqlite.Connection:
         """Open and return the database connection, creating schema on first call.
 
         Uses a lock to prevent concurrent coroutines from racing to
-        initialize the connection and schema simultaneously.
+        initialize the connection and schema simultaneously. The
+        ``_initialized`` flag is only flipped once schema creation has
+        fully completed, so concurrent callers that enter while schema is
+        being built wait on the lock instead of observing a half-built DB.
         """
-        if self._conn is not None:
-            return self._conn
+        if self._initialized:
+            return self._conn  # type: ignore[return-value]
         async with self._conn_lock:
-            if self._conn is None:
-                self._db_path.parent.mkdir(parents=True, exist_ok=True)
-                self._conn = await aiosqlite.connect(self._db_path)
-                self._conn.row_factory = aiosqlite.Row
-                await self._conn.execute("PRAGMA journal_mode=WAL")
-                await self._conn.execute("PRAGMA busy_timeout=5000")
-                await self._conn.execute("PRAGMA foreign_keys=ON")
-                await self._ensure_schema()
+            if self._initialized:
+                return self._conn  # type: ignore[return-value]
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = await aiosqlite.connect(self._db_path)
+            self._conn.row_factory = aiosqlite.Row
+            await self._conn.execute("PRAGMA journal_mode=WAL")
+            await self._conn.execute("PRAGMA busy_timeout=5000")
+            await self._conn.execute("PRAGMA foreign_keys=ON")
+            await self._ensure_schema()
+            self._initialized = True
         return self._conn
 
     async def _ensure_schema(self) -> None:
@@ -1770,3 +1776,4 @@ class DatabaseService:
         if self._conn is not None:
             await self._conn.close()
             self._conn = None
+        self._initialized = False

--- a/src/squire/instructions/container_agent.py
+++ b/src/squire/instructions/container_agent.py
@@ -8,6 +8,7 @@ from google.adk.agents.readonly_context import ReadonlyContext
 
 from .shared import (
     build_conversation_style,
+    build_host_scoped_tools_section,
     build_hosts_section,
     build_identity_section,
     build_risk_section,
@@ -28,6 +29,7 @@ You manage container lifecycle — viewing logs, managing containers, pulling
 images, cleaning up resources, and managing Docker Compose stacks.
 
 ## Tool Usage
+- Use `docker_ps` to list containers and confirm which `host` runs Docker before other actions.
 - Use `docker_logs` to view container logs for troubleshooting.
 - Use `docker_compose` to manage Compose stacks (start, stop, restart, pull, up, down).
 - Use `docker_container` to manage individual containers (inspect, start, stop, restart, remove).
@@ -41,6 +43,8 @@ images, cleaning up resources, and managing Docker Compose stacks.
   — the risk gate handles approval for dangerous actions via a UI dialog automatically.
 - NEVER fabricate command output. If a tool fails or is blocked, report the error
   and continue with any remaining work. Do NOT stop responding.
+
+{build_host_scoped_tools_section()}
 
 {build_risk_section(ctx)}
 {build_hosts_section(ctx)}\

--- a/src/squire/instructions/monitor_agent.py
+++ b/src/squire/instructions/monitor_agent.py
@@ -8,6 +8,7 @@ from google.adk.agents.readonly_context import ReadonlyContext
 
 from .shared import (
     build_conversation_style,
+    build_host_scoped_tools_section,
     build_hosts_section,
     build_identity_section,
     build_risk_section,
@@ -38,6 +39,8 @@ system health, resource usage, container status, logs, and configuration.
   For high-level summaries, use the snapshot in your context.
 - NEVER fabricate command output. If a tool fails or is blocked, report the error
   and continue with any remaining work. Do NOT stop responding.
+
+{build_host_scoped_tools_section()}
 
 {build_risk_section(ctx)}
 {build_hosts_section(ctx)}\

--- a/src/squire/instructions/router_agent.py
+++ b/src/squire/instructions/router_agent.py
@@ -30,6 +30,9 @@ do NOT transfer for simple interactions.
 
 You are one persona. When you transfer to a specialist, the user should not
 notice any change in voice or personality. The specialists share your identity.
+When routing container or host-scoped work, specialists must use the same `host`
+parameter across related tool calls for one task (default is `local` unless the user
+or prior discovery named another host).
 
 {build_hosts_section(ctx)}\
 {build_system_state_section(ctx)}

--- a/src/squire/instructions/shared.py
+++ b/src/squire/instructions/shared.py
@@ -103,6 +103,29 @@ You are executing a skill. Follow the instructions below.{host_line}
 - When you have completed all instructions, provide a summary, then emit [SKILL COMPLETE]."""
 
 
+def build_host_scoped_tools_section() -> str:
+    """Guidance for tools with a default host (Docker, SSH-backed execution)."""
+    return """\
+## Host-scoped tools (Docker and system commands)
+- Default `host` is `local` (where Squire runs). Omitting `host` does **not** mean "the host where
+  containers last appeared" or where a prior call succeeded — each tool defaults to `local` unless
+  you pass `host`.
+- **Which host does output describe?** Only the `host` you passed to **that** tool. If `docker_ps`
+  used `host="prod-apps-01"`, the container list is on **that** host — never tell the user a
+  container is "on local" or "on your Mac" unless you called with `host="local"` and it succeeded.
+- **Consistency:** If a call succeeds with `host="X"`, use the **same `X`** for every related
+  follow-up (e.g. `docker_ps` then `docker_image` then `docker_container`) unless the user names a
+  different host.
+- **Docker failures on `local`:** `Command not found: docker`, **cannot connect to the Docker
+  daemon**, or socket errors mean **this** `host` cannot run Docker commands right now — not that
+  containers seen in a **different** tool result "run locally." Do not mix hosts in your reasoning.
+  Prefer the same remote `host` where `docker_ps` succeeded, with explicit `host` on every follow-up,
+  instead of repeating the identical failing call on `local`.
+- **Anti-retry:** After **two** failures with the **same tool name and the same arguments**, stop
+  repeating. Tell the user what failed, then change approach (different `host`, confirm with
+  `docker_ps` on the intended host, or ask the user)."""
+
+
 def build_watch_mode_addendum(ctx: ReadonlyContext) -> str:
     """Return watch-mode instructions if watch_mode is active, else empty string."""
     if not ctx.state.get("watch_mode"):

--- a/src/squire/instructions/squire_agent.py
+++ b/src/squire/instructions/squire_agent.py
@@ -8,6 +8,7 @@ from google.adk.agents.readonly_context import ReadonlyContext
 
 from .shared import (
     build_conversation_style,
+    build_host_scoped_tools_section,
     build_hosts_section,
     build_identity_section,
     build_risk_section,
@@ -51,6 +52,8 @@ def build_instruction(ctx: ReadonlyContext) -> str:
   with any remaining work. Do NOT stop responding — always give the user a complete answer.
 - NEVER pretend you have run a command or tool. If a tool call fails, tell the user
   exactly what happened.
+
+{build_host_scoped_tools_section()}
 
 {build_risk_section(ctx)}
 {build_hosts_section(ctx)}\

--- a/src/squire/skills/service.py
+++ b/src/squire/skills/service.py
@@ -75,6 +75,55 @@ class SkillService:
     def __init__(self, skills_dir: Path) -> None:
         self._dir = skills_dir
 
+    def _resolve_skill_dir(self, name: str) -> Path | None:
+        """Find the directory containing SKILL.md for a user-supplied slug or declared name.
+
+        Lookup order:
+
+        1. Exact directory name under ``skills_dir`` (spec slug).
+        2. Case-insensitive directory name match (helps macOS / human-entered URLs).
+        3. Declared ``name`` in SKILL.md frontmatter (directory slug may differ).
+        """
+        key = name.strip()
+        if not key:
+            return None
+        if not self._dir.is_dir():
+            return None
+
+        key_cf = key.casefold()
+        exact_dir: Path | None = None
+        case_dir: Path | None = None
+        for child in sorted(self._dir.iterdir()):
+            if not child.is_dir():
+                continue
+            skill_file = child / "SKILL.md"
+            if not skill_file.is_file():
+                continue
+            if child.name == key:
+                exact_dir = child
+            elif child.name.casefold() == key_cf:
+                case_dir = child
+
+        # Prefer the real directory entry name (correct casing for parsing on
+        # case-insensitive volumes) over constructing ``_dir / key``.
+        if exact_dir is not None:
+            return exact_dir
+        if case_dir is not None:
+            return case_dir
+
+        for child in sorted(self._dir.iterdir()):
+            skill_file = child / "SKILL.md"
+            if not child.is_dir() or not skill_file.is_file():
+                continue
+            try:
+                skill = self._parse_skill_md(skill_file)
+            except Exception:
+                continue
+            if skill.name == key or skill.name.casefold() == key_cf:
+                return child
+
+        return None
+
     def list_skills(self, *, enabled_only: bool = False, trigger: str | None = None) -> list[Skill]:
         """List all skills, optionally filtered by enabled state and trigger type."""
         if not self._dir.is_dir():
@@ -97,12 +146,12 @@ class SkillService:
         return skills
 
     def get_skill(self, name: str) -> Skill | None:
-        """Get a skill by name. Returns None if not found."""
-        skill_file = self._dir / name / "SKILL.md"
-        if not skill_file.is_file():
+        """Get a skill by directory slug or declared frontmatter ``name``."""
+        skill_dir = self._resolve_skill_dir(name)
+        if skill_dir is None:
             return None
         try:
-            return self._parse_skill_md(skill_file)
+            return self._parse_skill_md(skill_dir / "SKILL.md")
         except Exception:
             return None
 
@@ -116,8 +165,8 @@ class SkillService:
 
     def delete_skill(self, name: str) -> bool:
         """Delete a skill directory. Returns True if it existed."""
-        skill_dir = self._dir / name
-        if not skill_dir.is_dir():
+        skill_dir = self._resolve_skill_dir(name)
+        if skill_dir is None or not skill_dir.is_dir():
             return False
         shutil.rmtree(skill_dir)
         return True

--- a/src/squire/tools/_docker_hints.py
+++ b/src/squire/tools/_docker_hints.py
@@ -1,0 +1,43 @@
+"""Helpers for Docker tool error messages."""
+
+
+def _is_local_docker_backend_failure(message: str) -> bool:
+    """True when local Docker CLI cannot run against an engine (missing CLI, down daemon, socket)."""
+    if "Command not found: docker" in message:
+        return True
+    lower = message.lower()
+    return (
+        "cannot connect to the docker daemon" in lower
+        or "is the docker daemon running" in lower
+        or "error during connect" in lower
+    )
+
+
+def append_local_docker_error_hint(execution_host: str, message: str) -> str:
+    """If Docker failed on local (missing CLI or unreachable daemon), append host-selection hint."""
+    if execution_host != "local":
+        return message
+    if not _is_local_docker_backend_failure(message):
+        return message
+    try:
+        from ._registry import get_registry
+
+        names = list(get_registry().host_names)
+    except Exception:
+        return (
+            f"{message}\nHint: This call used host=local. Start Docker locally or pass host= for a "
+            "remote machine where the engine runs."
+        )
+
+    remotes = [n for n in names if n != "local"]
+    if not remotes:
+        return (
+            f"{message}\nHint: This call used host=local. Start the Docker daemon (or fix context/"
+            "socket) on this machine before Docker tools will work here."
+        )
+
+    joined = ", ".join(remotes)
+    return (
+        f"{message}\nHint: This call used host=local. If containers were listed via docker_ps on "
+        f"another host, pass that same host= on pull/inspect/restart. Other configured hosts: {joined}."
+    )

--- a/src/squire/tools/docker_cleanup.py
+++ b/src/squire/tools/docker_cleanup.py
@@ -1,5 +1,6 @@
 """docker_cleanup tool — prune unused Docker resources."""
 
+from ._docker_hints import append_local_docker_error_hint
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -48,7 +49,7 @@ async def docker_cleanup(
     result = await backend.run(cmd, timeout=120.0)
 
     if result.returncode != 0:
-        return f"Error running 'docker {action}': {result.stderr}"
+        return append_local_docker_error_hint(host, f"Error running 'docker {action}': {result.stderr}")
 
     output = result.stdout.strip()
     return output if output else f"docker {action} completed successfully."

--- a/src/squire/tools/docker_compose.py
+++ b/src/squire/tools/docker_compose.py
@@ -1,5 +1,6 @@
 """docker_compose tool — read and manage Docker Compose stacks."""
 
+from ._docker_hints import append_local_docker_error_hint
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -82,7 +83,8 @@ async def docker_compose(
 
     if result.returncode != 0:
         path_info = f" (resolved path: {resolved_dir}/docker-compose.yml)" if resolved_dir else ""
-        return f"Error running 'docker compose {action}'{path_info}: {result.stderr}"
+        err = f"Error running 'docker compose {action}'{path_info}: {result.stderr}"
+        return append_local_docker_error_hint(resolved_host, err)
 
     output = result.stdout.strip()
     return output if output else f"docker compose {action} completed successfully."

--- a/src/squire/tools/docker_container.py
+++ b/src/squire/tools/docker_container.py
@@ -1,5 +1,6 @@
 """docker_container tool — manage individual container lifecycle."""
 
+from ._docker_hints import append_local_docker_error_hint
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -63,7 +64,8 @@ async def docker_container(
     result = await backend.run(cmd, timeout=60.0)
 
     if result.returncode != 0:
-        return f"Error running 'docker {action}' on '{container}': {result.stderr}"
+        err = f"Error running 'docker {action}' on '{container}': {result.stderr}"
+        return append_local_docker_error_hint(resolved_host, err)
 
     output = result.stdout.strip()
     return output if output else f"docker {action} completed successfully for '{container}'."

--- a/src/squire/tools/docker_image.py
+++ b/src/squire/tools/docker_image.py
@@ -1,5 +1,6 @@
 """docker_image tool — manage Docker images."""
 
+from ._docker_hints import append_local_docker_error_hint
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -54,7 +55,8 @@ async def docker_image(
     result = await backend.run(cmd, timeout=120.0)
 
     if result.returncode != 0:
-        return f"Error running 'docker image {action}'{f' for {image!r}' if image else ''}: {result.stderr}"
+        err = f"Error running 'docker image {action}'{f' for {image!r}' if image else ''}: {result.stderr}"
+        return append_local_docker_error_hint(host, err)
 
     output = result.stdout.strip()
     return output if output else f"docker image {action} completed successfully."

--- a/src/squire/tools/docker_logs.py
+++ b/src/squire/tools/docker_logs.py
@@ -1,5 +1,6 @@
 """docker_logs tool — read container logs."""
 
+from ._docker_hints import append_local_docker_error_hint
 from ._registry import get_registry
 
 RISK_LEVEL = 2  # Low
@@ -43,7 +44,8 @@ async def docker_logs(
     result = await backend.run(cmd, timeout=30.0)
 
     if result.returncode != 0:
-        return f"Error reading logs for '{container}': {result.stderr}"
+        err = f"Error reading logs for '{container}': {result.stderr}"
+        return append_local_docker_error_hint(resolved_host, err)
 
     output = result.stdout + result.stderr  # docker logs writes to stderr too
 

--- a/src/squire/tools/docker_network.py
+++ b/src/squire/tools/docker_network.py
@@ -1,5 +1,6 @@
 """docker_network tool — manage Docker networks."""
 
+from ._docker_hints import append_local_docker_error_hint
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -47,7 +48,8 @@ async def docker_network(
     result = await backend.run(cmd, timeout=30.0)
 
     if result.returncode != 0:
-        return f"Error running 'docker network {action}'{f' for {network!r}' if network else ''}: {result.stderr}"
+        err = f"Error running 'docker network {action}'{f' for {network!r}' if network else ''}: {result.stderr}"
+        return append_local_docker_error_hint(host, err)
 
     output = result.stdout.strip()
     return output if output else f"docker network {action} completed successfully."

--- a/src/squire/tools/docker_ps.py
+++ b/src/squire/tools/docker_ps.py
@@ -1,5 +1,6 @@
 """docker_ps tool — list Docker containers with status."""
 
+from ._docker_hints import append_local_docker_error_hint
 from ._registry import get_registry
 
 RISK_LEVEL = 1  # Info
@@ -33,6 +34,6 @@ async def docker_ps(all_containers: bool = True, format: str = "table", host: st
     result = await backend.run(cmd, timeout=30.0)
 
     if result.returncode != 0:
-        return f"Error running docker ps: {result.stderr}"
+        return append_local_docker_error_hint(host, f"Error running docker ps: {result.stderr}")
 
     return result.stdout.strip() if result.stdout.strip() else "No containers found."

--- a/src/squire/tools/docker_volume.py
+++ b/src/squire/tools/docker_volume.py
@@ -1,5 +1,6 @@
 """docker_volume tool — manage Docker volumes."""
 
+from ._docker_hints import append_local_docker_error_hint
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -47,7 +48,8 @@ async def docker_volume(
     result = await backend.run(cmd, timeout=30.0)
 
     if result.returncode != 0:
-        return f"Error running 'docker volume {action}'{f' for {volume!r}' if volume else ''}: {result.stderr}"
+        err = f"Error running 'docker volume {action}'{f' for {volume!r}' if volume else ''}: {result.stderr}"
+        return append_local_docker_error_hint(host, err)
 
     output = result.stdout.strip()
     return output if output else f"docker volume {action} completed successfully."

--- a/src/squire/tools/groups.py
+++ b/src/squire/tools/groups.py
@@ -36,6 +36,7 @@ MONITOR_RISK_LEVELS = {
 
 # Container agent — container lifecycle management
 CONTAINER_TOOLS = [
+    safe_tool(docker_ps),
     safe_tool(docker_logs),
     safe_tool(docker_compose),
     safe_tool(docker_container),

--- a/tests/test_agents/test_agent_tree.py
+++ b/tests/test_agents/test_agent_tree.py
@@ -56,19 +56,16 @@ class TestMultiAgentMode:
         for sa in agent.sub_agents:
             assert sa.before_tool_callback is not None, f"{sa.name} missing callback"
 
-    def test_no_duplicate_tools(self):
+    def test_each_sub_agent_has_unique_tools(self):
+        """Sub-agents must not wire the same tool twice; sharing across agents is allowed."""
         config = AppConfig(multi_agent=True)
         agent = create_squire_agent(
             app_config=config,
             risk_gate_factory=_make_factory(),
         )
-        all_tool_names = []
         for sa in agent.sub_agents:
-            for tool in sa.tools:
-                name = tool.__name__ if hasattr(tool, "__name__") else str(tool)
-                all_tool_names.append(name)
-
-        assert len(all_tool_names) == len(set(all_tool_names)), f"Duplicate tools: {all_tool_names}"
+            names = [tool.__name__ if hasattr(tool, "__name__") else str(tool) for tool in sa.tools]
+            assert len(names) == len(set(names)), f"{sa.name} has duplicate tools: {names}"
 
     def test_sub_agent_tool_counts(self):
         config = AppConfig(multi_agent=True)
@@ -77,7 +74,7 @@ class TestMultiAgentMode:
             risk_gate_factory=_make_factory(),
         )
         tool_counts = {sa.name: len(sa.tools) for sa in agent.sub_agents}
-        assert tool_counts == {"Monitor": 5, "Container": 7, "Admin": 2, "Notifier": 5}
+        assert tool_counts == {"Monitor": 5, "Container": 8, "Admin": 2, "Notifier": 5}
 
     def test_requires_risk_gate_factory(self):
         config = AppConfig(multi_agent=True)

--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -2,8 +2,9 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
+import pytest
 from google.genai import types
 
 from squire.api.routers.chat import (
@@ -12,6 +13,7 @@ from squire.api.routers.chat import (
     _maybe_backfill_history_from_db,
     _run_single_turn,
     _should_persist_assistant_turn,
+    _stream_response,
 )
 
 
@@ -60,6 +62,65 @@ def test_should_not_persist_empty_turn_without_tokens():
     assert _should_persist_assistant_turn("", None, None, None) is False
 
 
+@pytest.mark.asyncio
+async def test_stream_response_skill_stops_after_text_only_followup():
+    """Skill auto-continue must not loop when the model answers without tools."""
+    websocket = AsyncMock()
+    session = SimpleNamespace(id="sid")
+    app_config = SimpleNamespace(user_id="uid")
+
+    with patch("squire.api.routers.chat._run_single_turn", new_callable=AsyncMock) as m_turn:
+        m_turn.side_effect = [
+            ("Ran tools", True, None, None, None),
+            ("Finished (text only)", False, None, None, None),
+        ]
+        session_state = {"latest_snapshot": {}, "available_hosts": []}
+        await _stream_response(
+            websocket=websocket,
+            runner=SimpleNamespace(),
+            session=session,
+            agent=SimpleNamespace(name="Squire"),
+            user_text="run skill",
+            app_config=app_config,
+            db=None,
+            notifier=None,
+            session_state=session_state,
+            skill_active=True,
+            stop_requested=None,
+        )
+    assert m_turn.call_count == 2
+    assert m_turn.call_args_list[0].kwargs.get("state_delta") is session_state
+    assert m_turn.call_args_list[1].kwargs.get("state_delta") is session_state
+
+
+@pytest.mark.asyncio
+async def test_stream_response_skill_stops_on_marker_after_tool_turn():
+    """[SKILL COMPLETE] on a later text-only turn ends the loop (not gated on tools that turn)."""
+    websocket = AsyncMock()
+    session = SimpleNamespace(id="sid")
+    app_config = SimpleNamespace(user_id="uid")
+
+    with patch("squire.api.routers.chat._run_single_turn", new_callable=AsyncMock) as m_turn:
+        m_turn.side_effect = [
+            ("Step done", True, None, None, None),
+            ("All done\n[SKILL COMPLETE]", False, None, None, None),
+        ]
+        await _stream_response(
+            websocket=websocket,
+            runner=SimpleNamespace(),
+            session=session,
+            agent=SimpleNamespace(name="Squire"),
+            user_text="run skill",
+            app_config=app_config,
+            db=None,
+            notifier=None,
+            session_state={},
+            skill_active=True,
+            stop_requested=None,
+        )
+    assert m_turn.call_count == 2
+
+
 class _FakeRunner:
     def __init__(self, events):
         self._events = events
@@ -82,6 +143,37 @@ def _text_event(text: str, *, partial: bool, final: bool):
         content=SimpleNamespace(parts=[part]),
         is_final_response=lambda: final,
     )
+
+
+@pytest.mark.asyncio
+async def test_run_single_turn_forwards_state_delta_to_runner():
+    """Durable ADK session must receive state (e.g. active_skill) via run_async state_delta."""
+    captured: dict = {}
+
+    async def fake_run_async(**kwargs):
+        captured.update(kwargs)
+        if False:
+            yield None  # pragma: no cover
+
+    runner = SimpleNamespace(run_async=fake_run_async)
+    websocket = AsyncMock()
+    session = SimpleNamespace(id="sid")
+    app_config = SimpleNamespace(user_id="uid")
+    delta = {"active_skill": {"skill_name": "t", "hosts": ["all"], "instructions": "go"}}
+
+    await _run_single_turn(
+        websocket=websocket,
+        runner=runner,
+        session=session,
+        agent=SimpleNamespace(name="Squire"),
+        user_text="hi",
+        app_config=app_config,
+        db=None,
+        state_delta=delta,
+    )
+    assert captured.get("state_delta") is delta
+    assert captured.get("session_id") == "sid"
+    assert captured.get("user_id") == "uid"
 
 
 def test_run_single_turn_honors_stop_requested():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -170,6 +170,31 @@ async def test_list_sessions_includes_token_totals(db):
 
 
 @pytest.mark.asyncio
+async def test_list_sessions_filtered_by_watch_id(db):
+    # Two watch runs, each with one watch session bound to a distinct chat session.
+    await db.create_watch_run("watch-alpha")
+    await db.create_watch_run("watch-beta")
+    await db.create_session("sess-alpha", preview="alpha")
+    await db.create_session("sess-beta", preview="beta")
+    await db.create_session("sess-standalone", preview="unrelated")
+    await db.create_watch_session("wss-alpha", watch_id="watch-alpha", adk_session_id="sess-alpha")
+    await db.create_watch_session("wss-beta", watch_id="watch-beta", adk_session_id="sess-beta")
+
+    alpha_only = await db.list_sessions(watch_id="watch-alpha")
+    assert [s["session_id"] for s in alpha_only] == ["sess-alpha"]
+
+    beta_only = await db.list_sessions(watch_id="watch-beta")
+    assert [s["session_id"] for s in beta_only] == ["sess-beta"]
+
+    # Unknown watch id → empty results (does not fall through to unfiltered list).
+    assert await db.list_sessions(watch_id="watch-unknown") == []
+
+    # No filter → all three sessions visible.
+    unfiltered_ids = {s["session_id"] for s in await db.list_sessions()}
+    assert {"sess-alpha", "sess-beta", "sess-standalone"} <= unfiltered_ids
+
+
+@pytest.mark.asyncio
 async def test_watch_cycles_include_token_counts(db):
     await db.insert_watch_event(1, "cycle_start", '{"session_id":"sess-w"}')
     await db.insert_watch_event(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,10 @@
 """Tests for DatabaseService."""
 
+import asyncio
+
 import pytest
+
+from squire.database.service import DatabaseService
 
 
 @pytest.mark.asyncio
@@ -314,3 +318,52 @@ async def test_watch_hierarchy_queries(db):
     cycles = await db.list_watch_cycles_for_session("watch_h1", "wss_h1")
     assert len(cycles) == 1
     assert cycles[0]["cycle_id"] == "cyc_h1"
+
+
+@pytest.mark.asyncio
+async def test_late_caller_waits_for_schema_creation(tmp_path, monkeypatch):
+    """A caller that arrives mid-init must not see a half-built schema.
+
+    Regression: ``_get_conn`` used to flip its "connection is ready" state
+    *before* ``_ensure_schema`` completed. A second caller arriving while
+    schema was still being built hit the fast path (``self._conn is not None``,
+    no lock) and ran queries against tables that hadn't been created yet —
+    surfacing as a flaky ``no such table: watch_approvals`` error on slower
+    CI runners.
+
+    This test forces the race by slowing ``_ensure_schema`` with a sleep,
+    then starting a late caller after the lock has been taken so it reaches
+    ``_get_conn`` while schema creation is mid-flight.
+    """
+    db = DatabaseService(tmp_path / "race.db")
+    original_ensure_schema = db._ensure_schema
+
+    async def slow_ensure_schema() -> None:
+        await asyncio.sleep(0.2)
+        await original_ensure_schema()
+
+    monkeypatch.setattr(db, "_ensure_schema", slow_ensure_schema)
+
+    try:
+
+        async def late_caller() -> int:
+            await asyncio.sleep(0.05)
+            return await db.insert_watch_approval(
+                request_id="late",
+                tool_name="restart_container",
+                args=None,
+                risk_level=3,
+            )
+
+        early = asyncio.create_task(
+            db.insert_watch_approval(
+                request_id="early",
+                tool_name="restart_container",
+                args=None,
+                risk_level=3,
+            )
+        )
+        late = asyncio.create_task(late_caller())
+        await asyncio.gather(early, late)
+    finally:
+        await db.close()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -120,6 +120,32 @@ class TestParsing:
         assert skill.name == "dir-name"
         assert skill.instructions == "Do something."
 
+    def test_get_skill_by_frontmatter_when_directory_slug_differs(self, skill_service, tmp_path):
+        """Chat and API pass declared ``name``; directory may be a different slug."""
+        skill_dir = tmp_path / "folder-slug"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: logical-name\ndescription: test\n---\n\nRun the task.")
+        by_dir = skill_service.get_skill("folder-slug")
+        by_name = skill_service.get_skill("logical-name")
+        assert by_dir is not None and by_name is not None
+        assert by_dir.name == "logical-name"
+        assert by_name.instructions == "Run the task."
+
+    def test_delete_skill_resolves_declared_name(self, skill_service, tmp_path):
+        skill_dir = tmp_path / "folder-slug"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: logical-name\ndescription: x\n---\n\nBody.")
+        assert skill_service.delete_skill("logical-name") is True
+        assert not skill_dir.exists()
+
+    def test_get_skill_case_insensitive_directory(self, skill_service, tmp_path):
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\ndescription: x\n---\n\nHi.")
+        loaded = skill_service.get_skill("MY-SKILL")
+        assert loaded is not None
+        assert loaded.name == "my-skill"
+
     def test_multiline_instructions(self, skill_service):
         instructions = "Step 1: Check containers.\n\nStep 2: Restart if needed.\n\n- Item A\n- Item B"
         skill = _make_skill(instructions=instructions)

--- a/tests/test_tools/test_docker_hints.py
+++ b/tests/test_tools/test_docker_hints.py
@@ -1,0 +1,50 @@
+"""Tests for Docker tool error hint helper."""
+
+from unittest.mock import MagicMock, patch
+
+from squire.tools._docker_hints import append_local_docker_error_hint
+
+
+def test_append_hint_non_local_unchanged() -> None:
+    msg = "Error: Command not found: docker"
+    assert append_local_docker_error_hint("prod-apps-01", msg) == msg
+
+
+def test_append_hint_no_docker_pattern_unchanged() -> None:
+    msg = "Error running docker ps: permission denied"
+    assert append_local_docker_error_hint("local", msg) == msg
+
+
+def test_append_hint_local_only_cli_missing() -> None:
+    reg = MagicMock()
+    reg.host_names = ["local"]
+    with patch("squire.tools._registry.get_registry", return_value=reg):
+        msg = "Error: Command not found: docker"
+        out = append_local_docker_error_hint("local", msg)
+    assert msg in out
+    assert "host=local" in out
+    assert "daemon" in out.lower() or "socket" in out.lower()
+
+
+def test_append_hint_daemon_connection_lists_remotes() -> None:
+    reg = MagicMock()
+    reg.host_names = ["local", "prod-apps-01"]
+    with patch("squire.tools._registry.get_registry", return_value=reg):
+        msg = (
+            "Error: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n"
+        )
+        out = append_local_docker_error_hint("local", msg)
+    assert msg in out
+    assert "prod-apps-01" in out
+    assert "docker_ps" in out
+
+
+def test_append_hint_lists_remotes_cli_missing() -> None:
+    reg = MagicMock()
+    reg.host_names = ["local", "prod-apps-01", "lab-02"]
+    with patch("squire.tools._registry.get_registry", return_value=reg):
+        msg = "Error: Command not found: docker"
+        out = append_local_docker_error_hint("local", msg)
+    assert "prod-apps-01" in out
+    assert "lab-02" in out
+    assert "host=" in out

--- a/web/src/app/activity/page.tsx
+++ b/web/src/app/activity/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 import useSWR from "swr";
 import { apiGet } from "@/lib/api";
 import { EventTimeline } from "@/components/events/event-timeline";
@@ -15,7 +15,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useUrlState, useUrlStateNumber } from "@/hooks/use-url-state";
 import type { EventInfo, SessionInfo, WatchRunSummary } from "@/lib/types";
+
+type WindowPreset = "1h" | "24h" | "7d" | "custom";
 
 const CATEGORIES = [
   "all",
@@ -42,39 +45,51 @@ const WINDOW_PRESETS = [
   { value: "custom", label: "Custom start", hours: null },
 ] as const;
 
-export default function ActivityPage() {
-  const [category, setCategory] = useState("all");
-  const [limit, setLimit] = useState(100);
-  const [sessionId, setSessionId] = useState("");
-  const [watchId, setWatchId] = useState("");
-  const [windowPreset, setWindowPreset] = useState<(typeof WINDOW_PRESETS)[number]["value"]>("24h");
-  const [customSince, setCustomSince] = useState("");
-  const [presetSinceIso, setPresetSinceIso] = useState<string | null>(null);
+function computeSinceIso(preset: WindowPreset, custom: string): string | null {
+  if (preset === "custom") {
+    if (!custom) return null;
+    const parsed = new Date(custom);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  const match = WINDOW_PRESETS.find((item) => item.value === preset);
+  if (!match?.hours) return null;
+  return new Date(Date.now() - match.hours * 60 * 60 * 1000).toISOString();
+}
 
-  const handleWindowPresetChange = (value: (typeof WINDOW_PRESETS)[number]["value"]) => {
-    setWindowPreset(value);
-    if (value === "custom") {
-      setPresetSinceIso(null);
-      return;
-    }
-    const preset = WINDOW_PRESETS.find((item) => item.value === value);
-    const hours = preset?.hours;
-    if (!hours) {
-      setPresetSinceIso(null);
-      return;
-    }
-    setPresetSinceIso(new Date(Date.now() - hours * 60 * 60 * 1000).toISOString());
+export default function ActivityPage() {
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading activity...</div>}>
+      <ActivityPageInner />
+    </Suspense>
+  );
+}
+
+function ActivityPageInner() {
+  const [category, setCategory] = useUrlState<string>("category", "all");
+  const [limit, setLimit] = useUrlStateNumber("limit", 100);
+  const [sessionId, setSessionId] = useUrlState<string>("session_id", "");
+  const [watchId, setWatchId] = useUrlState<string>("watch_id", "");
+  const [windowPreset, setWindowPreset] = useUrlState<WindowPreset>("window", "24h");
+  const [customSince, setCustomSince] = useUrlState<string>("since", "");
+
+  // `sinceIso` is derived from the preset / custom-start. To keep render pure
+  // (no `Date.now()` during render) the anchor is captured in an initializer
+  // and updated from the input event handlers below.
+  const [sinceIso, setSinceIso] = useState<string | null>(() =>
+    computeSinceIso(windowPreset, customSince),
+  );
+
+  const applyWindowPreset = (next: WindowPreset) => {
+    setWindowPreset(next);
+    setSinceIso(computeSinceIso(next, customSince));
   };
 
-  let sinceIso: string | null = presetSinceIso;
-  if (windowPreset === "custom") {
-    if (!customSince) {
-      sinceIso = null;
-    } else {
-      const parsed = new Date(customSince);
-      sinceIso = Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  const applyCustomSince = (next: string) => {
+    setCustomSince(next);
+    if (windowPreset === "custom") {
+      setSinceIso(computeSinceIso("custom", next));
     }
-  }
+  };
 
   const params = new URLSearchParams();
   if (category !== "all") params.set("category", category);
@@ -122,7 +137,7 @@ export default function ActivityPage() {
               <Label>Window</Label>
               <Select
                 value={windowPreset}
-                onValueChange={(value) => handleWindowPresetChange(value as (typeof WINDOW_PRESETS)[number]["value"])}
+                onValueChange={(value) => applyWindowPreset(String(value ?? "24h") as WindowPreset)}
               >
                 <SelectTrigger className="w-full">
                   <SelectValue />
@@ -144,13 +159,13 @@ export default function ActivityPage() {
                   type="datetime-local"
                   className="w-full"
                   value={customSince}
-                  onChange={(e) => setCustomSince(e.target.value)}
+                  onChange={(e) => applyCustomSince(e.target.value)}
                 />
               </div>
             )}
             <div className="space-y-2">
               <Label>Category</Label>
-              <Select value={category} onValueChange={(v) => setCategory(v ?? "all")}>
+              <Select value={category} onValueChange={(v) => setCategory(String(v ?? "all"))}>
                 <SelectTrigger className="w-full">
                   <SelectValue />
                 </SelectTrigger>

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /* eslint-disable @next/next/no-img-element */
-import { Suspense, startTransition, useCallback, useEffect, useRef, useState } from "react";
+import { Suspense, startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { apiGet, apiPatch, apiPost } from "@/lib/api";
 import { useWebSocket } from "@/hooks/use-websocket";
@@ -128,6 +128,14 @@ function ChatPageInner() {
   const [modelLoading, setModelLoading] = useState(true);
   const [modelSaving, setModelSaving] = useState(false);
   const [modelError, setModelError] = useState<string | null>(null);
+
+  // Size the model dropdown trigger to fit the longest option so the layout
+  // stays stable regardless of which model is selected. Uses `ch` units
+  // because the trigger is rendered in a monospace font.
+  const longestModelLen = useMemo(
+    () => modelOptions.reduce((max, opt) => Math.max(max, opt.length), 0),
+    [modelOptions],
+  );
 
   // Track streaming state with a ref to avoid closure staleness
   const chatInputRef = useRef<ChatInputHandle>(null);
@@ -464,7 +472,12 @@ function ChatPageInner() {
             <>
               <Select value={selectedModel} onValueChange={(value) => setSelectedModel(value ?? "")}>
                 <SelectTrigger
-                  className="h-8 w-[20rem] min-w-40 text-xs font-mono"
+                  className="h-8 min-w-48 max-w-[32rem] text-xs font-mono"
+                  style={
+                    longestModelLen
+                      ? { width: `calc(${longestModelLen}ch + 2.5rem)` }
+                      : undefined
+                  }
                   aria-label="Active model"
                   disabled={modelSaving || modelOptions.length === 0}
                 >

--- a/web/src/app/config/page.tsx
+++ b/web/src/app/config/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense } from "react";
 import useSWR from "swr";
 import { apiGet } from "@/lib/api";
 import { ConfigEditor } from "@/components/config/config-editor";
@@ -37,7 +38,9 @@ export default function ConfigPage() {
           restart.
         </p>
       </div>
-      <ConfigEditor config={config} onSaved={() => mutate()} />
+      <Suspense fallback={<Skeleton className="h-64 rounded-lg" />}>
+        <ConfigEditor config={config} onSaved={() => mutate()} />
+      </Suspense>
     </div>
   );
 }

--- a/web/src/app/notifications/page.tsx
+++ b/web/src/app/notifications/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Suspense } from "react";
 import useSWR from "swr";
 import { apiGet } from "@/lib/api";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -7,6 +8,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { NotificationHistory } from "@/components/notifications/notification-history";
 import { AlertRulesTab } from "@/components/notifications/alert-rules-tab";
 import { ChannelsTab } from "@/components/notifications/channels-tab";
+import { useUrlState } from "@/hooks/use-url-state";
 import type { EventInfo } from "@/lib/types";
 
 const NOTIFICATION_CATEGORIES = [
@@ -28,6 +30,15 @@ function NotificationsSkeleton() {
 }
 
 export default function NotificationsPage() {
+  return (
+    <Suspense fallback={<NotificationsSkeleton />}>
+      <NotificationsPageInner />
+    </Suspense>
+  );
+}
+
+function NotificationsPageInner() {
+  const [tab, setTab] = useUrlState<string>("tab", "history");
   const { data: allEvents, isLoading } = useSWR(
     `/api/events?limit=200`,
     () => apiGet<EventInfo[]>(`/api/events?limit=200`),
@@ -46,7 +57,7 @@ export default function NotificationsPage() {
     <div className="space-y-6 animate-fade-in-up">
       <h1 className="text-2xl">Notifications</h1>
 
-      <Tabs defaultValue="history">
+      <Tabs value={tab} onValueChange={(value) => setTab(String(value))}>
         <TabsList className="flex flex-wrap">
           <TabsTrigger value="history">History</TabsTrigger>
           <TabsTrigger value="rules">Alert Rules</TabsTrigger>

--- a/web/src/app/sessions/page.tsx
+++ b/web/src/app/sessions/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { Suspense } from "react";
 import useSWR from "swr";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { apiGet, apiDelete } from "@/lib/api";
 import {
   Table,
@@ -12,7 +14,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { Trash2, MessageSquare, History, Eraser, FileSearch } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Trash2, MessageSquare, History, Eraser, FileSearch, X } from "lucide-react";
 import type { SessionInfo } from "@/lib/types";
 
 function relativeTime(dateStr: string): string {
@@ -30,9 +33,23 @@ function relativeTime(dateStr: string): string {
 }
 
 export default function SessionsPage() {
-  const { data: sessions, mutate } = useSWR("/api/sessions", () =>
-    apiGet<SessionInfo[]>("/api/sessions")
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading sessions...</div>}>
+      <SessionsPageInner />
+    </Suspense>
   );
+}
+
+function SessionsPageInner() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const watchId = searchParams.get("watch_id");
+
+  const fetchKey = watchId
+    ? `/api/sessions?watch_id=${encodeURIComponent(watchId)}`
+    : "/api/sessions";
+
+  const { data: sessions, mutate } = useSWR(fetchKey, () => apiGet<SessionInfo[]>(fetchKey));
 
   const handleDelete = async (sessionId: string) => {
     if (!confirm("Delete this session and all its messages?")) return;
@@ -44,6 +61,10 @@ export default function SessionsPage() {
     if (!confirm("Delete ALL sessions and their messages? This cannot be undone.")) return;
     await apiDelete("/api/sessions");
     mutate();
+  };
+
+  const clearWatchFilter = () => {
+    router.replace("/sessions");
   };
 
   return (
@@ -58,10 +79,33 @@ export default function SessionsPage() {
         )}
       </div>
 
+      {watchId && (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-primary/30 bg-primary/5 px-3 py-2 text-sm">
+          <span className="text-muted-foreground">Filtered by watch run:</span>
+          <Badge variant="secondary" className="font-mono text-xs">
+            {watchId}
+          </Badge>
+          <Button variant="ghost" size="sm" className="ml-auto h-7" onClick={clearWatchFilter}>
+            <X className="mr-1 h-3.5 w-3.5" />
+            Clear filter
+          </Button>
+        </div>
+      )}
+
       {!sessions || sessions.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-muted-foreground gap-3">
           <History className="h-8 w-8" />
-          <p className="text-sm">No sessions found</p>
+          <p className="text-sm">
+            {watchId ? "No sessions found for this watch run" : "No sessions found"}
+          </p>
+          {watchId && (
+            <Link
+              href={`/watch-explorer?watch_id=${encodeURIComponent(watchId)}`}
+              className="text-xs text-primary underline-offset-4 hover:underline"
+            >
+              Back to Watch Explorer
+            </Link>
+          )}
         </div>
       ) : (
         <Table>

--- a/web/src/app/tools/page.tsx
+++ b/web/src/app/tools/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useState } from "react";
+import { Fragment, Suspense, useState } from "react";
 import useSWR from "swr";
 import { apiGet, apiPatch } from "@/lib/api";
 import {
@@ -23,7 +23,10 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Wrench, ChevronRight, Save, Loader2, Search, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
+import { useUrlState, useUrlStateSet } from "@/hooks/use-url-state";
 import type { ToolInfo, ToolAction } from "@/lib/types";
+
+type SortCol = "name" | "group" | "risk" | "";
 
 const RISK_COLORS: Record<number, string> = {
   1: "bg-green-500/15 text-green-700 dark:text-green-400",
@@ -86,19 +89,27 @@ function ActionRow({ toolName, action, onOverride, pendingValue }: {
 }
 
 export default function ToolsPage() {
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading tools...</div>}>
+      <ToolsPageInner />
+    </Suspense>
+  );
+}
+
+function ToolsPageInner() {
   const { data: tools, mutate } = useSWR("/api/tools", () =>
     apiGet<ToolInfo[]>("/api/tools")
   );
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [expanded, setExpanded] = useUrlStateSet("expanded");
   const [saving, setSaving] = useState(false);
   const [persist, setPersist] = useState(false);
 
-  // Search, filter, sort
-  const [search, setSearch] = useState("");
-  const [groupFilter, setGroupFilter] = useState("all");
-  const [statusFilter, setStatusFilter] = useState("all");
-  const [sortCol, setSortCol] = useState<"name" | "group" | "risk" | null>(null);
-  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+  // Search, filter, sort — URL-backed so they survive navigation.
+  const [search, setSearch] = useUrlState<string>("q", "");
+  const [groupFilter, setGroupFilter] = useUrlState<string>("group", "all");
+  const [statusFilter, setStatusFilter] = useUrlState<string>("status", "all");
+  const [sortCol, setSortCol] = useUrlState<SortCol>("sort", "");
+  const [sortDir, setSortDir] = useUrlState<"asc" | "desc">("dir", "asc");
 
   // Track pending config changes
   const [pendingOverrides, setPendingOverrides] = useState<Record<string, number | null>>({});
@@ -111,12 +122,10 @@ export default function ToolsPage() {
     Object.keys(pendingApproval).length > 0;
 
   const toggleExpand = (name: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(name)) next.delete(name);
-      else next.add(name);
-      return next;
-    });
+    const next = new Set(expanded);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    setExpanded(next);
   };
 
   const getEffectiveStatus = (tool: ToolInfo): boolean => {
@@ -217,7 +226,7 @@ export default function ToolsPage() {
 
   const toggleSort = (col: "name" | "group" | "risk") => {
     if (sortCol === col) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
     } else {
       setSortCol(col);
       setSortDir("asc");
@@ -280,7 +289,7 @@ export default function ToolsPage() {
               className="pl-8 h-8 text-sm"
             />
           </div>
-          <Select value={groupFilter} onValueChange={(v) => setGroupFilter(v ?? "all")}>
+          <Select value={groupFilter} onValueChange={(v) => setGroupFilter(String(v ?? "all"))}>
             <SelectTrigger className="h-8 w-[130px] text-xs">
               <SelectValue placeholder="All groups" />
             </SelectTrigger>
@@ -291,7 +300,7 @@ export default function ToolsPage() {
               <SelectItem value="admin">Admin</SelectItem>
             </SelectContent>
           </Select>
-          <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v ?? "all")}>
+          <Select value={statusFilter} onValueChange={(v) => setStatusFilter(String(v ?? "all"))}>
             <SelectTrigger className="h-8 w-[130px] text-xs">
               <SelectValue placeholder="All statuses" />
             </SelectTrigger>

--- a/web/src/app/watch/page.tsx
+++ b/web/src/app/watch/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import useSWR from "swr";
 import { apiGet } from "@/lib/api";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -9,10 +9,20 @@ import { WatchStatsCard } from "@/components/watch/watch-stats-card";
 import { WatchLiveStream } from "@/components/watch/watch-live-stream";
 import { WatchCycleHistory } from "@/components/watch/watch-cycle-history";
 import { WatchConfigDrawer } from "@/components/watch/watch-config-drawer";
+import { useUrlState } from "@/hooks/use-url-state";
 import type { WatchStatus } from "@/lib/types";
 
 export default function WatchPage() {
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading watch...</div>}>
+      <WatchPageInner />
+    </Suspense>
+  );
+}
+
+function WatchPageInner() {
   const [configOpen, setConfigOpen] = useState(false);
+  const [tab, setTab] = useUrlState<string>("tab", "stream");
 
   const { data: status, mutate } = useSWR(
     "/api/watch/status",
@@ -39,7 +49,7 @@ export default function WatchPage() {
         </div>
       </div>
 
-      <Tabs defaultValue="stream">
+      <Tabs value={tab} onValueChange={(value) => setTab(String(value))}>
         <TabsList>
           <TabsTrigger value="stream">Live Stream</TabsTrigger>
           <TabsTrigger value="history">Cycle History</TabsTrigger>

--- a/web/src/components/config/config-editor.tsx
+++ b/web/src/components/config/config-editor.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import type { ConfigDetailResponse } from "@/lib/types";
 import { ChannelsTab } from "@/components/notifications/channels-tab";
+import { useUrlState } from "@/hooks/use-url-state";
 import { AppConfigForm } from "./app-config-form";
 import { LLMConfigForm } from "./llm-config-form";
 import { WatchConfigForm } from "./watch-config-form";
@@ -92,10 +93,11 @@ function ReadOnlySection({
 }
 
 export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
+  const [tab, setTab] = useUrlState<string>("tab", "app");
   return (
     <div className="space-y-4">
       <ConfigEnvOverrideNotice config={config} />
-      <Tabs defaultValue="app">
+      <Tabs value={tab} onValueChange={(value) => setTab(String(value))}>
       <TabsList className="flex flex-wrap">
         <TabsTrigger value="app">App</TabsTrigger>
         <TabsTrigger value="llm">LLM</TabsTrigger>

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
+import { Suspense, useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { apiGet } from "@/lib/api";
 import {
@@ -40,40 +40,88 @@ const systemNav = [
   { href: "/config", label: "Config", icon: Settings },
 ];
 
-export function Sidebar() {
-  const pathname = usePathname();
-  const mounted = useSyncExternalStore(() => () => {}, () => true, () => false);
-  const { data: config } = useSWR("/api/config", () =>
-    apiGet<ConfigDetailResponse>("/api/config")
-  );
-  const version = config?.app?.values?.version as string | undefined;
+const STORAGE_KEY = "squire_last_url_by_section";
 
-  const renderLink = ({ href, label, icon: Icon }: typeof chatNav[number]) => {
+type NavItem = (typeof chatNav)[number];
+
+/**
+ * Remembers the last full URL (path + search) visited within each top-level
+ * section, stored in sessionStorage. Clicking a sidebar link for a section
+ * then resolves to the stored URL so the user lands back in the same
+ * tab/filter they left.
+ */
+function useSectionMemory(): (href: string) => string {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const mapRef = useRef<Record<string, string>>({});
+
+  // Hydrate from sessionStorage on mount.
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(STORAGE_KEY);
+      if (raw) mapRef.current = JSON.parse(raw);
+    } catch {
+      mapRef.current = {};
+    }
+  }, []);
+
+  // Record the current URL for its owning section whenever path or query changes.
+  useEffect(() => {
+    const sections = [...chatNav, ...monitorNav, ...systemNav].map((i) => i.href);
+    const section = sections.find((href) => pathname === href || pathname.startsWith(href + "/"));
+    if (!section) return;
+    const qs = searchParams.toString();
+    const full = qs ? `${pathname}?${qs}` : pathname;
+    mapRef.current = { ...mapRef.current, [section]: full };
+    try {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(mapRef.current));
+    } catch {
+      // sessionStorage may be unavailable (private mode, etc.) — fall through
+    }
+  }, [pathname, searchParams]);
+
+  return useCallback((href: string) => mapRef.current[href] ?? href, []);
+}
+
+function SidebarNav() {
+  const pathname = usePathname();
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+  const resolve = useSectionMemory();
+
+  const renderLink = ({ href, label, icon: Icon }: NavItem) => {
+    // Active state keys off pathname only, so the highlight stays correct
+    // regardless of which sub-state the resolved href points at.
     const isActive = mounted && (pathname === href || pathname.startsWith(href + "/"));
     return (
       <Link
         key={href}
-        href={href}
+        href={resolve(href)}
         className={cn(
           "group relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-200",
           isActive
             ? "bg-primary/12 text-primary"
-            : "text-muted-foreground hover:bg-accent hover:text-foreground"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground",
         )}
       >
         {isActive && (
           <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-r-full bg-primary" />
         )}
-        <Icon className={cn(
-          "h-4 w-4 shrink-0 transition-colors",
-          isActive ? "text-primary" : "text-muted-foreground group-hover:text-foreground"
-        )} />
+        <Icon
+          className={cn(
+            "h-4 w-4 shrink-0 transition-colors",
+            isActive ? "text-primary" : "text-muted-foreground group-hover:text-foreground",
+          )}
+        />
         {label}
       </Link>
     );
   };
 
-  const renderGroup = (label: string, items: typeof chatNav) => (
+  const renderGroup = (label: string, items: NavItem[]) => (
     <div className="space-y-0.5">
       <p className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">
         {label}
@@ -81,6 +129,49 @@ export function Sidebar() {
       {items.map(renderLink)}
     </div>
   );
+
+  return (
+    <>
+      {renderGroup("Chat", chatNav)}
+      {renderGroup("Monitoring", monitorNav)}
+      {renderGroup("System", systemNav)}
+    </>
+  );
+}
+
+function SidebarNavFallback() {
+  // Bare nav rendered while SidebarNav suspends on useSearchParams.
+  const items: [string, NavItem[]][] = [
+    ["Chat", chatNav],
+    ["Monitoring", monitorNav],
+    ["System", systemNav],
+  ];
+  return (
+    <>
+      {items.map(([label, group]) => (
+        <div key={label} className="space-y-0.5">
+          <p className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">
+            {label}
+          </p>
+          {group.map(({ href, label: itemLabel, icon: Icon }) => (
+            <Link
+              key={href}
+              href={href}
+              className="group relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-all duration-200 hover:bg-accent hover:text-foreground"
+            >
+              <Icon className="h-4 w-4 shrink-0 text-muted-foreground group-hover:text-foreground" />
+              {itemLabel}
+            </Link>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+}
+
+export function Sidebar() {
+  const { data: config } = useSWR("/api/config", () => apiGet<ConfigDetailResponse>("/api/config"));
+  const version = config?.app?.values?.version as string | undefined;
 
   return (
     <aside className="hidden md:flex w-56 flex-col border-r border-border/60 bg-sidebar backdrop-blur-sm">
@@ -94,9 +185,9 @@ export function Sidebar() {
 
       {/* Navigation */}
       <nav className="flex-1 flex flex-col gap-4 p-3 pt-4">
-        {renderGroup("Chat", chatNav)}
-        {renderGroup("Monitoring", monitorNav)}
-        {renderGroup("System", systemNav)}
+        <Suspense fallback={<SidebarNavFallback />}>
+          <SidebarNav />
+        </Suspense>
 
         {/* Version footer */}
         <div className="mt-auto px-3 pb-1">

--- a/web/src/components/watch/investigation-workbench.tsx
+++ b/web/src/components/watch/investigation-workbench.tsx
@@ -18,7 +18,7 @@ import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Eraser } from "lucide-react";
+import { Eraser, History } from "lucide-react";
 
 function parseJson(value: string | null | undefined): Record<string, unknown> {
   if (!value) return {};
@@ -255,9 +255,19 @@ export function WatchExplorer() {
 
       <Card className="min-w-0 xl:h-[calc(100vh-11rem)]">
         <CardHeader className="pb-3">
-          <CardTitle className="text-base">
-            {view === "timeline" ? "Timeline View" : "Sessions & Cycles"}
-          </CardTitle>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-base">
+              {view === "timeline" ? "Timeline View" : "Sessions & Cycles"}
+            </CardTitle>
+            {selectedWatchId && (
+              <Link href={`/sessions?watch_id=${encodeURIComponent(selectedWatchId)}`}>
+                <Button variant="outline" size="sm">
+                  <History className="mr-2 h-4 w-4" />
+                  Open in Sessions
+                </Button>
+              </Link>
+            )}
+          </div>
         </CardHeader>
         <CardContent className="space-y-2 overflow-auto xl:max-h-[calc(100vh-15rem)]">
           {view === "timeline" &&

--- a/web/src/hooks/use-url-state.ts
+++ b/web/src/hooks/use-url-state.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useCallback } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+/**
+ * Sync a piece of page state with a single URL search param.
+ *
+ * Reading the value happens synchronously from `useSearchParams()`, so the
+ * current URL is the source of truth. Writing uses `router.replace()` to avoid
+ * polluting history with every tab/filter click. When `next` equals
+ * `defaultValue`, the key is removed from the URL so bare paths stay clean.
+ *
+ * Pattern mirrors the existing `useWorkbenchQuery` hook in
+ * `web/src/components/watch/investigation-workbench.tsx`.
+ */
+export function useUrlState<T extends string>(
+  key: string,
+  defaultValue: T,
+): [T, (next: T) => void] {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const raw = searchParams.get(key);
+  const value = (raw ?? defaultValue) as T;
+
+  const setValue = useCallback(
+    (next: T) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (!next || next === defaultValue) {
+        params.delete(key);
+      } else {
+        params.set(key, next);
+      }
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [searchParams, router, pathname, key, defaultValue],
+  );
+
+  return [value, setValue];
+}
+
+/**
+ * Variant for `Set<string>` state (e.g. expanded row ids), serialized as a
+ * comma-separated URL param. Empty sets clear the param.
+ */
+export function useUrlStateSet(key: string): [Set<string>, (next: Set<string>) => void] {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const raw = searchParams.get(key);
+  const value = raw ? new Set(raw.split(",").filter(Boolean)) : new Set<string>();
+
+  const setValue = useCallback(
+    (next: Set<string>) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next.size === 0) {
+        params.delete(key);
+      } else {
+        params.set(key, Array.from(next).join(","));
+      }
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [searchParams, router, pathname, key],
+  );
+
+  return [value, setValue];
+}
+
+/**
+ * Variant for numeric state, serialized with a default so URLs stay clean.
+ */
+export function useUrlStateNumber(
+  key: string,
+  defaultValue: number,
+): [number, (next: number) => void] {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const raw = searchParams.get(key);
+  const parsed = raw === null ? NaN : Number(raw);
+  const value = Number.isFinite(parsed) ? parsed : defaultValue;
+
+  const setValue = useCallback(
+    (next: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next === defaultValue) {
+        params.delete(key);
+      } else {
+        params.set(key, String(next));
+      }
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [searchParams, router, pathname, key, defaultValue],
+  );
+
+  return [value, setValue];
+}


### PR DESCRIPTION
## Problem

Three loosely related rough edges hit at once on the working tree:

1. **Sub-agents kept retrying Docker calls against the wrong host.** When a tool ran on `local` but the user was clearly talking about a remote machine (or vice versa), Docker errors carried no signal back, so the model would re-run the same failing call against the same host instead of re-asking which host to use.
2. **UI state did not survive navigation.** Tabs on Config / Notifications / Watch, Tools filters/sort/expanded rows, and Activity filters all reset to defaults after navigating away and back. The sidebar also dropped the user back at the section root rather than the page they were last on.
3. **Chat skills did not actually apply.** The WebSocket built `active_skill` into in-memory `session.state.update(...)`, but the ADK runner reloads chat sessions from SQLite, so the model never saw the skill. On top of that, `[SKILL COMPLETE]` could be missed when the model produced a text-only final turn, leading to up to 15 dead text-only auto-continue rounds, and `?skill=` lookups by slug failed if the directory and frontmatter `name` differed.

## Context

- The host-selection problem manifested most often via the Container agent, which previously had to hand off to Monitor for `docker_ps` discovery. Adding `docker_ps` to Container removes that round-trip but also means Container is more likely to be the agent that runs against the wrong host first, so it needs the same host-discipline guidance Monitor has.
- The URL-state work follows the existing `useWorkbenchQuery` pattern in `web/src/components/watch/investigation-workbench.tsx` rather than introducing a different state model.
- The chat-skill state-delta fix is the one that actually unblocks skill execution end-to-end; the loop/`[SKILL COMPLETE]` and slug-lookup fixes are smaller bugs that surfaced once skills started applying for real.

No issue numbers — these all came out of using the product.

## Solution

**Agent guidance (shared `instructions/shared.py`)** — one block of host-discipline rules: default `host`, what each tool's output describes, consistency across Docker calls, daemon vs remote confusion, and an explicit anti-retry rule when the same call has failed identically. Wired into Squire root, Monitor, Container, and the router agent. Container additionally gains `docker_ps` so it can do read-only discovery without a Monitor handoff.

**Docker error hints (`src/squire/tools/_docker_hints.py`)** — small helper that detects local-CLI / down-daemon / socket failures and appends a single hint line listing other configured hosts. Applied uniformly across the Docker tool surface (`docker_cleanup`, `docker_compose`, `docker_container`, `docker_image`, `docker_logs`, `docker_network`, `docker_ps`, `docker_volume`). Lives behind a private module so the hint logic is unit-testable in isolation.

**Watch → Sessions linking** — `GET /api/sessions` now accepts `watch_id`, joining through the existing `watch_sessions` table. Watch Explorer has an "Open in Sessions" button on the selected run; Sessions page reads `?watch_id=` and shows a filter chip with a clear button.

**URL-state hooks (`web/src/hooks/use-url-state.ts`)** — three hooks (`useUrlState<T>`, `useUrlStateSet`, `useUrlStateNumber`) that mirror the existing `useWorkbenchQuery` pattern: read synchronously from `useSearchParams`, write via `router.replace` so history doesn't fill up with tab clicks, and clear the param when the value matches the default so URLs stay clean. Adopted on Config, Notifications, Watch, Tools, and Activity pages. Sidebar tracks the last full URL per top-level section via sessionStorage so clicking `Config` after visiting another page returns to the same tab the user left.

**Chat skill loop** — the load-bearing fix is in `src/squire/api/routers/chat.py`: the WebSocket now passes session state (including `active_skill`) as ADK `state_delta` on each `run_async` call, so the runner's reloaded SQLite session actually sees the skill. Around that:
- Auto-continue stops on text-only turns and honors `[SKILL COMPLETE]` from accumulated assistant text (no more 15 dead rounds).
- `SkillService.get_skill` / `delete_skill` resolve by directory slug, case-insensitive directory match, or declared frontmatter `name`, so `?skill=` matches what `/api/skills` returns.
- WebSocket skill query params are trimmed.

**Misc UI** — chat header model dropdown auto-sizes to the longest model id (with min/max caps) instead of a hardcoded 20rem clip.

## Testing

### Unit tests

- `tests/test_tools/test_docker_hints.py` (new) — covers the hint helper: non-local hosts pass through unchanged, non-matching messages pass through unchanged, missing-CLI / daemon-down / socket-error messages get the hint appended, and the listed remotes come from the registry.
- `tests/test_skills.py` — new cases for `SkillService.get_skill` resolving by slug, case-insensitive directory, and frontmatter `name`; `delete_skill` parity.
- `tests/test_database.py` — new coverage for the `watch_id` join path on session listing.
- `tests/test_api_chat.py` — expanded WebSocket coverage for state-delta delivery, the `[SKILL COMPLETE]` text-only path, and the auto-continue stop condition.
- `tests/test_agents/test_agent_tree.py` — sub-agent tool uniqueness is now asserted per specialist (the same tool may appear on more than one sub-agent intentionally, e.g. `docker_ps` on both Monitor and Container).

### Integration tests

No new integration tests. The chat-skill changes were exercised manually against a running `make web` instance (skill applies on first turn, `[SKILL COMPLETE]` exits cleanly, no dead text-only rounds). Docker host-hint behavior is covered by the unit test on the helper plus existing per-tool error-path tests; reproducing a real local daemon-down condition in CI would add fragility for low marginal value.

### Test results

```
$ uv run pytest -q
473 passed, 3 warnings in 3.97s

$ uv run ruff check src tests
All checks passed!

$ uv run ruff format --check src tests
162 files already formatted
```

The 3 warnings are pre-existing (Pydantic enum serializer warning on `risk_tolerance`, two `AsyncMock` coroutine warnings in unrelated host/local-backend tests).

## Reviewer Validation

1. `uv run pytest -q` — should report `473 passed`.
2. `uv run ruff check src tests && uv run ruff format --check src tests` — both clean.
3. Inspect `src/squire/instructions/shared.py` and confirm the host-discipline block reads as guidance the model will actually follow (no internal agent names leaked — should say "Squire", not "Monitor"/"Container").
4. Inspect `src/squire/api/routers/chat.py` and confirm `state_delta` is passed on every `run_async` call, not just session creation. This is the load-bearing change for chat skills.
5. `make web`, then in the chat UI: select a skill via the dropdown, send a message, and verify the skill instructions actually take effect on turn 1 (previously they would not). End the conversation by having the model emit `[SKILL COMPLETE]` and confirm the loop exits without extra text-only turns.
6. In the Watch Explorer, click a run, then "Open in Sessions" — Sessions page should load with a filter chip showing the watch id, and the list should be restricted to that watch's sessions. Click the X on the chip to clear.
7. On Config / Notifications / Watch / Tools / Activity, switch tabs/filters, navigate away, and use the sidebar to return — state should be preserved (URL has the params, sidebar restores the full URL).
8. Edge case worth eyeballing: chat header model dropdown with a long model id (e.g. `claude-opus-4-6[1m]`) — should auto-fit, not clip.

## TODOs / Follow-Ups

- The host-hint helper only covers Docker tools today. Other host-scoped tool families (e.g. raw `system_*` calls) could benefit from the same treatment but are out of scope here.
- Sidebar last-URL memory uses sessionStorage, which means it resets across browser sessions. If users want it to persist across restarts, that's a follow-up (localStorage with a small migration).
- The 3 pre-existing pytest warnings (Pydantic enum serializer, two `AsyncMock` coroutine warnings) are not addressed by this PR.

Generated with [Claude Code](https://claude.com/claude-code)