### PR TITLE
feat(tools): effect classification, bulk edit, multi-action deny fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tool & skill effect classification:** Every tool declares an `EFFECT` (`read` / `write` / `mixed`); multi-action tools declare per-action `EFFECTS`. New `TOOL_EFFECTS` registry and `get_tool_effect()` helper in `squire.tools`. `GET /api/tools` now includes a tool-level `effect` field and per-action `effect` on multi-action tools; `GET /api/skills` includes `effect` (optional frontmatter `metadata.effect`, default `"mixed"`). The Tools and Skills pages render an Effect column with a colored badge and a filter dropdown (read/write/mixed); the Tools page URL-state backs the new filter. Skill form has a matching Effect selector. Bootstrapped watch playbooks (`recover-container-unhealthy`, `triage-disk-pressure`) are seeded as `effect: write`. Effect is UI-only metadata — orthogonal to risk and not consumed by the risk gate, guardrails, or approval today.
 - **Dev tooling:** ``scripts/webhook_receiver.py`` and ``make webhook-receiver`` — stdlib HTTP server that logs Squire webhook POSTs (for integration testing); ``squire.example.toml`` documents localhost and ``host.docker.internal`` URLs.
 - **Agent instructions:** Shared guidance for host-scoped tools (default `host`, which host tool output describes, consistency across Docker calls, daemon vs remote confusion, anti-retry after repeated identical failures) on the root Squire agent, Monitor, Container, and router; Container agent now includes `docker_ps` for discovery without a Monitor handoff (also on Monitor for read-only observation).
 - **Docker errors:** When Docker fails on `local` (missing CLI, unreachable daemon, or socket/connect errors), Docker tool error text appends a short hint about passing `host=` consistently and lists other configured hosts when available.
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Multi-action tool deny:** Adding a multi-action tool (e.g. `docker_container`, `systemctl`) to `tools_deny` now blocks every action on that tool. Previously only single-action tools like `docker_ps` were blocked because the risk gate compared the compound action name (`docker_container:inspect`) against a denied set that only contained the bare tool name.
 - **Chat skill loop:** WebSocket skill auto-continue no longer runs up to 15 text-only turns when the model stops calling tools; `[SKILL COMPLETE]` is honored from accumulated assistant text even on a final text-only turn.
 - **Skill lookup:** `SkillService.get_skill` (and `delete_skill`) now resolve skills by directory slug, case-insensitive directory match, or declared frontmatter `name`, so chat `?skill=` and the API match how skills are listed; WebSocket skill query params are trimmed.
 - **Chat skills:** Session state built when the WebSocket opens (including `active_skill`) is now passed as ADK `state_delta` on each `run_async` call. The runner reloads chat sessions from SQLite, so in-memory `session.state.update` alone never applied skill instructions to the model.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,11 +86,13 @@ Tools live in `src/squire/tools/`. Each tool is a plain async function in its ow
 import json
 import logging
 
+from ._effects import Effect
 from ._registry import get_registry
 
 logger = logging.getLogger(__name__)
 
 RISK_LEVEL = 1  # 1=read-only info, 5=destructive/irreversible
+EFFECT: Effect = "read"  # "read" | "write" | "mixed" — what the tool does to system state
 
 async def my_tool(host: str = "local") -> str:
     """One-line summary shown to the agent as the tool description.
@@ -107,12 +109,13 @@ async def my_tool(host: str = "local") -> str:
     return json.dumps({"output": result.stdout.strip()})
 ```
 
-For tools with multiple actions at different risk levels, use `RISK_LEVELS: dict[str, int]` with `"tool_name:action"` keys instead of a single `RISK_LEVEL`.
+For tools with multiple actions, use `RISK_LEVELS: dict[str, int]` with `"tool_name:action"` keys and a matching `EFFECTS: dict[str, Effect]` with bare action names (e.g. `{"status": "read", "restart": "write"}`) instead of the scalar forms.
 
 **2. Register the tool in `src/squire/tools/__init__.py`**
 
 ```python
-# Add the import:
+# Add the imports:
+from .my_tool import EFFECT as _mt_effect
 from .my_tool import RISK_LEVEL as _mt_risk
 from .my_tool import my_tool
 
@@ -127,7 +130,15 @@ TOOL_RISK_LEVELS: dict[str, int] = {
     ...
     "my_tool": _mt_risk,
 }
+
+# Add to TOOL_EFFECTS:
+TOOL_EFFECTS: dict[str, Effect | dict[str, Effect]] = {
+    ...
+    "my_tool": _mt_effect,
+}
 ```
+
+`tests/test_tools/test_tool_effects.py::test_every_tool_has_effect` enforces that every registered tool has a declared effect — if you forget to add it here, the test will fail.
 
 The `safe_tool` wrapper is applied here at registration time, not in the tool module itself.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,6 +162,12 @@ flowchart TD
     PROMPT -->|Declined| DENY_U
 ```
 
+### Effect classification (orthogonal UI metadata)
+
+Every tool also declares an `EFFECT` — `"read"` (observes only), `"write"` (mutates state), or `"mixed"` (both, or depends on arguments). Multi-action tools declare per-action effects in `EFFECTS: dict[str, Effect]`, and the tool-level effect is derived (`read` if all actions read, `write` if all write, else `mixed`). The registry lives alongside `TOOL_RISK_LEVELS` as `TOOL_EFFECTS` in `squire.tools`, and `GET /api/tools` surfaces the value per tool and per action. Skills carry the same field under frontmatter `metadata.effect` (default `"mixed"`).
+
+Effect is purely UI metadata today — it is not consumed by the risk gate, guardrails, or approval policy. Risk is about severity; effect is about what the tool *does*. A `write` can be low risk (`docker_image:pull`) and a `read` can be sensitive (`read_config` on a secrets file). Keep the two axes separate.
+
 
 
 ### Homelab risk patterns

--- a/src/squire/api/routers/skills.py
+++ b/src/squire/api/routers/skills.py
@@ -45,6 +45,7 @@ def bootstrap_watch_playbooks(skills_service=Depends(get_skills_service)):
             trigger="watch",
             hosts=["all"],
             incident_keys=["container-unhealthy:"],
+            effect="write",
             instructions=(
                 "When a container is unhealthy or restarting:\n"
                 "1) Inspect recent logs before restart.\n"
@@ -60,6 +61,7 @@ def bootstrap_watch_playbooks(skills_service=Depends(get_skills_service)):
             trigger="watch",
             hosts=["all"],
             incident_keys=["disk-pressure:", "disk-warning:"],
+            effect="write",
             instructions=(
                 "When disk pressure is detected:\n"
                 "1) Verify actual primary mount utilization before remediation.\n"
@@ -148,6 +150,7 @@ def create_skill(body: SkillCreate, skills_service=Depends(get_skills_service)):
             hosts=body.hosts,
             trigger=body.trigger,
             incident_keys=body.incident_keys,
+            effect=body.effect,
             instructions=body.instructions,
         )
     except ValueError as e:

--- a/src/squire/api/routers/tools.py
+++ b/src/squire/api/routers/tools.py
@@ -5,7 +5,7 @@ import inspect
 from fastapi import APIRouter, Depends
 
 from ...config import GuardrailsConfig
-from ...tools import TOOL_RISK_LEVELS
+from ...tools import TOOL_EFFECTS, TOOL_RISK_LEVELS, get_tool_effect
 
 # Import raw tool functions for signature introspection
 from ...tools.docker_cleanup import docker_cleanup
@@ -110,12 +110,17 @@ def _build_tool_catalog(guardrails: GuardrailsConfig) -> list[ToolInfo]:
 
         action_names = _get_action_names(name)
 
+        tool_effect = get_tool_effect(name)
+
         if action_names:
+            action_effects = TOOL_EFFECTS[name]
+            assert isinstance(action_effects, dict)  # multi-action tools always have dict entries
             actions = [
                 ToolAction(
                     name=action,
                     risk_level=TOOL_RISK_LEVELS.get(f"{name}:{action}", 1),
                     risk_override=overrides.get(f"{name}:{action}"),
+                    effect=action_effects[action],
                 )
                 for action in action_names
             ]
@@ -128,6 +133,7 @@ def _build_tool_catalog(guardrails: GuardrailsConfig) -> list[ToolInfo]:
                     actions=actions,
                     status=status,
                     approval_policy=approval_policy,
+                    effect=tool_effect,
                 )
             )
         else:
@@ -141,6 +147,7 @@ def _build_tool_catalog(guardrails: GuardrailsConfig) -> list[ToolInfo]:
                     risk_override=overrides.get(name),
                     status=status,
                     approval_policy=approval_policy,
+                    effect=tool_effect,
                 )
             )
     return tools

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -1,6 +1,10 @@
 """Pydantic response models for the Squire web API."""
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
+
+Effect = Literal["read", "write", "mixed"]
 
 # --- System / Snapshots ---
 
@@ -142,6 +146,7 @@ class Skill(BaseModel):
     trigger: str = "manual"
     enabled: bool = True
     incident_keys: list[str] = []
+    effect: Effect = "mixed"
     instructions: str = ""
 
 
@@ -152,6 +157,7 @@ class SkillCreate(BaseModel):
     trigger: str = "manual"
     incident_keys: list[str] = []
     allow_custom_incident_prefixes: bool = False
+    effect: Effect = "mixed"
     instructions: str
 
 
@@ -162,6 +168,7 @@ class SkillUpdate(BaseModel):
     enabled: bool | None = None
     incident_keys: list[str] | None = None
     allow_custom_incident_prefixes: bool | None = None
+    effect: Effect | None = None
     instructions: str | None = None
 
 
@@ -231,6 +238,7 @@ class ToolAction(BaseModel):
     name: str
     risk_level: int
     risk_override: int | None = None
+    effect: Effect
 
 
 class ToolInfo(BaseModel):
@@ -243,6 +251,7 @@ class ToolInfo(BaseModel):
     risk_override: int | None = None  # single-action tools only
     status: str  # "enabled" | "disabled"
     approval_policy: str | None = None  # "always" | "never" | null
+    effect: Effect  # tool-level; derived from per-action effects for multi-action tools
 
 
 # --- Config ---

--- a/src/squire/callbacks/risk_gate.py
+++ b/src/squire/callbacks/risk_gate.py
@@ -144,6 +144,19 @@ def create_risk_gate(
             else:
                 return {"error": f"Blocked: unknown tool '{compound_name}'."}
 
+        # Disabling a multi-action tool (e.g. `docker_container`) must block every
+        # action on that tool. The RuleGate denied set only matches the Action.name
+        # we pass in (compound), so check the bare tool name ourselves.
+        denied_tools = _set_from_state(tool_context.state.get("risk_denied_tools"))
+        if tool_name in denied_tools:
+            return {
+                "error": (
+                    f"[BLOCKED] '{compound_name}' was denied by the risk policy: "
+                    f"tool '{tool_name}' is disabled. "
+                    "Do NOT retry this tool call. Tell the user it was blocked and suggest alternatives."
+                )
+            }
+
         tool_risk = scoped_risk_levels[compound_name]
 
         # Apply per-tool risk override if configured

--- a/src/squire/skills/service.py
+++ b/src/squire/skills/service.py
@@ -14,9 +14,12 @@ the ``metadata`` key to stay spec-compliant.
 import re
 import shutil
 from pathlib import Path
+from typing import Literal
 
 import yaml
 from pydantic import BaseModel, Field, field_validator
+
+Effect = Literal["read", "write", "mixed"]
 
 # Spec: lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, max 64 chars.
 _NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
@@ -31,6 +34,7 @@ class Skill(BaseModel):
     trigger: str = "manual"  # "manual" | "watch"
     enabled: bool = True
     incident_keys: list[str] = Field(default_factory=list)
+    effect: Effect = "mixed"  # what the skill does to system state
     instructions: str = ""  # freeform Markdown body
 
     @field_validator("name")
@@ -202,6 +206,7 @@ class SkillService:
             trigger=meta.get("trigger", "manual"),
             enabled=meta.get("enabled", True),
             incident_keys=meta.get("incident_keys", []),
+            effect=meta.get("effect", "mixed"),
             instructions=body,
         )
 
@@ -224,6 +229,8 @@ class SkillService:
             metadata["enabled"] = skill.enabled
         if skill.incident_keys:
             metadata["incident_keys"] = skill.incident_keys
+        if skill.effect != "mixed":
+            metadata["effect"] = skill.effect
         if metadata:
             frontmatter["metadata"] = metadata
         fm_str = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False).strip()

--- a/src/squire/tools/__init__.py
+++ b/src/squire/tools/__init__.py
@@ -15,6 +15,7 @@ Tool conventions:
   to decide whether user approval is needed.
 """
 
