### PR TITLE
feat(dev): webhook receiver for notification testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dev tooling:** ``scripts/webhook_receiver.py`` and ``make webhook-receiver`` — stdlib HTTP server that logs Squire webhook POSTs (for integration testing); ``squire.example.toml`` documents localhost and ``host.docker.internal`` URLs.
 - **Agent instructions:** Shared guidance for host-scoped tools (default `host`, which host tool output describes, consistency across Docker calls, daemon vs remote confusion, anti-retry after repeated identical failures) on the root Squire agent, Monitor, Container, and router; Container agent now includes `docker_ps` for discovery without a Monitor handoff (also on Monitor for read-only observation).
 - **Docker errors:** When Docker fails on `local` (missing CLI, unreachable daemon, or socket/connect errors), Docker tool error text appends a short hint about passing `host=` consistently and lists other configured hosts when available.
 - **Sessions filter by watch run:** `GET /api/sessions` now accepts an optional `watch_id` query param that joins through `watch_sessions` to restrict results to chat sessions initiated by that watch.

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ web: web-build ## Build Next.js export then start FastAPI + static UI
 watch: ## Start autonomous watch mode
 	cd $(REPO_ROOT) && uv run squire watch
 
+.PHONY: webhook-receiver
+webhook-receiver: ## Dev-only HTTP server to capture Squire notification webhooks
+	cd $(REPO_ROOT) && uv run python scripts/webhook_receiver.py
+
 # ---------------------------------------------------------------------------
 # Docker
 # ---------------------------------------------------------------------------

--- a/scripts/webhook_receiver.py
+++ b/scripts/webhook_receiver.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Minimal HTTP server to receive Squire notification webhooks for integration testing.
+
+Squire posts JSON to each configured webhook URL (see ``WebhookDispatcher``). Run this
+script, then point ``squire.toml`` at it:
+
+- Native Squire on the same machine: ``url = "http://127.0.0.1:<port>/webhook"``
+- Squire in Docker (receiver on the host): ``url = "http://host.docker.internal:<port>/webhook"``
+
+Enable notifications (``[notifications] enabled = true``) and add a ``[[notifications.webhooks]]``
+entry with matching ``url`` and optional ``events`` / ``headers``.
+
+Example: ``uv run python scripts/webhook_receiver.py`` or ``make webhook-receiver``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import urlparse
+
+
+class WebhookHTTPServer(HTTPServer):
+    """HTTPServer with webhook path and logging flags."""
+
+    webhook_path: str
+    quiet: bool
+    verbose_json: bool
+    verbose_http: bool
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        RequestHandlerClass: type[BaseHTTPRequestHandler],
+        *,
+        webhook_path: str,
+        quiet: bool,
+        verbose_json: bool,
+        verbose_http: bool,
+    ) -> None:
+        self.webhook_path = webhook_path
+        self.quiet = quiet
+        self.verbose_json = verbose_json
+        self.verbose_http = verbose_http
+        super().__init__(server_address, RequestHandlerClass)
+
+
+class WebhookReceiverHandler(BaseHTTPRequestHandler):
+    server: WebhookHTTPServer
+
+    def log_message(self, format: str, *args: Any) -> None:
+        if self.server.verbose_http:
+            super().log_message(format, *args)
+
+    def _send_json(self, code: int, obj: dict[str, Any]) -> None:
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _path(self) -> str:
+        return urlparse(self.path).path
+
+    def do_GET(self) -> None:
+        p = self._path()
+        if p in ("/", self.server.webhook_path):
+            self._send_json(
+                200,
+                {
+                    "status": "ok",
+                    "post_json_to": self.server.webhook_path,
+                },
+            )
+        else:
+            self._send_json(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        if self._path() != self.server.webhook_path:
+            self._send_json(404, {"error": "not found"})
+            return
+
+        raw_len = self.headers.get("Content-Length")
+        try:
+            length = int(raw_len) if raw_len is not None else 0
+        except ValueError:
+            self._send_json(400, {"ok": False, "error": "invalid Content-Length"})
+            return
+
+        raw = self.rfile.read(length) if length > 0 else b""
+        try:
+            data: Any = json.loads(raw.decode() if raw else "{}")
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            self._send_json(400, {"ok": False, "error": str(e)})
+            return
+
+        if not isinstance(data, dict):
+            self._send_json(400, {"ok": False, "error": "JSON root must be an object"})
+            return
+
+        if not self.server.quiet:
+            self._print_payload(data)
+
+        self._send_json(200, {"ok": True})
+
+    def _print_payload(self, data: dict[str, Any]) -> None:
+        cat = data.get("category", "")
+        summary = data.get("summary", "")
+        line = f"[webhook] category={cat!r} summary={summary!r}"
+        print(line, file=sys.stdout)
+        if self.server.verbose_json:
+            print(json.dumps(data, indent=2), file=sys.stdout)
+            print(file=sys.stdout)
+
+
+def normalize_path(path: str) -> str:
+    p = path.strip()
+    if not p.startswith("/"):
+        p = "/" + p
+    return p
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Receive Squire notification webhooks (POST JSON).")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind address (default: all interfaces)")
+    parser.add_argument("--port", type=int, default=9847, help="Listen port (default: 9847)")
+    parser.add_argument(
+        "--path",
+        default="/webhook",
+        help="URL path for POST webhooks (default: /webhook)",
+    )
+    parser.add_argument("--quiet", action="store_true", help="Do not print each payload to stdout")
+    parser.add_argument("--verbose", action="store_true", help="After the summary line, print full JSON (indented)")
+    parser.add_argument("--verbose-http", action="store_true", help="Log http.server request lines to stderr")
+    args = parser.parse_args()
+
+    webhook_path = normalize_path(args.path)
+    server = WebhookHTTPServer(
+        (args.host, args.port),
+        WebhookReceiverHandler,
+        webhook_path=webhook_path,
+        quiet=args.quiet,
+        verbose_json=args.verbose,
+        verbose_http=args.verbose_http,
+    )
+    print(
+        f"Listening on http://{args.host}:{args.port}{webhook_path} (GET / or {webhook_path} for health)",
+        file=sys.stderr,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down.", file=sys.stderr)
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/squire.example.toml
+++ b/squire.example.toml
@@ -101,6 +101,15 @@
 # name = "ntfy"
 # url = "https://ntfy.sh/squire-alerts"
 # events = ["*"]
+#
+# Local test receiver (``uv run python scripts/webhook_receiver.py`` — default path /webhook, port 9847):
+# [[notifications.webhooks]]
+# name = "dev-echo"
+# url = "http://127.0.0.1:9847/webhook"
+# events = ["*"]
+#
+# Same receiver on the Docker host when Squire runs in a container:
+# url = "http://host.docker.internal:9847/webhook"
 
 # --- Email notifications ---
 # [notifications.email]

--- a/uv.lock
+++ b/uv.lock
@@ -601,7 +601,7 @@ wheels = [
 
 [[package]]
 name = "google-adk"
-version = "1.27.1"
+version = "1.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -650,9 +650,9 @@ dependencies = [
     { name = "watchdog" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/59/e49d38b6948192180ed971d65bd03ad75d07593476db1cdd63b5cf6cfbeb/google_adk-1.27.1.tar.gz", hash = "sha256:b252b6e2139385fb8b96cc24026f77be83a93a71da877aa3e7e98868a8f5c9d9", size = 2297550, upload-time = "2026-03-13T23:09:05.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/7a/2d596bf923d9491163b1fc74f9927c538ffa8ea8fec3cadacf26749d2239/google_adk-1.31.0.tar.gz", hash = "sha256:1ebcf2f3c790bd95e8fc43c5390606a9a1019f424bdbd675fcdd4ed33e5b4c3d", size = 2407101, upload-time = "2026-04-17T00:59:03.83Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/ac/dfaa3f751c22662ff045814f62f68be7f8e5a9c0dbd882c24a7afb5284c7/google_adk-1.27.1-py3-none-any.whl", hash = "sha256:806c72dd6d79b16a1dd86e5874ed48f5a42f2acc0129becbb77487a7629af224", size = 2688647, upload-time = "2026-03-13T23:09:03.457Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4f/ce4a0de8a7b03431d67d7375c5e9c1becc8b9351630b7b34f0943b42fb27/google_adk-1.31.0-py3-none-any.whl", hash = "sha256:1886cfd0c9f1455fb08500348e8861be6c6810ec3eabc9dfcbfe1309ea8e3202", size = 2849240, upload-time = "2026-04-17T00:59:01.452Z" },
 ]
 
 [[package]]
@@ -729,7 +729,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.141.0"
+version = "1.148.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
@@ -745,13 +745,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/dc/1209c7aab43bd7233cf631165a3b1b4284d22fc7fe7387c66228d07868ab/google_cloud_aiplatform-1.141.0.tar.gz", hash = "sha256:e3b1cdb28865dd862aac9c685dfc5ac076488705aba0a5354016efadcddd59c6", size = 10152688, upload-time = "2026-03-10T22:20:08.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/f3/b2a9417014c93858a2e3266134f931eefd972c2d410b25d7b8782fc6f143/google_cloud_aiplatform-1.148.1.tar.gz", hash = "sha256:75d605fba34e68714bd08e1e482755d0a6e3ae972805f809d088e686c30879e7", size = 10278758, upload-time = "2026-04-17T23:45:26.738Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/fc/428af69a69ff2e477e7f5e12d227b31fe5790f1a8234aacd54297f49c836/google_cloud_aiplatform-1.141.0-py2.py3-none-any.whl", hash = "sha256:6bd25b4d514c40b8181ca703e1b313ad6d0454ab8006fc9907fb3e9f672f31d1", size = 8358409, upload-time = "2026-03-10T22:20:04.871Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5b/e3515d7bbba602c2b0f6a0da5431785e897252443682e4735d0e6873dc8f/google_cloud_aiplatform-1.148.1-py2.py3-none-any.whl", hash = "sha256:035101e2d8e65c6a706cc3930b2452de7ddcbde50dd130320fcea0d8b03b0c5a", size = 8434481, upload-time = "2026-04-17T23:45:22.919Z" },
 ]
 
 [package.optional-dependencies]
 agent-engines = [
+    { name = "aiohttp" },
     { name = "cloudpickle" },
     { name = "google-cloud-iam" },
     { name = "google-cloud-logging" },
@@ -1097,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.67.0"
+version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1111,9 +1112,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/07/59a498f81f2c7b0649eacda2ea470b7fd8bd7149f20caba22962081bdd51/google_genai-1.67.0.tar.gz", hash = "sha256:897195a6a9742deb6de240b99227189ada8b2d901d61bdfba836c3092021eab6", size = 506972, upload-time = "2026-03-12T20:39:16.241Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/c2/562aa1f086e53529ffbeb5b43d5d8bc42c1b968102b5e2163fad005ce298/google_genai-1.67.0-py3-none-any.whl", hash = "sha256:58b0484ff2d4335fa53c724b489e9f807fcca8115d9cdbd8fdf341121fbd6d2d", size = 733542, upload-time = "2026-03-12T20:39:14.615Z" },
+    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
 ]
 
 [[package]]
@@ -2506,7 +2507,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -2515,9 +2516,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -2744,15 +2745,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "14.3.3"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -2993,14 +2994,14 @@ requires-dist = [
     { name = "aiosqlite", specifier = "==0.22.1" },
     { name = "asyncssh", specifier = "==2.22.0" },
     { name = "fastapi", specifier = "==0.135.1" },
-    { name = "google-adk", specifier = "==1.27.1" },
+    { name = "google-adk", specifier = "==1.31.0" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "litellm", specifier = "==1.82.2" },
     { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-settings", specifier = "==2.13.1" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "rich", specifier = "==14.3.3" },
+    { name = "rich", specifier = "==15.0.0" },
     { name = "tomlkit", specifier = "==0.14.0" },
     { name = "typer", specifier = "==0.24.1" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.44.0" },
@@ -3009,7 +3010,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = "==1.20.0" },
-    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest", specifier = "==9.0.3" },
     { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "ruff", specifier = "==0.15.6" },
 ]


### PR DESCRIPTION
## Problem

There was no lightweight, repo-local way to capture Squire webhook POSTs when exercising notifications in an integrated or Docker setup.

## Context

Squire sends JSON via `httpx` POST to configured webhook URLs (`WebhookDispatcher`). A dedicated echo server makes it easy to confirm payloads and HTTP success without relying on external services.

## Solution

- Add `scripts/webhook_receiver.py`: stdlib `HTTPServer`, health GET, POST JSON logging, CLI flags (`--host`, `--port`, `--path`, `--quiet`, `--verbose`, `--verbose-http`).
- Document example URLs in `squire.example.toml` (localhost and `host.docker.internal` for Docker).
- Add `make webhook-receiver` and a CHANGELOG entry.
- Commit `uv.lock` sync (dependency graph refresh from the working tree).

## Testing

### Unit tests

None added for the dev script (manual smoke only).

### Integration tests

Manual: `uv run python scripts/webhook_receiver.py --host 127.0.0.1 --port 19847` with `curl` GET `/`, POST `/webhook` with a Squire-shaped JSON body, wrong path returns 404.

### Test results

- `uv run ruff check scripts/webhook_receiver.py` — pass.
- Curl smoke — health JSON, POST `{"ok": true}`, wrong path 404.

## Reviewer Validation

1. `make webhook-receiver` (or `uv run python scripts/webhook_receiver.py`) and open `http://127.0.0.1:9847/` — expect JSON with `status: ok`.
2. `curl -sS -X POST http://127.0.0.1:9847/webhook -H 'Content-Type: application/json' -d '{"app":"squire","timestamp":"2026-01-01T00:00:00+00:00","category":"user","summary":"test"}'` — expect `{"ok": true}` and a log line on the server terminal.
3. Skim `uv.lock` diff if dependency bumps need a second pair of eyes (small line delta).

## TODOs / Follow-Ups

None — this PR is self-contained. Optional later: optional Compose service for the receiver instead of `host.docker.internal`.

Made with [Cursor](https://cursor.com)