+from ._effects import Effect, derive_effect
 from ._registry import get_db as get_db
 from ._registry import get_guardrails as get_guardrails
 from ._registry import get_notifier as get_notifier
@@ -24,32 +25,46 @@ from ._registry import set_guardrails as set_guardrails
 from ._registry import set_notifier as set_notifier
 from ._registry import set_registry as set_registry
 from ._safe import safe_tool
+from .docker_cleanup import EFFECTS as _dclean_effects
 from .docker_cleanup import RISK_LEVELS as _dclean_risks
 from .docker_cleanup import docker_cleanup
+from .docker_compose import EFFECTS as _dc_effects
 from .docker_compose import RISK_LEVELS as _dc_risks
 from .docker_compose import docker_compose
+from .docker_container import EFFECTS as _dcont_effects
 from .docker_container import RISK_LEVELS as _dcont_risks
 from .docker_container import docker_container
+from .docker_image import EFFECTS as _dimg_effects
 from .docker_image import RISK_LEVELS as _dimg_risks
 from .docker_image import docker_image
+from .docker_logs import EFFECT as _dl_effect
 from .docker_logs import RISK_LEVEL as _dl_risk
 from .docker_logs import docker_logs
+from .docker_network import EFFECTS as _dnet_effects
 from .docker_network import RISK_LEVELS as _dnet_risks
 from .docker_network import docker_network
+from .docker_ps import EFFECT as _dp_effect
 from .docker_ps import RISK_LEVEL as _dp_risk
 from .docker_ps import docker_ps
+from .docker_volume import EFFECTS as _dvol_effects
 from .docker_volume import RISK_LEVELS as _dvol_risks
 from .docker_volume import docker_volume
+from .journalctl import EFFECT as _jctl_effect
 from .journalctl import RISK_LEVEL as _jctl_risk
 from .journalctl import journalctl
+from .network_info import EFFECT as _ni_effect
 from .network_info import RISK_LEVEL as _ni_risk
 from .network_info import network_info
+from .read_config import EFFECT as _rc_effect
 from .read_config import RISK_LEVEL as _rc_risk
 from .read_config import read_config
+from .run_command import EFFECT as _runcmd_effect
 from .run_command import RISK_LEVEL as _runcmd_risk
 from .run_command import run_command
+from .system_info import EFFECT as _si_effect
 from .system_info import RISK_LEVEL as _si_risk
 from .system_info import system_info
+from .systemctl import EFFECTS as _sctl_effects
 from .systemctl import RISK_LEVELS as _sctl_risks
 from .systemctl import systemctl
 
@@ -86,3 +101,31 @@ TOOL_RISK_LEVELS: dict[str, int] = {
     **_sctl_risks,
     "run_command": _runcmd_risk,
 }
+
+# Effect classification per tool. Single-action tools map to a single Effect;
+# multi-action tools map to a dict of action → Effect. Tool-level effect is
+# derived via ``get_tool_effect`` — see ``_effects.derive_effect``.
+TOOL_EFFECTS: dict[str, Effect | dict[str, Effect]] = {
+    "system_info": _si_effect,
+    "network_info": _ni_effect,
+    "docker_ps": _dp_effect,
+    "docker_logs": _dl_effect,
+    "docker_compose": _dc_effects,
+    "docker_container": _dcont_effects,
+    "docker_image": _dimg_effects,
+    "docker_cleanup": _dclean_effects,
+    "docker_volume": _dvol_effects,
+    "docker_network": _dnet_effects,
+    "read_config": _rc_effect,
+    "journalctl": _jctl_effect,
+    "systemctl": _sctl_effects,
+    "run_command": _runcmd_effect,
+}
+
+
+def get_tool_effect(tool_name: str) -> Effect:
+    """Return the tool-level effect — derived for multi-action tools."""
+    entry = TOOL_EFFECTS[tool_name]
+    if isinstance(entry, str):
+        return entry
+    return derive_effect(entry)

--- a/src/squire/tools/_effects.py
+++ b/src/squire/tools/_effects.py
@@ -1,0 +1,31 @@
+"""Tool effect classification — read vs. write vs. mixed.
+
+`effect` is UI metadata describing what a tool does to system state:
+- ``read``  — observes only (no mutation)
+- ``write`` — mutates state
+- ``mixed`` — both, or depends on arguments (e.g. ``run_command``)
+
+Effect is orthogonal to risk level. A ``write`` can be low risk; a ``read``
+can be sensitive. This module is deliberately dependency-free so it can be
+imported by both ``squire.tools`` and ``squire.api`` without circular imports.
+"""
+
+from typing import Literal
+
+Effect = Literal["read", "write", "mixed"]
+
+
+def derive_effect(per_action: dict[str, Effect]) -> Effect:
+    """Collapse a per-action effect map to a single tool-level effect.
+
+    Returns ``"read"`` if every action reads, ``"write"`` if every action
+    writes, and ``"mixed"`` otherwise. Raises ``ValueError`` on empty input.
+    """
+    if not per_action:
+        raise ValueError("per_action must not be empty")
+    values = set(per_action.values())
+    if values == {"read"}:
+        return "read"
+    if values == {"write"}:
+        return "write"
+    return "mixed"

--- a/src/squire/tools/docker_cleanup.py
+++ b/src/squire/tools/docker_cleanup.py
@@ -1,6 +1,7 @@
 """docker_cleanup tool — prune unused Docker resources."""
 
 from ._docker_hints import append_local_docker_error_hint
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -9,6 +10,14 @@ RISK_LEVELS: dict[str, int] = {
     "docker_cleanup:prune_images": 3,
     "docker_cleanup:prune_volumes": 4,
     "docker_cleanup:prune_all": 4,
+}
+
+EFFECTS: dict[str, Effect] = {
+    "df": "read",
+    "prune_containers": "write",
+    "prune_images": "write",
+    "prune_volumes": "write",
+    "prune_all": "write",
 }
 
 

--- a/src/squire/tools/docker_compose.py
+++ b/src/squire/tools/docker_compose.py
@@ -1,6 +1,7 @@
 """docker_compose tool — read and manage Docker Compose stacks."""
 
 from ._docker_hints import append_local_docker_error_hint
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -11,6 +12,16 @@ RISK_LEVELS: dict[str, int] = {
     "docker_compose:restart": 3,
     "docker_compose:up": 3,
     "docker_compose:down": 4,
+}
+
+EFFECTS: dict[str, Effect] = {
+    "ps": "read",
+    "config": "read",
+    "logs": "read",
+    "pull": "write",
+    "restart": "write",
+    "up": "write",
+    "down": "write",
 }
 
 

--- a/src/squire/tools/docker_container.py
+++ b/src/squire/tools/docker_container.py
@@ -1,6 +1,7 @@
 """docker_container tool — manage individual container lifecycle."""
 
 from ._docker_hints import append_local_docker_error_hint
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -9,6 +10,14 @@ RISK_LEVELS: dict[str, int] = {
     "docker_container:stop": 3,
     "docker_container:restart": 3,
     "docker_container:remove": 4,
+}
+
+EFFECTS: dict[str, Effect] = {
+    "inspect": "read",
+    "start": "write",
+    "stop": "write",
+    "restart": "write",
+    "remove": "write",
 }
 
 

--- a/src/squire/tools/docker_image.py
+++ b/src/squire/tools/docker_image.py
@@ -1,6 +1,7 @@
 """docker_image tool — manage Docker images."""
 
 from ._docker_hints import append_local_docker_error_hint
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -8,6 +9,13 @@ RISK_LEVELS: dict[str, int] = {
     "docker_image:inspect": 1,
     "docker_image:pull": 2,
     "docker_image:remove": 3,
+}
+
+EFFECTS: dict[str, Effect] = {
+    "list": "read",
+    "inspect": "read",
+    "pull": "write",
+    "remove": "write",
 }
 
 

--- a/src/squire/tools/docker_logs.py
+++ b/src/squire/tools/docker_logs.py
@@ -1,9 +1,11 @@
 """docker_logs tool — read container logs."""
 
 from ._docker_hints import append_local_docker_error_hint
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVEL = 2  # Low
+EFFECT: Effect = "read"
 
 
 async def docker_logs(

--- a/src/squire/tools/docker_network.py
+++ b/src/squire/tools/docker_network.py
@@ -1,11 +1,17 @@
 """docker_network tool — manage Docker networks."""
 
 from ._docker_hints import append_local_docker_error_hint
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
     "docker_network:list": 1,
     "docker_network:inspect": 1,
+}
+
+EFFECTS: dict[str, Effect] = {
+    "list": "read",
+    "inspect": "read",
 }
 
 

--- a/src/squire/tools/docker_ps.py
+++ b/src/squire/tools/docker_ps.py
@@ -1,9 +1,11 @@
 """docker_ps tool — list Docker containers with status."""
 
 from ._docker_hints import append_local_docker_error_hint
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVEL = 1  # Info
+EFFECT: Effect = "read"
 
 
 async def docker_ps(all_containers: bool = True, format: str = "table", host: str = "local") -> str:

--- a/src/squire/tools/docker_volume.py
+++ b/src/squire/tools/docker_volume.py
@@ -1,11 +1,17 @@
 """docker_volume tool — manage Docker volumes."""
 
 from ._docker_hints import append_local_docker_error_hint
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
     "docker_volume:list": 1,
     "docker_volume:inspect": 1,
+}
+
+EFFECTS: dict[str, Effect] = {
+    "list": "read",
+    "inspect": "read",
 }
 
 

--- a/src/squire/tools/journalctl.py
+++ b/src/squire/tools/journalctl.py
@@ -1,8 +1,10 @@
 """journalctl tool — read systemd journal logs."""
 
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVEL = 2  # Low
+EFFECT: Effect = "read"
 
 
 async def journalctl(

--- a/src/squire/tools/network_info.py
+++ b/src/squire/tools/network_info.py
@@ -3,9 +3,11 @@
 import json
 import platform
 
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVEL = 1  # Info
+EFFECT: Effect = "read"
 
 
 def _get_os_type(backend, host: str) -> str:

--- a/src/squire/tools/read_config.py
+++ b/src/squire/tools/read_config.py
@@ -3,9 +3,11 @@
 import os
 import posixpath
 
+from ._effects import Effect
 from ._registry import get_guardrails, get_registry
 
 RISK_LEVEL = 2  # Low
+EFFECT: Effect = "read"
 
 
 async def read_config(path: str, head: int | None = None, host: str = "local") -> str:

--- a/src/squire/tools/run_command.py
+++ b/src/squire/tools/run_command.py
@@ -2,9 +2,11 @@
 
 import shlex
 
+from ._effects import Effect
 from ._registry import get_guardrails, get_registry
 
 RISK_LEVEL = 5  # Critical
+EFFECT: Effect = "mixed"  # shell escape hatch — effect depends on the command
 
 
 async def run_command(command: str, timeout: float = 30.0, host: str = "local") -> str:

--- a/src/squire/tools/system_info.py
+++ b/src/squire/tools/system_info.py
@@ -4,11 +4,13 @@ import json
 import logging
 import platform
 
+from ._effects import Effect
 from ._registry import get_registry
 
 logger = logging.getLogger(__name__)
 
 RISK_LEVEL = 1  # Info
+EFFECT: Effect = "read"
 
 
 def _get_os_type(backend, host: str) -> str:

--- a/src/squire/tools/systemctl.py
+++ b/src/squire/tools/systemctl.py
@@ -1,5 +1,6 @@
 """systemctl tool — manage systemd services."""
 
+from ._effects import Effect
 from ._registry import get_registry
 
 RISK_LEVELS: dict[str, int] = {
@@ -9,6 +10,15 @@ RISK_LEVELS: dict[str, int] = {
     "systemctl:start": 3,
     "systemctl:restart": 3,
     "systemctl:stop": 4,
+}
+
+EFFECTS: dict[str, Effect] = {
+    "status": "read",
+    "is-active": "read",
+    "is-enabled": "read",
+    "start": "write",
+    "restart": "write",
+    "stop": "write",
 }
 
 

--- a/tests/test_api/test_tools_endpoint.py
+++ b/tests/test_api/test_tools_endpoint.py
@@ -103,3 +103,44 @@ class TestBuildToolCatalog:
         si = next(t for t in tools if t.name == "system_info")
         assert "system information" in si.description.lower()
         assert "\n" not in si.description
+
+
+class TestEffect:
+    def test_every_tool_has_effect(self):
+        guardrails = GuardrailsConfig()
+        tools = _build_tool_catalog(guardrails)
+        for t in tools:
+            assert t.effect in {"read", "write", "mixed"}
+
+    def test_single_action_read_tool(self):
+        guardrails = GuardrailsConfig()
+        tools = _build_tool_catalog(guardrails)
+        si = next(t for t in tools if t.name == "system_info")
+        assert si.effect == "read"
+
+    def test_run_command_is_mixed(self):
+        guardrails = GuardrailsConfig()
+        tools = _build_tool_catalog(guardrails)
+        rc = next(t for t in tools if t.name == "run_command")
+        assert rc.effect == "mixed"
+
+    def test_multi_action_tool_effect_derived_mixed(self):
+        guardrails = GuardrailsConfig()
+        tools = _build_tool_catalog(guardrails)
+        dc = next(t for t in tools if t.name == "docker_container")
+        assert dc.effect == "mixed"  # inspect=read, start/stop/... = write
+
+    def test_multi_action_all_read_tool_effect(self):
+        guardrails = GuardrailsConfig()
+        tools = _build_tool_catalog(guardrails)
+        dv = next(t for t in tools if t.name == "docker_volume")
+        assert dv.effect == "read"  # only list and inspect
+
+    def test_per_action_effect_present(self):
+        guardrails = GuardrailsConfig()
+        tools = _build_tool_catalog(guardrails)
+        dc = next(t for t in tools if t.name == "docker_container")
+        by_name = {a.name: a.effect for a in dc.actions}
+        assert by_name["inspect"] == "read"
+        assert by_name["remove"] == "write"
+        assert by_name["start"] == "write"

--- a/tests/test_callbacks/test_risk_gate_factory.py
+++ b/tests/test_callbacks/test_risk_gate_factory.py
@@ -338,6 +338,34 @@ class TestRiskOverrides:
         assert result is None  # overridden to risk 1
 
     @pytest.mark.asyncio
+    async def test_disabled_tool_denies_bare_name(self):
+        """`tools_deny` on a single-action tool blocks it."""
+        gate = create_risk_gate(tool_risk_levels={"system_info": 1})
+        ctx = _make_context(threshold=5)
+        ctx.state["risk_denied_tools"] = {"system_info"}
+        result = await gate(_make_tool("system_info"), {}, ctx)
+        assert result is not None
+        assert "BLOCKED" in result["error"]
+        assert "disabled" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_disabled_multi_action_tool_blocks_every_action(self):
+        """Disabling `docker_container` must block every action, not just compound names."""
+        gate = create_risk_gate(
+            tool_risk_levels={
+                "docker_container:inspect": 1,
+                "docker_container:remove": 4,
+            }
+        )
+        for action in ("inspect", "remove"):
+            ctx = _make_context(threshold=5)
+            ctx.state["risk_denied_tools"] = {"docker_container"}
+            result = await gate(_make_tool("docker_container"), {"action": action}, ctx)
+            assert result is not None, f"action={action} should have been blocked"
+            assert "BLOCKED" in result["error"]
+            assert "disabled" in result["error"]
+
+    @pytest.mark.asyncio
     async def test_override_only_affects_specified_tool(self):
         """An override for one tool should not affect another."""
         gate = create_risk_gate(

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -183,6 +183,29 @@ class TestParsing:
         assert "  - nas\n" in content
         assert "  trigger: watch\n" in content
 
+    def test_effect_defaults_to_mixed(self, skill_service, tmp_path):
+        skill_dir = tmp_path / "no-effect"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("---\nname: no-effect\ndescription: test\n---\n\nBody.")
+        loaded = skill_service.get_skill("no-effect")
+        assert loaded is not None
+        assert loaded.effect == "mixed"
+
+    def test_effect_roundtrip(self, skill_service, tmp_path):
+        skill = _make_skill(effect="write")
+        skill_service.save_skill(skill)
+        loaded = skill_service.get_skill("test-skill")
+        assert loaded.effect == "write"
+        content = (tmp_path / "test-skill" / "SKILL.md").read_text()
+        assert "effect: write" in content
+
+    def test_default_effect_omitted_from_frontmatter(self, skill_service, tmp_path):
+        """When effect == 'mixed' (default), it should not appear in rendered metadata."""
+        skill = _make_skill()  # effect="mixed" by default
+        skill_service.save_skill(skill)
+        content = (tmp_path / "test-skill" / "SKILL.md").read_text()
+        assert "effect:" not in content
+
     def test_legacy_host_metadata_is_retrofitted_to_hosts(self, skill_service, tmp_path):
         skill_dir = tmp_path / "legacy-skill"
         skill_dir.mkdir()

--- a/tests/test_skills_api.py
+++ b/tests/test_skills_api.py
@@ -85,6 +85,65 @@ def test_bootstrap_starter_playbooks(skills_service):
     assert "triage-disk-pressure" in result["created"] or "triage-disk-pressure" in result["skipped"]
 
 
+def test_bootstrap_playbooks_have_write_effect(skills_service):
+    bootstrap_watch_playbooks(skills_service=skills_service)
+    for name in ("recover-container-unhealthy", "triage-disk-pressure"):
+        skill = skills_service.get_skill(name)
+        assert skill is not None
+        assert skill.effect == "write"
+
+
+def test_create_skill_defaults_effect_to_mixed(skills_service):
+    result = create_skill(
+        SkillCreate(
+            name="defaults-mixed",
+            description="desc",
+            trigger="manual",
+            hosts=["all"],
+            instructions="Do stuff",
+        ),
+        skills_service=skills_service,
+    )
+    assert result.effect == "mixed"
+
+
+def test_create_skill_roundtrips_effect(skills_service):
+    result = create_skill(
+        SkillCreate(
+            name="reads-only",
+            description="desc",
+            trigger="manual",
+            hosts=["all"],
+            effect="read",
+            instructions="Observe stuff",
+        ),
+        skills_service=skills_service,
+    )
+    assert result.effect == "read"
+    reloaded = skills_service.get_skill("reads-only")
+    assert reloaded.effect == "read"
+
+
+def test_update_skill_changes_effect(skills_service):
+    create_skill(
+        SkillCreate(
+            name="to-change",
+            description="desc",
+            trigger="manual",
+            hosts=["all"],
+            effect="mixed",
+            instructions="Do stuff",
+        ),
+        skills_service=skills_service,
+    )
+    updated = update_skill(
+        "to-change",
+        SkillUpdate(effect="write"),
+        skills_service=skills_service,
+    )
+    assert updated.effect == "write"
+
+
 @pytest.mark.asyncio
 async def test_dry_run_contract_fields(skills_service, monkeypatch):
     create_skill(

--- a/tests/test_tools/test_tool_effects.py
+++ b/tests/test_tools/test_tool_effects.py
@@ -1,0 +1,71 @@
+"""Tests for tool effect classification (read / write / mixed)."""
+
+import pytest
+
+from squire.tools import ALL_TOOLS, TOOL_EFFECTS, TOOL_RISK_LEVELS, get_tool_effect
+from squire.tools._effects import derive_effect
+
+
+def test_every_tool_has_effect():
+    """Registry completeness — adding a tool without EFFECT/EFFECTS must fail."""
+    tool_names = {t.__name__ for t in ALL_TOOLS}
+    assert tool_names == set(TOOL_EFFECTS.keys())
+
+
+def test_multi_action_effects_cover_all_actions():
+    """Every ``tool:action`` risk entry has a matching effect on the same action."""
+    for key in TOOL_RISK_LEVELS:
+        if ":" not in key:
+            continue
+        tool, action = key.split(":", 1)
+        entry = TOOL_EFFECTS[tool]
+        assert isinstance(entry, dict), f"{tool} has per-action risks but flat effect"
+        assert action in entry, f"{tool}:{action} missing from EFFECTS"
+
+
+def test_single_action_tools_have_scalar_effect():
+    """Tools without per-action risks should map to a scalar Effect (read/write/mixed)."""
+    multi_tool_names = {key.split(":", 1)[0] for key in TOOL_RISK_LEVELS if ":" in key}
+    for tool_name, entry in TOOL_EFFECTS.items():
+        if tool_name in multi_tool_names:
+            assert isinstance(entry, dict)
+        else:
+            assert isinstance(entry, str)
+            assert entry in {"read", "write", "mixed"}
+
+
+class TestDeriveEffect:
+    def test_all_read(self):
+        assert derive_effect({"a": "read", "b": "read"}) == "read"
+
+    def test_all_write(self):
+        assert derive_effect({"a": "write", "b": "write"}) == "write"
+
+    def test_mixed(self):
+        assert derive_effect({"a": "read", "b": "write"}) == "mixed"
+
+    def test_explicit_mixed_collapses_to_mixed(self):
+        assert derive_effect({"a": "mixed"}) == "mixed"
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            derive_effect({})
+
+
+class TestGetToolEffect:
+    def test_read_only_tool(self):
+        assert get_tool_effect("system_info") == "read"
+        assert get_tool_effect("docker_ps") == "read"
+        assert get_tool_effect("journalctl") == "read"
+
+    def test_all_read_multi_action_tool(self):
+        # docker_volume has only list/inspect actions — both read
+        assert get_tool_effect("docker_volume") == "read"
+        assert get_tool_effect("docker_network") == "read"
+
+    def test_mixed_multi_action_tool(self):
+        assert get_tool_effect("docker_container") == "mixed"
+        assert get_tool_effect("systemctl") == "mixed"
+
+    def test_run_command_is_mixed(self):
+        assert get_tool_effect("run_command") == "mixed"

--- a/web/src/app/skills/page.tsx
+++ b/web/src/app/skills/page.tsx
@@ -34,7 +34,13 @@ import {
   ToggleLeft,
   ToggleRight,
 } from "lucide-react";
-import type { HostInfo, IncidentFamilyInfo, PlaybookDryRunSelection, Skill } from "@/lib/types";
+import type { Effect, HostInfo, IncidentFamilyInfo, PlaybookDryRunSelection, Skill } from "@/lib/types";
+
+const EFFECT_COLORS: Record<Effect, string> = {
+  read: "bg-sky-500/12 text-sky-700 dark:text-sky-400",
+  write: "bg-amber-500/12 text-amber-700 dark:text-amber-400",
+  mixed: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-300",
+};
 
 export default function SkillsPage() {
   const router = useRouter();
@@ -48,6 +54,7 @@ export default function SkillsPage() {
 
   const [formOpen, setFormOpen] = useState(false);
   const [editingSkill, setEditingSkill] = useState<Skill | null>(null);
+  const [effectFilter, setEffectFilter] = useState<string>("all");
   const [dryRunKey, setDryRunKey] = useState("disk-pressure:local");
   const [dryRunHost, setDryRunHost] = useState("local");
   const availableHostNames = Array.from(
@@ -64,6 +71,7 @@ export default function SkillsPage() {
     trigger: string;
     incident_keys: string[];
     allow_custom_incident_prefixes: boolean;
+    effect: Effect;
     instructions: string;
   }) => {
     await apiPost("/api/skills", data);
@@ -78,6 +86,7 @@ export default function SkillsPage() {
     trigger: string;
     incident_keys: string[];
     allow_custom_incident_prefixes: boolean;
+    effect: Effect;
     instructions: string;
   }) => {
     const { name, ...rest } = data;
@@ -242,6 +251,21 @@ export default function SkillsPage() {
           </p>
         </div>
       ) : (
+        <>
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-muted-foreground">Effect:</span>
+          <Select value={effectFilter} onValueChange={(v) => setEffectFilter(v ?? "all")}>
+            <SelectTrigger className="h-8 w-[110px] text-xs">
+              <SelectValue placeholder="All" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              <SelectItem value="read">Read</SelectItem>
+              <SelectItem value="write">Write</SelectItem>
+              <SelectItem value="mixed">Mixed</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
         <Table>
           <TableHeader>
             <TableRow>
@@ -249,13 +273,16 @@ export default function SkillsPage() {
               <TableHead>Description</TableHead>
               <TableHead>Hosts</TableHead>
               <TableHead>Trigger</TableHead>
+              <TableHead>Effect</TableHead>
               <TableHead>Incident Keys</TableHead>
               <TableHead>Status</TableHead>
               <TableHead />
             </TableRow>
           </TableHeader>
           <TableBody>
-            {skills.map((s) => (
+            {skills
+              .filter((s) => effectFilter === "all" || s.effect === effectFilter)
+              .map((s) => (
               <TableRow key={s.name} className="hover:bg-muted/50">
                 <TableCell className="font-medium">{s.name}</TableCell>
                 <TableCell className="text-sm text-muted-foreground max-w-xs truncate">
@@ -265,6 +292,11 @@ export default function SkillsPage() {
                 <TableCell>
                   <Badge variant={s.trigger === "watch" ? "secondary" : "outline"}>
                     {s.trigger}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" className={EFFECT_COLORS[s.effect]}>
+                    {s.effect}
                   </Badge>
                 </TableCell>
                 <TableCell className="text-xs text-muted-foreground max-w-xs truncate">
@@ -320,6 +352,7 @@ export default function SkillsPage() {
             ))}
           </TableBody>
         </Table>
+        </>
       )}
 
       <SkillForm

--- a/web/src/app/tools/page.tsx
+++ b/web/src/app/tools/page.tsx
@@ -48,6 +48,15 @@ const EFFECT_COLORS: Record<Effect, string> = {
   mixed: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-300",
 };
 
+// base-ui's <SelectValue> renders the raw value key, not the selected item's
+// label. Pass the label text as children so the trigger shows "Risk-based"
+// instead of "default".
+const APPROVAL_LABELS: Record<string, string> = {
+  default: "Risk-based",
+  always: "Always",
+  never: "Auto-allow",
+};
+
 function EffectBadge({ effect }: { effect: Effect }) {
   return (
     <Badge variant="outline" className={EFFECT_COLORS[effect]}>
@@ -138,10 +147,37 @@ function ToolsPageInner() {
   // Bulk-selection state (ephemeral — cleared after save).
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
-  const hasPending =
-    Object.keys(pendingOverrides).length > 0 ||
-    pendingDeny !== null ||
-    Object.keys(pendingApproval).length > 0;
+  // `hasPending` must reflect *effective* changes, not just stale entries in
+  // the pending maps: a user can edit and then revert a field, and the save
+  // bar should disappear.
+  const originalDeny = new Set(
+    (tools ?? []).filter((t) => t.status === "disabled").map((t) => t.name)
+  );
+
+  const denyChanged = (() => {
+    if (pendingDeny === null) return false;
+    if (pendingDeny.size !== originalDeny.size) return true;
+    for (const n of pendingDeny) if (!originalDeny.has(n)) return true;
+    return false;
+  })();
+
+  const approvalChanged = Object.entries(pendingApproval).some(([name, policy]) => {
+    const tool = tools?.find((t) => t.name === name);
+    const original = tool?.approval_policy ?? null;
+    return policy !== original;
+  });
+
+  const overridesChanged = Object.entries(pendingOverrides).some(([key, value]) => {
+    const [toolName, actionName] = key.split(":");
+    const tool = tools?.find((t) => t.name === toolName);
+    if (!tool) return value !== null;
+    const original = actionName
+      ? tool.actions?.find((a) => a.name === actionName)?.risk_override ?? null
+      : tool.risk_override ?? null;
+    return value !== original;
+  });
+
+  const hasPending = denyChanged || approvalChanged || overridesChanged;
 
   const toggleExpand = (name: string) => {
     const next = new Set(expanded);
@@ -553,7 +589,9 @@ function ToolsPageInner() {
                           onValueChange={(v) => handleApprovalChange(tool.name, v ?? "default")}
                         >
                           <SelectTrigger className="h-7 w-[120px] text-xs" onClick={(e) => e.stopPropagation()}>
-                            <SelectValue />
+                            <SelectValue>
+                              {APPROVAL_LABELS[getEffectiveApproval(tool) ?? "default"]}
+                            </SelectValue>
                           </SelectTrigger>
                           <SelectContent>
                             <SelectItem value="default">Risk-based</SelectItem>

--- a/web/src/app/tools/page.tsx
+++ b/web/src/app/tools/page.tsx
@@ -24,9 +24,9 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Wrench, ChevronRight, Save, Loader2, Search, ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 import { useUrlState, useUrlStateSet } from "@/hooks/use-url-state";
-import type { ToolInfo, ToolAction } from "@/lib/types";
+import type { Effect, ToolInfo, ToolAction } from "@/lib/types";
 
-type SortCol = "name" | "group" | "risk" | "";
+type SortCol = "name" | "group" | "risk" | "effect" | "";
 
 const RISK_COLORS: Record<number, string> = {
   1: "bg-green-500/15 text-green-700 dark:text-green-400",
@@ -41,6 +41,20 @@ const GROUP_COLORS: Record<string, string> = {
   container: "bg-violet-500/12 text-violet-700 dark:text-violet-400",
   admin: "bg-amber-500/12 text-amber-700 dark:text-amber-400",
 };
+
+const EFFECT_COLORS: Record<Effect, string> = {
+  read: "bg-sky-500/12 text-sky-700 dark:text-sky-400",
+  write: "bg-amber-500/12 text-amber-700 dark:text-amber-400",
+  mixed: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-300",
+};
+
+function EffectBadge({ effect }: { effect: Effect }) {
+  return (
+    <Badge variant="outline" className={EFFECT_COLORS[effect]}>
+      {effect}
+    </Badge>
+  );
+}
 
 function RiskBadge({ level, override }: { level: number; override?: number | null }) {
   const effective = override ?? level;
@@ -62,8 +76,12 @@ function ActionRow({ toolName, action, onOverride, pendingValue }: {
   const hasPending = pendingValue !== undefined;
   return (
     <TableRow className="bg-muted/30">
+      <TableCell />
       <TableCell className="pl-10 text-sm text-muted-foreground">{action.name}</TableCell>
       <TableCell />
+      <TableCell>
+        <EffectBadge effect={action.effect} />
+      </TableCell>
       <TableCell>
         <RiskBadge level={action.risk_level} override={action.risk_override} />
       </TableCell>
@@ -107,6 +125,7 @@ function ToolsPageInner() {
   // Search, filter, sort — URL-backed so they survive navigation.
   const [search, setSearch] = useUrlState<string>("q", "");
   const [groupFilter, setGroupFilter] = useUrlState<string>("group", "all");
+  const [effectFilter, setEffectFilter] = useUrlState<string>("effect", "all");
   const [statusFilter, setStatusFilter] = useUrlState<string>("status", "all");
   const [sortCol, setSortCol] = useUrlState<SortCol>("sort", "");
   const [sortDir, setSortDir] = useUrlState<"asc" | "desc">("dir", "asc");
@@ -115,6 +134,9 @@ function ToolsPageInner() {
   const [pendingOverrides, setPendingOverrides] = useState<Record<string, number | null>>({});
   const [pendingDeny, setPendingDeny] = useState<Set<string> | null>(null);
   const [pendingApproval, setPendingApproval] = useState<Record<string, string | null>>({});
+
+  // Bulk-selection state (ephemeral — cleared after save).
+  const [selected, setSelected] = useState<Set<string>>(new Set());
 
   const hasPending =
     Object.keys(pendingOverrides).length > 0 ||
@@ -157,6 +179,41 @@ function ToolsPageInner() {
 
   const handleOverride = (compound: string, value: number | null) => {
     setPendingOverrides((prev) => ({ ...prev, [compound]: value }));
+  };
+
+  const toggleSelected = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const clearSelection = () => setSelected(new Set());
+
+  const bulkSetEnabled = (enabled: boolean) => {
+    if (!tools || selected.size === 0) return;
+    const current = pendingDeny ?? new Set(
+      tools.filter((t) => t.status === "disabled").map((t) => t.name)
+    );
+    const next = new Set(current);
+    for (const name of selected) {
+      if (enabled) next.delete(name);
+      else next.add(name);
+    }
+    setPendingDeny(next);
+  };
+
+  const bulkSetApproval = (value: string) => {
+    if (selected.size === 0) return;
+    setPendingApproval((prev) => {
+      const next = { ...prev };
+      for (const name of selected) {
+        next[name] = value === "default" ? null : value;
+      }
+      return next;
+    });
   };
 
   const handleSave = async () => {
@@ -218,13 +275,14 @@ function ToolsPageInner() {
       setPendingOverrides({});
       setPendingDeny(null);
       setPendingApproval({});
+      clearSelection();
       mutate();
     } finally {
       setSaving(false);
     }
   };
 
-  const toggleSort = (col: "name" | "group" | "risk") => {
+  const toggleSort = (col: "name" | "group" | "risk" | "effect") => {
     if (sortCol === col) {
       setSortDir(sortDir === "asc" ? "desc" : "asc");
     } else {
@@ -245,6 +303,7 @@ function ToolsPageInner() {
         if (!t.name.toLowerCase().includes(q) && !t.description.toLowerCase().includes(q)) return false;
       }
       if (groupFilter !== "all" && t.group !== groupFilter) return false;
+      if (effectFilter !== "all" && t.effect !== effectFilter) return false;
       if (statusFilter !== "all" && t.status !== statusFilter) return false;
       return true;
     })
@@ -253,11 +312,28 @@ function ToolsPageInner() {
       const dir = sortDir === "asc" ? 1 : -1;
       if (sortCol === "name") return a.name.localeCompare(b.name) * dir;
       if (sortCol === "group") return a.group.localeCompare(b.group) * dir;
+      if (sortCol === "effect") return a.effect.localeCompare(b.effect) * dir;
       if (sortCol === "risk") return (getMaxRisk(a) - getMaxRisk(b)) * dir;
       return 0;
     });
 
-  const SortIcon = ({ col }: { col: "name" | "group" | "risk" }) => {
+  const filteredNames = filteredTools.map((t) => t.name);
+  const allFilteredSelected =
+    filteredNames.length > 0 && filteredNames.every((n) => selected.has(n));
+
+  const toggleSelectAllFiltered = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allFilteredSelected) {
+        for (const n of filteredNames) next.delete(n);
+      } else {
+        for (const n of filteredNames) next.add(n);
+      }
+      return next;
+    });
+  };
+
+  const SortIcon = ({ col }: { col: "name" | "group" | "risk" | "effect" }) => {
     if (sortCol !== col) return <ArrowUpDown className="h-3 w-3 ml-1 opacity-40" />;
     return sortDir === "asc"
       ? <ArrowUp className="h-3 w-3 ml-1" />
@@ -289,27 +365,47 @@ function ToolsPageInner() {
               className="pl-8 h-8 text-sm"
             />
           </div>
-          <Select value={groupFilter} onValueChange={(v) => setGroupFilter(String(v ?? "all"))}>
-            <SelectTrigger className="h-8 w-[130px] text-xs">
-              <SelectValue placeholder="All groups" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All groups</SelectItem>
-              <SelectItem value="monitor">Monitor</SelectItem>
-              <SelectItem value="container">Container</SelectItem>
-              <SelectItem value="admin">Admin</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select value={statusFilter} onValueChange={(v) => setStatusFilter(String(v ?? "all"))}>
-            <SelectTrigger className="h-8 w-[130px] text-xs">
-              <SelectValue placeholder="All statuses" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All statuses</SelectItem>
-              <SelectItem value="enabled">Enabled</SelectItem>
-              <SelectItem value="disabled">Disabled</SelectItem>
-            </SelectContent>
-          </Select>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">Group:</span>
+            <Select value={groupFilter} onValueChange={(v) => setGroupFilter(String(v ?? "all"))}>
+              <SelectTrigger className="h-8 w-[120px] text-xs">
+                <SelectValue placeholder="All" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All</SelectItem>
+                <SelectItem value="monitor">Monitor</SelectItem>
+                <SelectItem value="container">Container</SelectItem>
+                <SelectItem value="admin">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">Effect:</span>
+            <Select value={effectFilter} onValueChange={(v) => setEffectFilter(String(v ?? "all"))}>
+              <SelectTrigger className="h-8 w-[100px] text-xs">
+                <SelectValue placeholder="All" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All</SelectItem>
+                <SelectItem value="read">Read</SelectItem>
+                <SelectItem value="write">Write</SelectItem>
+                <SelectItem value="mixed">Mixed</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">Status:</span>
+            <Select value={statusFilter} onValueChange={(v) => setStatusFilter(String(v ?? "all"))}>
+              <SelectTrigger className="h-8 w-[110px] text-xs">
+                <SelectValue placeholder="All" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All</SelectItem>
+                <SelectItem value="enabled">Enabled</SelectItem>
+                <SelectItem value="disabled">Disabled</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
         </div>
       )}
 
@@ -320,14 +416,77 @@ function ToolsPageInner() {
         </div>
       ) : (
         <>
+          {hasPending && (
+            <div className="sticky top-0 z-20 flex items-center justify-between rounded-md border border-primary/30 bg-primary/10 px-3 py-2 backdrop-blur-sm">
+              <span className="text-xs text-muted-foreground">You have unsaved changes.</span>
+              <div className="flex items-center gap-3">
+                <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={persist}
+                    onChange={(e) => setPersist(e.target.checked)}
+                    className="rounded"
+                  />
+                  Save to disk
+                </label>
+                <Button size="sm" onClick={handleSave} disabled={saving}>
+                  {saving ? (
+                    <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                  ) : (
+                    <Save className="h-3.5 w-3.5 mr-1" />
+                  )}
+                  Save Changes
+                </Button>
+              </div>
+            </div>
+          )}
+          {selected.size > 0 && (
+            <div className="flex flex-wrap items-center gap-3 rounded-md border bg-muted/40 px-3 py-2">
+              <span className="text-xs font-medium">{selected.size} selected</span>
+              <Button size="sm" variant="outline" onClick={() => bulkSetEnabled(true)}>
+                Enable
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => bulkSetEnabled(false)}>
+                Disable
+              </Button>
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">Approval:</span>
+                <Select value="" onValueChange={(v) => bulkSetApproval(String(v ?? "default"))}>
+                  <SelectTrigger className="h-7 w-[140px] text-xs">
+                    <SelectValue placeholder="Set for all" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="default">Risk-based</SelectItem>
+                    <SelectItem value="always">Always</SelectItem>
+                    <SelectItem value="never">Auto-allow</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button size="sm" variant="ghost" onClick={clearSelection} className="ml-auto text-xs">
+                Clear
+              </Button>
+            </div>
+          )}
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="w-9">
+                  <input
+                    type="checkbox"
+                    checked={allFilteredSelected}
+                    onChange={toggleSelectAllFiltered}
+                    aria-label="Select all visible tools"
+                    className="rounded"
+                  />
+                </TableHead>
                 <TableHead className="cursor-pointer select-none" onClick={() => toggleSort("name")}>
                   <span className="flex items-center">Name<SortIcon col="name" /></span>
                 </TableHead>
                 <TableHead className="cursor-pointer select-none" onClick={() => toggleSort("group")}>
                   <span className="flex items-center">Group<SortIcon col="group" /></span>
+                </TableHead>
+                <TableHead className="cursor-pointer select-none" onClick={() => toggleSort("effect")}>
+                  <span className="flex items-center">Effect<SortIcon col="effect" /></span>
                 </TableHead>
                 <TableHead className="cursor-pointer select-none" onClick={() => toggleSort("risk")}>
                   <span className="flex items-center">Risk<SortIcon col="risk" /></span>
@@ -340,7 +499,7 @@ function ToolsPageInner() {
             <TableBody>
               {filteredTools.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={6} className="text-center text-sm text-muted-foreground py-8">
+                  <TableCell colSpan={8} className="text-center text-sm text-muted-foreground py-8">
                     No tools match your filters
                   </TableCell>
                 </TableRow>
@@ -354,6 +513,15 @@ function ToolsPageInner() {
                       className={`hover:bg-muted/50${isMulti ? " cursor-pointer" : ""}`}
                       onClick={() => isMulti && toggleExpand(tool.name)}
                     >
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          checked={selected.has(tool.name)}
+                          onChange={() => toggleSelected(tool.name)}
+                          aria-label={`Select ${tool.name}`}
+                          className="rounded"
+                        />
+                      </TableCell>
                       <TableCell className="font-medium">
                         <span className="flex items-center gap-1.5">
                           {isMulti && (
@@ -368,6 +536,9 @@ function ToolsPageInner() {
                         <Badge variant="outline" className={GROUP_COLORS[tool.group] ?? ""}>
                           {tool.group}
                         </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <EffectBadge effect={tool.effect} />
                       </TableCell>
                       <TableCell>
                         {tool.risk_level != null ? (
@@ -436,27 +607,6 @@ function ToolsPageInner() {
             </TableBody>
           </Table>
 
-          {hasPending && (
-            <div className="flex items-center justify-between pt-2 border-t">
-              <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                <input
-                  type="checkbox"
-                  checked={persist}
-                  onChange={(e) => setPersist(e.target.checked)}
-                  className="rounded"
-                />
-                Save to disk
-              </label>
-              <Button size="sm" onClick={handleSave} disabled={saving}>
-                {saving ? (
-                  <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
-                ) : (
-                  <Save className="h-3.5 w-3.5 mr-1" />
-                )}
-                Save Changes
-              </Button>
-            </div>
-          )}
         </>
       )}
     </div>

--- a/web/src/app/tools/page.tsx
+++ b/web/src/app/tools/page.tsx
@@ -27,6 +27,24 @@ import { useUrlState, useUrlStateSet } from "@/hooks/use-url-state";
 import type { Effect, ToolInfo, ToolAction } from "@/lib/types";
 
 type SortCol = "name" | "group" | "risk" | "effect" | "";
+type SortDir = "asc" | "desc";
+
+// Sort is persisted as a single URL param so sequential setter calls from
+// `toggleSort` don't race against each other via `router.replace`. Empty
+// sortCol maps to no param.
+function parseSortParam(raw: string): { col: SortCol; dir: SortDir } {
+  if (!raw) return { col: "", dir: "asc" };
+  if (raw.startsWith("-")) {
+    const col = raw.slice(1) as SortCol;
+    return { col, dir: "desc" };
+  }
+  return { col: raw as SortCol, dir: "asc" };
+}
+
+function serializeSortParam(col: SortCol, dir: SortDir): string {
+  if (!col) return "";
+  return dir === "desc" ? `-${col}` : col;
+}
 
 const RISK_COLORS: Record<number, string> = {
   1: "bg-green-500/15 text-green-700 dark:text-green-400",
@@ -136,8 +154,8 @@ function ToolsPageInner() {
   const [groupFilter, setGroupFilter] = useUrlState<string>("group", "all");
   const [effectFilter, setEffectFilter] = useUrlState<string>("effect", "all");
   const [statusFilter, setStatusFilter] = useUrlState<string>("status", "all");
-  const [sortCol, setSortCol] = useUrlState<SortCol>("sort", "");
-  const [sortDir, setSortDir] = useUrlState<"asc" | "desc">("dir", "asc");
+  const [sortParam, setSortParam] = useUrlState<string>("sort", "");
+  const { col: sortCol, dir: sortDir } = parseSortParam(sortParam);
 
   // Track pending config changes
   const [pendingOverrides, setPendingOverrides] = useState<Record<string, number | null>>({});
@@ -320,10 +338,9 @@ function ToolsPageInner() {
 
   const toggleSort = (col: "name" | "group" | "risk" | "effect") => {
     if (sortCol === col) {
-      setSortDir(sortDir === "asc" ? "desc" : "asc");
+      setSortParam(serializeSortParam(col, sortDir === "asc" ? "desc" : "asc"));
     } else {
-      setSortCol(col);
-      setSortDir("asc");
+      setSortParam(serializeSortParam(col, "asc"));
     }
   };
 

--- a/web/src/components/skills/skill-form.tsx
+++ b/web/src/components/skills/skill-form.tsx
@@ -20,7 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { HostInfo, IncidentFamilyInfo, Skill } from "@/lib/types";
+import type { Effect, HostInfo, IncidentFamilyInfo, Skill } from "@/lib/types";
 
 interface SkillFormProps {
   open: boolean;
@@ -32,6 +32,7 @@ interface SkillFormProps {
     trigger: string;
     incident_keys: string[];
     allow_custom_incident_prefixes: boolean;
+    effect: Effect;
     instructions: string;
   }) => void;
   skill?: Skill | null;
@@ -44,6 +45,7 @@ export function SkillForm({ open, onOpenChange, onSubmit, skill, incidentFamilie
   const [description, setDescription] = useState(skill?.description ?? "");
   const [selectedHost, setSelectedHost] = useState(skill?.hosts?.[0] ?? "all");
   const [trigger, setTrigger] = useState(skill?.trigger ?? "manual");
+  const [effect, setEffect] = useState<Effect>(skill?.effect ?? "mixed");
   const [incidentKeys, setIncidentKeys] = useState<string[]>(skill?.incident_keys ?? []);
   const [customIncidentKeys, setCustomIncidentKeys] = useState("");
   const [allowCustomIncidentPrefixes, setAllowCustomIncidentPrefixes] = useState(false);
@@ -70,6 +72,7 @@ export function SkillForm({ open, onOpenChange, onSubmit, skill, incidentFamilie
       trigger,
       incident_keys: trigger === "watch" ? mergedIncidentKeys : [],
       allow_custom_incident_prefixes: trigger === "watch" ? allowCustomIncidentPrefixes : false,
+      effect,
       instructions: instructions.trim(),
     });
   };
@@ -199,6 +202,23 @@ export function SkillForm({ open, onOpenChange, onSubmit, skill, incidentFamilie
                 </div>
               </div>
             )}
+
+            <div className="space-y-2">
+              <Label>Effect</Label>
+              <Select value={effect} onValueChange={(v) => setEffect((v ?? "mixed") as Effect)}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="read">Read — observes only</SelectItem>
+                  <SelectItem value="write">Write — mutates state</SelectItem>
+                  <SelectItem value="mixed">Mixed — both, or depends</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Declare what this skill does to system state. Used for filtering in the catalog.
+              </p>
+            </div>
 
             <div className="space-y-2">
               <Label htmlFor="skill-instructions">Instructions</Label>

--- a/web/src/hooks/use-url-state.ts
+++ b/web/src/hooks/use-url-state.ts
@@ -27,7 +27,7 @@ export function useUrlState<T extends string>(
 
   const setValue = useCallback(
     (next: T) => {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(currentSearchString(searchParams));
       if (!next || next === defaultValue) {
         params.delete(key);
       } else {
@@ -56,7 +56,7 @@ export function useUrlStateSet(key: string): [Set<string>, (next: Set<string>) =
 
   const setValue = useCallback(
     (next: Set<string>) => {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(currentSearchString(searchParams));
       if (next.size === 0) {
         params.delete(key);
       } else {
@@ -88,7 +88,7 @@ export function useUrlStateNumber(
 
   const setValue = useCallback(
     (next: number) => {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(currentSearchString(searchParams));
       if (next === defaultValue) {
         params.delete(key);
       } else {
@@ -101,4 +101,20 @@ export function useUrlStateNumber(
   );
 
   return [value, setValue];
+}
+
+/**
+ * Return the live URL search string when possible. `useSearchParams()` reflects
+ * the snapshot at render time — if two setters from different `useUrlState`
+ * hooks fire in the same event handler, the second one would otherwise race
+ * against the first's `router.replace()` and clobber it. Next.js's
+ * `router.replace()` updates `window.location` synchronously via
+ * `history.replaceState()`, so reading from the window lets sequential writes
+ * compose.
+ */
+function currentSearchString(searchParams: ReturnType<typeof useSearchParams>): string {
+  if (typeof window !== "undefined") {
+    return window.location.search.replace(/^\?/, "");
+  }
+  return searchParams.toString();
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,5 +1,7 @@
 // TypeScript types matching the API schemas
 
+export type Effect = "read" | "write" | "mixed";
+
 export interface ContainerInfo {
   name: string;
   image: string;
@@ -109,6 +111,7 @@ export interface Skill {
   trigger: string;
   enabled: boolean;
   incident_keys: string[];
+  effect: Effect;
   instructions: string;
 }
 
@@ -323,6 +326,7 @@ export interface ToolAction {
   name: string;
   risk_level: number;
   risk_override: number | null;
+  effect: Effect;
 }
 
 export interface ToolInfo {
@@ -335,6 +339,7 @@ export interface ToolInfo {
   risk_override: number | null;
   status: "enabled" | "disabled";
   approval_policy: "always" | "never" | null;
+  effect: Effect;
 }
 
 export interface ConfigResponse {


### PR DESCRIPTION
## Problem

Squire's tools are hard to reason about at a glance. A user browsing the Tools or Skills pages can't tell which tools *observe* system state versus which *mutate* it — the distinction is implicit in the Monitor/Container/Admin group labels and integer risk levels, but nothing names it directly. Risk is a severity axis, not a read/write axis.

The Tools page also had no way to edit more than one tool at a time: enabling or disabling all 14 tools required 14 individual clicks, and the Save Changes button was at the bottom of the page where it was easy to miss.

Finally, while testing the new bulk-disable flow, I found that adding a multi-action tool like `docker_container` to `tools_deny` did not actually block its actions. `docker_ps` (single-action) was blocked correctly, but `docker_container:inspect` sailed through. Users could disable "all tools" from the UI and Squire would still execute calls.

## Context

- Tools live in `src/squire/tools/` with a `RISK_LEVEL` (single-action) or `RISK_LEVELS: dict` (multi-action) per module and a central `TOOL_RISK_LEVELS` in `tools/__init__.py`.
- Skills follow the Open Agent Skills spec with Squire-specific fields under a `metadata` key in frontmatter.
- The risk gate (`src/squire/callbacks/risk_gate.py`) hands an `Action(name=compound_name, ...)` to `agent-risk-engine`'s `RuleGate`, whose denied-set match is an exact string compare. For `docker_container`, the compound name is `docker_container:inspect` but the denied set from `tools_deny` contained bare `docker_container` — no match.

This PR was planned via `/Users/will/.claude/plans/managing-and-searching-through-wild-treasure.md`; the deny fix surfaced during manual verification of the bulk-disable UI.

## Solution

**Effect classification (UI-only metadata).** Every tool declares an `EFFECT` of `read` / `write` / `mixed`. Multi-action tools declare per-action `EFFECTS: dict[str, Effect]`; the tool-level value is derived by `derive_effect()` (all-read → `read`, all-write → `write`, else `mixed`). Authors declare intent explicitly — a completeness test fails if a registered tool is missing its effect. Skills carry the same field via optional frontmatter `metadata.effect` (default `"mixed"`). Effect is deliberately *not* plumbed into the risk gate, guardrails, or approval policy today — it is orthogonal UI metadata. Mixing it into risk scoring would conflate severity with action semantics.

**UI: column + filter + badge on both pages.** Tools and Skills each render an Effect column with a colored badge (sky / amber / zinc to match existing palette) and a dropdown filter. The Tools page filter is URL-backed, matching the existing `group` / `status` filters. Each filter dropdown in the toolbar now has an inline label ("Group:", "Effect:", "Status:") because the base-ui `<Select>` shows the raw value, not the item label, and unlabeled "all" dropdowns confuse users.

**Bulk edit on Tools.** Added a checkbox column and a bulk action bar that appears when rows are selected. The select-all checkbox acts on the filtered view. Bulk actions (Enable / Disable / Approval) stage into the existing `pendingDeny` / `pendingApproval` state, so there's no new endpoint and no behavior divergence from per-row edits.

**Sticky Save bar.** The Save Changes control moved from a bottom footer to a sticky primary-colored bar at the top of the table, visible whenever there are unsaved edits. This is unmissable with any number of rows.

**Multi-action deny fix.** The risk gate now checks the bare `tool_name` against the denied set explicitly, in addition to whatever `RuleGate` does with the compound name. This preserves the UX that disabling a whole tool disables all its actions without touching `agent-risk-engine`'s public surface or the session-state schema.

## Testing

### Unit tests

- `tests/test_tools/test_tool_effects.py` (new, 11 tests) — registry-completeness (`ALL_TOOLS` names == `TOOL_EFFECTS` keys), per-action coverage (every `tool:action` in `TOOL_RISK_LEVELS` has a matching action in `EFFECTS`), `derive_effect` edge cases, known-value spot checks, single vs multi-action typing.
- `tests/test_api/test_tools_endpoint.py::TestEffect` (6 tests) — `/api/tools` exposes `effect` per tool and per action; multi-action tools derive `mixed`; `docker_volume`/`docker_network` (all-read) derive `read`.
- `tests/test_skills.py` — skill `effect` defaults to `"mixed"`, round-trips to `metadata.effect`, and the default is omitted from rendered frontmatter.
- `tests/test_skills_api.py` — `SkillCreate`/`SkillUpdate` round-trip `effect`; bootstrap playbooks seeded as `write`.
- `tests/test_callbacks/test_risk_gate_factory.py` — two new regression tests: single-action denied-tool block, and multi-action tool deny blocks every action (`inspect`, `remove`, ...).

### Integration / manual

- `make ci` ran after each phase; final run: **501 passed, 3 warnings** (warnings are unrelated google-adk experimental-feature notices).
- `make web` with `curl -s localhost:8420/api/tools | jq` confirms every tool has `effect` and multi-action tools expose `actions[*].effect`.
- Manually verified in browser: Effect column renders on `/tools` and `/skills`; filter dropdown narrows both tables; Tools URL reflects `?effect=read` and survives refresh; bulk select-all + Disable writes all 14 tool names to `tools_deny` (confirmed via `/api/config`); after the fix, chat attempts to call `docker_container:inspect` are blocked with `[BLOCKED] … is disabled`.

## Reviewer Validation

1. `uv run pytest tests/test_tools/test_tool_effects.py tests/test_api/test_tools_endpoint.py tests/test_callbacks/test_risk_gate_factory.py tests/test_skills.py tests/test_skills_api.py -v` — expect all passing.
2. `make ci` — expect all green.
3. `make web` and visit `http://localhost:8420/tools`:
   - Column order: checkbox | Name | Group | Effect | Risk | Approval | Status | Override.
   - `system_info` shows `read`; `run_command` shows `mixed`; `docker_container` shows `mixed` with `inspect=read` / `remove=write` when expanded.
   - Selecting rows reveals the bulk action bar; clicking Disable + Save Changes adds the tools to `tools_deny`.
   - Filter `?effect=read` in the URL preserves across refresh.
4. Start a chat session with all tools disabled, ask "check containers". Expect every tool call (including `docker_container:inspect`, `systemctl:status`, …) to return `[BLOCKED] … is disabled` rather than succeeding.
5. Skim `src/squire/callbacks/risk_gate.py` diff and confirm the new `denied_tools` check is above the `agent-risk-engine` evaluation path — belt-and-suspenders relative to the RuleGate's own denied-set handling.

## TODOs / Follow-Ups

- Effect is UI-only. If we want it to participate in guardrails (e.g. a `tools_effect_overrides` field, or letting skills restrict themselves to `read`-effect tools), that's a separate design conversation — intentionally out of scope here.
- The Skills page filter uses local `useState`, not URL state, to match the rest of that page's filters. Upgrading to `useUrlState` across the Skills page is a minor follow-up.
- Approval-bulk dropdown resets visually after each selection (stateless `value=""`), because each use sets per-tool overrides rather than a single shared state. Works correctly, but the empty trigger briefly shows the placeholder — acceptable for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)