### PR TITLE
feat(config): DB-backed config overrides with provenance UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **DB-backed config overrides:** UI edits to `app`, `llm`, `watch`, `guardrails`, `notifications`, and `skills` now persist as rows in a new `config_overrides` SQLite table (auto-created on first boot) and override `squire.toml` at load time. `squire.toml` is user-owned and read-only from the app's perspective. Pydantic config loaders compose a new `DatabaseOverrideSource` between env and TOML, so the precedence is **env vars > DB overrides > `squire.toml` > code defaults** for every mutable section. `DatabaseConfig` deliberately opts out of DB overrides to avoid a chicken-and-egg path resolution loop.
+- **Config provenance in API:** `ConfigSectionMeta` now includes a `sources` map (`{field: "env" | "db" | "toml" | "default"}`) so `GET /api/config` reports where each field's effective value came from.
+- **Reset endpoints:** `DELETE /api/config/{section}` and `DELETE /api/config/{section}/{field}` clear UI-driven overrides so values revert to TOML/defaults. Both rebuild the in-memory singleton, rewire downstream services (notifier/guardrails/skills), and enqueue a watch reload command.
+- **Config UI provenance indicators:** Each config field shows a small database pip when its current value came from a UI override; clicking the pip deletes that single override. A "Reset" button on each section header clears every DB override for that section at once.
+- **Watch subprocess deep reload:** A new `reload_config` command (enqueued automatically by any PATCH/DELETE on `/api/config`) rebuilds `WatchConfig`, `GuardrailsConfig`, `NotificationsConfig`, and the `NotificationRouter` from DB + TOML + defaults, closes the old notifier, and re-attaches fresh risk gates to the running agent (handles both single-agent and multi-agent modes). `_interruptible_sleep` now reads its interval through a getter so a mid-sleep reload that shortens `watch.interval_minutes` takes effect before the next cycle fires.
+
+### Changed
+
+- **Configuration UI:** Removed the "Save to disk" checkbox from every config form. UI edits now always go to the DB and live-apply; use the section Reset or per-field pip to revert. The Watch page drawer now PATCHes `/api/config/watch` + `/api/config/guardrails` directly and revalidates SWR caches so reopening the drawer shows fresh values.
+
+### Removed
+
+- **`PUT /api/watch/config`** — UI should use `PATCH /api/config/watch` (and `PATCH /api/config/guardrails` for risk tolerance) instead. The legacy "update_config" watch command is gone; the subprocess only accepts `reload_config`.
+- **`WatchConfigUpdate` schema** and the `persist` query parameter on `PATCH /api/config/*` — no longer used now that UI edits flow through DB overrides.
+
+### Migration
+
+- `config_overrides` is created automatically on first boot — no manual migration needed.
+- Operators relying on `PUT /api/watch/config` should switch to `PATCH /api/config/watch`. Scripts using `?persist=true` should drop the parameter; edits are now always durable (stored in `squire.db`).
+- Treat `squire.db` with the same sensitivity as `squire.toml`: webhook URLs and SMTP passwords edited via the UI now land there in plaintext.
+- `squire.toml` can be mounted read-only in Docker.
+
 ## [0.18.0] — 2026-04-18
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,7 +230,7 @@ Watch mode is started with `make watch` or `uv run squire watch`. The web UI **W
 | CLI                 | Typer                       | Command-line interface for scripting and quick tasks                    |
 | Database            | aiosqlite (SQLite)          | Session persistence, events, alert rules, watch state                   |
 | Remote Access       | asyncssh                    | SSH-based multi-machine management                                      |
-| Config              | Pydantic Settings           | Layered config (env vars > TOML > defaults)                             |
+| Config              | Pydantic Settings           | Layered config (env vars > DB overrides > TOML > defaults)              |
 | HTTP Client         | httpx                       | Webhook notifications, health checks                                    |
 
 
@@ -252,7 +252,8 @@ All state is stored in a single SQLite file (default: `~/.local/share/squire/squ
 | `watch_cycles`    | Canonical per-cycle aggregates (tokens, tool/incident counts, status, timing) keyed by `cycle_id` |
 | `watch_reports`   | Structured completion reports (watch- and session-level JSON digests)                 |
 | `watch_events`    | Append-only stream per cycle (`cycle_id`, `watch_id`, `watch_session_id`): tokens, tool calls, phases, incidents, cycle boundaries |
-| `watch_commands`  | Commands from the API to the watch process (`start`, `stop`, `update_config`)         |
+| `watch_commands`  | Commands from the API to the watch process (`start`, `stop`, `reload_config`)         |
+| `config_overrides` | Per-field UI overrides (section, field, value_json) that take precedence over `squire.toml` at load time |
 | `watch_approvals` | Approval requests from watch mode (pending / approved / denied)                     |
 | `managed_hosts`   | Remote hosts registered via the Hosts page (address, SSH config, tags, services)      |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,23 +1,30 @@
 # Configuration Reference
 
-Squire is configured through a TOML file and environment variables.
+Squire is configured through a TOML file, environment variables, and runtime UI edits. The TOML file is user-owned and read-only from the app's perspective; UI-driven changes land in the database.
 
 ## Precedence
 
 Settings are resolved in order (highest priority first):
 
-1. **Environment variables** (`SQUIRE_`*)
-2. **TOML config file** -- first found from:
+1. **Environment variables** (`SQUIRE_`*) -- always win; fields with an env var are locked in the UI.
+2. **DB overrides** -- rows in the `config_overrides` table of `squire.db`, written by PATCH/DELETE on `/api/config` and by the Configuration UI.
+3. **TOML config file** -- first found from:
   - `./squire.toml` (project directory)
   - `~/.config/squire/squire.toml` (user config)
   - `/etc/squire/squire.toml` (system-wide)
-3. **Built-in defaults**
+4. **Built-in defaults**
+
+`GET /api/config` reports the effective source for every field under `sections[...].sources`; the UI renders a small database pip next to any field whose current value is a DB override. Click the pip (or the section-level **Reset** button) to delete overrides and revert to TOML/defaults.
+
+`DatabaseConfig` (the `[db]` section) is intentionally never overridden by DB rows — the DB path has to be resolved before the override layer can read anything.
 
 To get started, copy the example config:
 
 ```bash
 cp squire.example.toml squire.toml
 ```
+
+Because UI edits now always persist in `squire.db`, treat that file with the same sensitivity as `squire.toml`: webhook URLs and SMTP passwords edited through the UI are stored there in plaintext. In Docker, `squire.toml` can now safely be mounted read-only.
 
 > **Looking for model recommendations?** See [Tested Models](#tested-models) for what's been validated.
 

--- a/src/squire/api/routers/config.py
+++ b/src/squire/api/routers/config.py
@@ -1,14 +1,20 @@
-"""Configuration endpoints."""
+"""Configuration endpoints.
+
+Precedence for runtime config: env vars > DB overrides > ``squire.toml`` > code
+defaults. UI edits land as rows in the ``config_overrides`` table; ``squire.toml``
+stays user-owned and is read-only from the app's perspective.
+"""
 
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel
 
 from squire.config import AppConfig, GuardrailsConfig, LLMConfig, NotificationsConfig, WatchConfig
-from squire.config.loader import get_env_overrides, get_toml_path, write_toml_section
+from squire.config.loader import get_env_overrides, get_section, get_toml_path, get_top_level
 from squire.config.notifications import EmailConfig, WebhookConfig
 from squire.config.skills import SkillsConfig
 from squire.notifications.factory import build_notification_router
@@ -22,6 +28,7 @@ from ..schemas import (
     AppConfigUpdate,
     ConfigDetailResponse,
     ConfigSectionMeta,
+    ConfigSource,
     GuardrailsConfigUpdate,
     LLMConfigUpdate,
     LLMModelsResponse,
@@ -34,6 +41,9 @@ router = APIRouter()
 
 # Fields that should never be exposed via the API
 _REDACTED = "••••••"
+
+# Sentinel section name for top-level AppConfig fields (no TOML section).
+_TOP_LEVEL_SECTION = "_top_"
 
 
 def _redact_llm(data: dict) -> dict:
@@ -66,19 +76,21 @@ class _SectionInfo:
     config_cls: type
     update_cls: type[BaseModel]
     env_prefix: str
-    toml_section: str | None  # None = top-level keys
+    toml_section: str | None  # None = top-level keys (AppConfig)
+    db_section: str  # key used in config_overrides.section
     redact: Callable | None = None
 
 
 _SECTIONS: dict[str, _SectionInfo] = {
-    "app": _SectionInfo("app_config", AppConfig, AppConfigUpdate, "SQUIRE_", None),
-    "llm": _SectionInfo("llm_config", LLMConfig, LLMConfigUpdate, "SQUIRE_LLM_", "llm", _redact_llm),
-    "watch": _SectionInfo("watch_config", WatchConfig, WatchConfigPatch, "SQUIRE_WATCH_", "watch"),
+    "app": _SectionInfo("app_config", AppConfig, AppConfigUpdate, "SQUIRE_", None, _TOP_LEVEL_SECTION),
+    "llm": _SectionInfo("llm_config", LLMConfig, LLMConfigUpdate, "SQUIRE_LLM_", "llm", "llm", _redact_llm),
+    "watch": _SectionInfo("watch_config", WatchConfig, WatchConfigPatch, "SQUIRE_WATCH_", "watch", "watch"),
     "guardrails": _SectionInfo(
         "guardrails",
         GuardrailsConfig,
         GuardrailsConfigUpdate,
         "SQUIRE_GUARDRAILS_",
+        "guardrails",
         "guardrails",
     ),
     "notifications": _SectionInfo(
@@ -87,24 +99,71 @@ _SECTIONS: dict[str, _SectionInfo] = {
         NotificationsConfigUpdate,
         "SQUIRE_NOTIFICATIONS_",
         "notifications",
+        "notifications",
         _redact_notifications,
     ),
-    "skills": _SectionInfo("skills_config", SkillsConfig, SkillsConfigUpdate, "SQUIRE_SKILLS_", "skills"),
+    "skills": _SectionInfo(
+        "skills_config",
+        SkillsConfig,
+        SkillsConfigUpdate,
+        "SQUIRE_SKILLS_",
+        "skills",
+        "skills",
+    ),
 }
 
 _IMMUTABLE_SECTIONS = {"database", "hosts"}
 
 
-def _section_meta(attr: str, info: _SectionInfo) -> ConfigSectionMeta:
-    """Build a ConfigSectionMeta for a config singleton."""
-    cfg = getattr(deps, attr, None)
+def _jsonify(value: Any) -> Any:
+    """Convert a Pydantic/Path value into a JSON-friendly representation for DB storage."""
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, list):
+        return [_jsonify(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _jsonify(v) for k, v in value.items()}
+    return value
+
+
+def _compute_toml_keys(info: _SectionInfo) -> set[str]:
+    """Return the set of field names currently set in ``squire.toml`` for this section."""
+    if info.toml_section is None:
+        return set(get_top_level().keys())
+    preserve = {"email"} if info.db_section == "notifications" else None
+    return set(get_section(info.toml_section, preserve=preserve).keys())
+
+
+async def _section_meta(info: _SectionInfo) -> ConfigSectionMeta:
+    """Build a ConfigSectionMeta for a config singleton, including provenance."""
+    cfg = getattr(deps, info.attr, None)
     if cfg is None:
-        return ConfigSectionMeta(values={}, env_overrides=[])
+        return ConfigSectionMeta(values={}, env_overrides=[], sources={})
     values = cfg.model_dump(mode="json")
     if info.redact:
         values = info.redact(values)
-    env_overrides = get_env_overrides(info.env_prefix, type(cfg).model_fields.keys())
-    return ConfigSectionMeta(values=values, env_overrides=env_overrides)
+
+    field_names = list(type(cfg).model_fields.keys())
+    env_overrides = get_env_overrides(info.env_prefix, field_names)
+    db_overrides: dict[str, Any] = {}
+    if deps.db is not None:
+        db_overrides = await deps.db.get_config_overrides(info.db_section)
+    toml_keys = _compute_toml_keys(info)
+
+    sources: dict[str, ConfigSource] = {}
+    for name in field_names:
+        if name in env_overrides:
+            sources[name] = "env"
+        elif name in db_overrides:
+            sources[name] = "db"
+        elif name in toml_keys:
+            sources[name] = "toml"
+        else:
+            sources[name] = "default"
+
+    return ConfigSectionMeta(values=values, env_overrides=env_overrides, sources=sources)
 
 
 # --- GET ---
@@ -123,19 +182,24 @@ async def get_config(
 
     toml_path = get_toml_path()
 
+    db_values: dict = {}
+    db_env_overrides: list[str] = []
+    if deps.db_config is not None:
+        db_values = deps.db_config.model_dump(mode="json")
+        db_env_overrides = get_env_overrides("SQUIRE_DB_", type(deps.db_config).model_fields.keys())
+
     return ConfigDetailResponse(
-        app=_section_meta("app_config", _SECTIONS["app"]),
-        llm=_section_meta("llm_config", _SECTIONS["llm"]),
+        app=await _section_meta(_SECTIONS["app"]),
+        llm=await _section_meta(_SECTIONS["llm"]),
         database=ConfigSectionMeta(
-            values=deps.db_config.model_dump(mode="json") if deps.db_config else {},
-            env_overrides=(
-                get_env_overrides("SQUIRE_DB_", type(deps.db_config).model_fields.keys()) if deps.db_config else []
-            ),
+            values=db_values,
+            env_overrides=db_env_overrides,
+            sources={},
         ),
-        notifications=_section_meta("notif_config", _SECTIONS["notifications"]),
-        guardrails=_section_meta("guardrails", _SECTIONS["guardrails"]),
-        watch=_section_meta("watch_config", _SECTIONS["watch"]),
-        skills=_section_meta("skills_config", _SECTIONS["skills"]),
+        notifications=await _section_meta(_SECTIONS["notifications"]),
+        guardrails=await _section_meta(_SECTIONS["guardrails"]),
+        watch=await _section_meta(_SECTIONS["watch"]),
+        skills=await _section_meta(_SECTIONS["skills"]),
         hosts=host_configs,
         toml_path=str(toml_path) if toml_path else None,
     )
@@ -195,7 +259,6 @@ def _merge_webhooks(existing: list[WebhookConfig], incoming: list[dict]) -> list
         name = wh_dict.get("name", "")
         old = existing_by_name.get(name)
         if old:
-            # Preserve redacted URL/headers from existing webhook
             if wh_dict.get("url") == _REDACTED:
                 wh_dict["url"] = old.url
             headers = wh_dict.get("headers", {})
@@ -228,26 +291,38 @@ def _merge_email(existing: EmailConfig | None, incoming: dict) -> EmailConfig:
     return EmailConfig.model_validate(base)
 
 
-def _persist_value(v):
-    """JSON/TOML-friendly value for ``write_toml_section``."""
-    if hasattr(v, "model_dump"):
-        return v.model_dump()
-    if isinstance(v, Path):
-        return str(v)
-    if isinstance(v, list) and v and hasattr(v[0], "model_dump"):
-        return [x.model_dump() for x in v]
-    return v
+async def _rewire_after_update(section: str, new_config: Any) -> None:
+    """Re-attach downstream services that hold references to a mutated config."""
+    if section == "notifications":
+        old_notifier = deps.notifier
+        deps.notifier = build_notification_router(new_config, db=deps.db)
+        tools_set_notifier(deps.notifier)
+        if old_notifier is not None:
+            await old_notifier.close()
+    elif section == "guardrails":
+        tools_set_guardrails(new_config)
+    elif section == "skills":
+        deps.skills_service = SkillService(new_config.path)
 
 
-@router.patch("/{section}")
-async def patch_config(
-    section: str,
-    body: dict = Body(...),
-    persist: bool = Query(False),
-):
+async def _enqueue_reload_command() -> None:
+    """Fire-and-forget ``reload_config`` command for the watch subprocess."""
+    if deps.db is None:
+        return
+    try:
+        await deps.db.insert_watch_command("reload_config")
+    except Exception:
+        # A failure to enqueue shouldn't fail the API call; watch will next
+        # pick up overrides on its next natural restart.
+        pass
+
+
+@router.patch("/{section}", response_model=ConfigSectionMeta)
+async def patch_config(section: str, body: dict = Body(...)):
     """Update a configuration section at runtime.
 
-    Only changed fields need to be sent. Use ``?persist=true`` to also write to squire.toml.
+    Only changed fields need to be sent. Writes land in the ``config_overrides``
+    DB table and override ``squire.toml`` at load time. Use ``DELETE`` to revert.
     """
     if section in _IMMUTABLE_SECTIONS:
         raise HTTPException(status_code=404, detail=f"Section '{section}' is not mutable at runtime")
@@ -255,17 +330,15 @@ async def patch_config(
     if info is None:
         raise HTTPException(status_code=404, detail=f"Unknown config section '{section}'")
 
-    # Strip redacted sentinel values before validation (they may not parse as the target type)
+    # Strip redacted sentinel values before validation.
     cleaned = {k: v for k, v in body.items() if v != _REDACTED}
 
-    # Parse and validate through the update schema
     update = info.update_cls.model_validate(cleaned)
     fields = update.model_dump(exclude_none=True)
 
     if not fields:
         raise HTTPException(status_code=400, detail="No fields to update")
 
-    # Check for env-overridden fields
     current = getattr(deps, info.attr)
     locked = get_env_overrides(info.env_prefix, fields.keys())
     if locked:
@@ -275,7 +348,7 @@ async def patch_config(
             detail=f"Cannot update env-var-overridden fields: {', '.join(env_vars)}",
         )
 
-    # Special handling for notifications webhooks + email
+    # Special handling for notifications webhooks + email (redaction roundtrip).
     if section == "notifications" and "webhooks" in fields:
         fields["webhooks"] = _merge_webhooks(current.webhooks, fields["webhooks"])
     if section == "notifications" and "email" in cleaned:
@@ -285,37 +358,60 @@ async def patch_config(
     if section == "skills" and "path" in fields:
         fields["path"] = Path(fields["path"])
 
-    # Create new config instance with updated fields
+    # Persist overrides to DB (JSON-safe serialization of complex values).
+    if deps.db is not None:
+        jsonified = {k: _jsonify(v) for k, v in fields.items()}
+        await deps.db.set_config_section_overrides(info.db_section, jsonified)
+
+    # Replace the singleton and rewire downstream services.
     new_config = current.model_copy(update=fields)
-
-    # Replace the singleton
     setattr(deps, info.attr, new_config)
+    await _rewire_after_update(section, new_config)
+    await _enqueue_reload_command()
 
-    # Recreate notifier if notifications changed (webhook + email, same as lifespan)
-    if section == "notifications":
-        old_notifier = deps.notifier
-        deps.notifier = build_notification_router(new_config, db=deps.db)
-        tools_set_notifier(deps.notifier)
-        if old_notifier is not None:
-            await old_notifier.close()
+    return await _section_meta(info)
 
-    if section == "guardrails":
-        tools_set_guardrails(new_config)
 
-    if section == "skills":
-        deps.skills_service = SkillService(new_config.path)
+# --- DELETE (reset overrides) ---
 
-    # Persist to TOML if requested
-    persist_path = None
-    if persist:
-        persist_data = {k: _persist_value(getattr(new_config, k)) for k in fields}
-        persist_path = write_toml_section(info.toml_section, persist_data)
 
-    values = new_config.model_dump(mode="json")
-    if info.redact:
-        values = info.redact(values)
+@router.delete("/{section}", response_model=ConfigSectionMeta)
+async def reset_section(section: str):
+    """Reset all UI-driven overrides for a section back to TOML/defaults."""
+    if section in _IMMUTABLE_SECTIONS:
+        raise HTTPException(status_code=404, detail=f"Section '{section}' is not mutable at runtime")
+    info = _SECTIONS.get(section)
+    if info is None:
+        raise HTTPException(status_code=404, detail=f"Unknown config section '{section}'")
 
-    return {
-        "values": values,
-        "persisted": str(persist_path) if persist_path else None,
-    }
+    if deps.db is not None:
+        await deps.db.clear_config_section(info.db_section)
+
+    new_config = info.config_cls()
+    setattr(deps, info.attr, new_config)
+    await _rewire_after_update(section, new_config)
+    await _enqueue_reload_command()
+
+    return await _section_meta(info)
+
+
+@router.delete("/{section}/{field}", response_model=ConfigSectionMeta)
+async def reset_field(section: str, field: str):
+    """Reset a single field's UI-driven override back to TOML/defaults."""
+    if section in _IMMUTABLE_SECTIONS:
+        raise HTTPException(status_code=404, detail=f"Section '{section}' is not mutable at runtime")
+    info = _SECTIONS.get(section)
+    if info is None:
+        raise HTTPException(status_code=404, detail=f"Unknown config section '{section}'")
+    if field not in info.config_cls.model_fields:
+        raise HTTPException(status_code=404, detail=f"Unknown field '{field}' in section '{section}'")
+
+    if deps.db is not None:
+        await deps.db.delete_config_override(info.db_section, field)
+
+    new_config = info.config_cls()
+    setattr(deps, info.attr, new_config)
+    await _rewire_after_update(section, new_config)
+    await _enqueue_reload_command()
+
+    return await _section_meta(info)

--- a/src/squire/api/routers/watch.py
+++ b/src/squire/api/routers/watch.py
@@ -1,7 +1,6 @@
 """Watch mode API endpoints — control, status, and history."""
 
 import asyncio
-import json
 import os
 
 from agent_risk_engine import RuleGate
@@ -12,7 +11,6 @@ from ..schemas import (
     WatchApprovalAction,
     WatchCommandResponse,
     WatchConfigResponse,
-    WatchConfigUpdate,
     WatchCycleSummary,
     WatchReportInfo,
     WatchRunSummary,
@@ -160,16 +158,6 @@ async def watch_config_get(
         max_remote_actions_per_cycle=watch_config.max_remote_actions_per_cycle,
         risk_tolerance=_effective_watch_risk_level(guardrails),
     )
-
-
-@router.put("/config", response_model=WatchCommandResponse)
-async def watch_config_update(update: WatchConfigUpdate, db=Depends(get_db)):
-    """Send config update to the running watch process."""
-    payload = update.model_dump(exclude_none=True)
-    if not payload:
-        raise HTTPException(status_code=400, detail="No fields to update")
-    await db.insert_watch_command("update_config", payload=json.dumps(payload))
-    return WatchCommandResponse(status="ok", message="Config update sent")
 
 
 @router.get("/cycles")

--- a/src/squire/api/schemas.py
+++ b/src/squire/api/schemas.py
@@ -269,9 +269,13 @@ class ConfigResponse(BaseModel):
     hosts: list[dict]
 
 
+ConfigSource = Literal["env", "db", "toml", "default"]
+
+
 class ConfigSectionMeta(BaseModel):
     values: dict
     env_overrides: list[str] = []
+    sources: dict[str, ConfigSource] = Field(default_factory=dict)
 
 
 class ConfigDetailResponse(BaseModel):
@@ -377,21 +381,6 @@ class WatchStatusResponse(BaseModel):
     total_output_tokens: str | None = None
     total_tokens: str | None = None
     last_outcome: str | None = None
-
-
-class WatchConfigUpdate(BaseModel):
-    interval_minutes: int | None = Field(default=None, ge=1)
-    max_tool_calls_per_cycle: int | None = Field(default=None, ge=1)
-    cycle_timeout_seconds: int | None = Field(default=None, ge=30)
-    checkin_prompt: str | None = None
-    notify_on_action: bool | None = None
-    notify_on_blocked: bool | None = None
-    cycles_per_session: int | None = Field(default=None, ge=1)
-    max_context_events: int | None = Field(default=None, ge=10)
-    max_identical_actions_per_cycle: int | None = Field(default=None, ge=1)
-    blocked_action_cooldown_cycles: int | None = Field(default=None, ge=1)
-    max_remote_actions_per_cycle: int | None = Field(default=None, ge=1)
-    risk_tolerance: int | None = Field(default=None, ge=1, le=5)
 
 
 class WatchConfigResponse(BaseModel):

--- a/src/squire/config/app.py
+++ b/src/squire/config/app.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import Field
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
+from .db_source import DatabaseOverrideSource
 from .loader import TomlSectionSource, get_top_level
 
 
@@ -55,6 +56,7 @@ class AppConfig(BaseSettings):
             init_settings,
             env_settings,
             dotenv_settings,
+            DatabaseOverrideSource(settings_cls, "_top_"),
             TomlSectionSource(settings_cls, get_top_level),
             file_secret_settings,
         )

--- a/src/squire/config/database.py
+++ b/src/squire/config/database.py
@@ -25,6 +25,8 @@ class DatabaseConfig(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
+        # DatabaseConfig intentionally omits DatabaseOverrideSource: resolving
+        # the DB path via DB-stored overrides would be a chicken-and-egg loop.
         return (
             init_settings,
             env_settings,

--- a/src/squire/config/db_source.py
+++ b/src/squire/config/db_source.py
@@ -1,0 +1,70 @@
+"""Pydantic settings source that reads UI-driven overrides from the SQLite DB.
+
+Mirrors ``TomlSectionSource`` but pulls from the ``config_overrides`` table.
+Sync-only because pydantic-settings sources run during ``BaseSettings.__init__``;
+uses ``sqlite3`` rather than the async ``aiosqlite`` wrapper.
+
+Precedence for every mutable config: env > DB > TOML > default. This module
+implements the DB layer; the TOML layer lives in ``loader.py``.
+
+``DatabaseConfig`` deliberately does NOT consume this source — resolving the DB
+path would create a chicken-and-egg problem. See ``_resolve_db_path`` below,
+which re-derives the path from env, TOML, and the hardcoded default without
+instantiating ``DatabaseConfig``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+
+
+class DatabaseOverrideSource(PydanticBaseSettingsSource):
+    """Load UI-driven field overrides for a given config section."""
+
+    def __init__(self, settings_cls: type[BaseSettings], section: str) -> None:
+        super().__init__(settings_cls)
+        self._section = section
+
+    def _resolve_db_path(self) -> Path:
+        env = os.environ.get("SQUIRE_DB_PATH")
+        if env:
+            return Path(env)
+        # Avoid importing at module scope to keep the import graph shallow.
+        from .loader import get_section
+
+        toml_path = get_section("db").get("path")
+        if toml_path:
+            return Path(toml_path)
+        return Path.home() / ".local" / "share" / "squire" / "squire.db"
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            path = self._resolve_db_path()
+            if not path.exists():
+                return {}
+            with sqlite3.connect(path) as conn:
+                conn.execute("PRAGMA busy_timeout = 5000")
+                rows = conn.execute(
+                    "SELECT field, value_json FROM config_overrides WHERE section = ?",
+                    (self._section,),
+                ).fetchall()
+        except (sqlite3.OperationalError, FileNotFoundError):
+            # Pre-schema / first boot — behave as if no overrides exist.
+            return {}
+        return {field: json.loads(value_json) for field, value_json in rows}
+
+    def get_field_value(self, field, field_name: str) -> tuple[Any, str, bool]:
+        data = self._load()
+        val = data.get(field_name)
+        return val, field_name, val is not None
+
+    def __call__(self) -> dict[str, Any]:
+        data = self._load()
+        field_names = set(self.settings_cls.model_fields.keys())
+        return {k: v for k, v in data.items() if k in field_names}

--- a/src/squire/config/guardrails.py
+++ b/src/squire/config/guardrails.py
@@ -11,6 +11,7 @@ from pydantic import BeforeValidator, Field
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
 from .app import RiskTolerance, _coerce_risk_tolerance
+from .db_source import DatabaseOverrideSource
 from .loader import TomlSectionSource, get_section
 
 
@@ -36,6 +37,7 @@ class GuardrailsConfig(BaseSettings):
             init_settings,
             env_settings,
             dotenv_settings,
+            DatabaseOverrideSource(settings_cls, "guardrails"),
             TomlSectionSource(settings_cls, partial(get_section, "guardrails")),
             file_secret_settings,
         )

--- a/src/squire/config/llm.py
+++ b/src/squire/config/llm.py
@@ -3,6 +3,7 @@ from functools import partial
 from pydantic import Field
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
+from .db_source import DatabaseOverrideSource
 from .loader import TomlSectionSource, get_section
 
 
@@ -28,6 +29,7 @@ class LLMConfig(BaseSettings):
             init_settings,
             env_settings,
             dotenv_settings,
+            DatabaseOverrideSource(settings_cls, "llm"),
             TomlSectionSource(settings_cls, partial(get_section, "llm")),
             file_secret_settings,
         )

--- a/src/squire/config/notifications.py
+++ b/src/squire/config/notifications.py
@@ -3,6 +3,7 @@ from functools import partial
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
+from .db_source import DatabaseOverrideSource
 from .loader import TomlSectionSource, get_section
 
 
@@ -57,6 +58,7 @@ class NotificationsConfig(BaseSettings):
             init_settings,
             env_settings,
             dotenv_settings,
+            DatabaseOverrideSource(settings_cls, "notifications"),
             TomlSectionSource(settings_cls, partial(get_section, "notifications", preserve={"email"})),
             file_secret_settings,
         )

--- a/src/squire/config/skills.py
+++ b/src/squire/config/skills.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from pydantic import Field
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
+from .db_source import DatabaseOverrideSource
 from .loader import TomlSectionSource, get_section
 
 
@@ -30,6 +31,7 @@ class SkillsConfig(BaseSettings):
             init_settings,
             env_settings,
             dotenv_settings,
+            DatabaseOverrideSource(settings_cls, "skills"),
             TomlSectionSource(settings_cls, partial(get_section, "skills")),
             file_secret_settings,
         )

--- a/src/squire/config/watch.py
+++ b/src/squire/config/watch.py
@@ -9,6 +9,7 @@ from functools import partial
 from pydantic import Field
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
 
+from .db_source import DatabaseOverrideSource
 from .loader import TomlSectionSource, get_section
 
 
@@ -34,6 +35,7 @@ class WatchConfig(BaseSettings):
             init_settings,
             env_settings,
             dotenv_settings,
+            DatabaseOverrideSource(settings_cls, "watch"),
             TomlSectionSource(settings_cls, partial(get_section, "watch")),
             file_secret_settings,
         )

--- a/src/squire/database/service.py
+++ b/src/squire/database/service.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 import aiosqlite
@@ -285,6 +286,20 @@ CREATE TABLE IF NOT EXISTS managed_hosts (
 )
 """
 
+_CREATE_CONFIG_OVERRIDES = """
+CREATE TABLE IF NOT EXISTS config_overrides (
+    section     TEXT NOT NULL,
+    field       TEXT NOT NULL,
+    value_json  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    PRIMARY KEY (section, field)
+)
+"""
+
+_CREATE_CONFIG_OVERRIDES_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_config_overrides_section ON config_overrides(section)
+"""
+
 
 class DatabaseService:
     """Async wrapper around aiosqlite for Squire persistence.
@@ -354,6 +369,8 @@ class DatabaseService:
             _CREATE_WATCH_REPORTS_IDX_WATCH,
             _CREATE_WATCH_REPORTS_IDX_SESSION,
             _CREATE_MANAGED_HOSTS,
+            _CREATE_CONFIG_OVERRIDES,
+            _CREATE_CONFIG_OVERRIDES_INDEX,
         )
         for stmt in core_statements:
             await self._conn.execute(stmt)
@@ -674,6 +691,80 @@ class DatabaseService:
         conn = await self._get_conn()
         await conn.execute("DELETE FROM watch_state")
         await conn.commit()
+
+    # --- Config Overrides ---
+
+    async def get_config_overrides(self, section: str) -> dict[str, Any]:
+        """Return all overrides for a single config section as {field: value}."""
+        conn = await self._get_conn()
+        cursor = await conn.execute(
+            "SELECT field, value_json FROM config_overrides WHERE section = ?",
+            (section,),
+        )
+        rows = await cursor.fetchall()
+        return {row["field"]: json.loads(row["value_json"]) for row in rows}
+
+    async def get_all_config_overrides(self) -> dict[str, dict[str, Any]]:
+        """Return every override grouped by section."""
+        conn = await self._get_conn()
+        cursor = await conn.execute("SELECT section, field, value_json FROM config_overrides")
+        rows = await cursor.fetchall()
+        result: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            result.setdefault(row["section"], {})[row["field"]] = json.loads(row["value_json"])
+        return result
+
+    async def set_config_override(self, section: str, field: str, value: Any) -> None:
+        """Upsert a single override row."""
+        conn = await self._get_conn()
+        now = datetime.now(UTC).isoformat()
+        await conn.execute(
+            """
+            INSERT INTO config_overrides (section, field, value_json, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(section, field) DO UPDATE SET
+                value_json = excluded.value_json,
+                updated_at = excluded.updated_at
+            """,
+            (section, field, json.dumps(value, default=str), now),
+        )
+        await conn.commit()
+
+    async def set_config_section_overrides(self, section: str, mapping: dict[str, Any]) -> None:
+        """Upsert every field in ``mapping`` under ``section`` in one transaction."""
+        if not mapping:
+            return
+        conn = await self._get_conn()
+        now = datetime.now(UTC).isoformat()
+        rows = [(section, field, json.dumps(value, default=str), now) for field, value in mapping.items()]
+        await conn.executemany(
+            """
+            INSERT INTO config_overrides (section, field, value_json, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(section, field) DO UPDATE SET
+                value_json = excluded.value_json,
+                updated_at = excluded.updated_at
+            """,
+            rows,
+        )
+        await conn.commit()
+
+    async def delete_config_override(self, section: str, field: str) -> bool:
+        """Delete a single override row. Returns True if a row was removed."""
+        conn = await self._get_conn()
+        cursor = await conn.execute(
+            "DELETE FROM config_overrides WHERE section = ? AND field = ?",
+            (section, field),
+        )
+        await conn.commit()
+        return cursor.rowcount > 0
+
+    async def clear_config_section(self, section: str) -> int:
+        """Delete every override for a section. Returns the number of rows removed."""
+        conn = await self._get_conn()
+        cursor = await conn.execute("DELETE FROM config_overrides WHERE section = ?", (section,))
+        await conn.commit()
+        return cursor.rowcount
 
     # --- Alert Rules ---
 

--- a/src/squire/watch.py
+++ b/src/squire/watch.py
@@ -12,7 +12,9 @@ import os
 import signal
 import sys
 from collections import defaultdict
+from collections.abc import Callable
 from datetime import UTC, datetime
+from typing import Any
 from uuid import uuid4
 
 from agent_risk_engine import RuleGate
@@ -60,23 +62,6 @@ from .watch_playbooks import route_playbooks_for_incidents
 load_dotenv()
 
 logger = logging.getLogger(__name__)
-
-# Keys allowed on WatchConfig from a live ``update_config`` command (JSON payload).
-_WATCH_LIVE_KEYS = frozenset(
-    {
-        "interval_minutes",
-        "max_tool_calls_per_cycle",
-        "cycle_timeout_seconds",
-        "checkin_prompt",
-        "notify_on_action",
-        "notify_on_blocked",
-        "cycles_per_session",
-        "max_context_events",
-        "max_identical_actions_per_cycle",
-        "blocked_action_cooldown_cycles",
-        "max_remote_actions_per_cycle",
-    }
-)
 
 _WATCH_ROUTING_TIMEOUT_SECONDS = 15
 _WATCH_ROUTING_MAX_LLM_CALLS = 4
@@ -226,24 +211,116 @@ def _build_watch_report(*, watch_id: str, sessions: list[dict], cycles: list[dic
     }
 
 
-def _validated_live_watch_updates(
-    payload: dict,
-    watch_config: WatchConfig,
-) -> tuple[dict, int | None]:
-    """Validate and normalize live watch config updates before applying them."""
-    updates = {key: payload[key] for key in _WATCH_LIVE_KEYS if key in payload}
-    if updates:
-        candidate = watch_config.model_dump()
-        candidate.update(updates)
-        validated = WatchConfig.model_validate(candidate)
-        updates = {key: getattr(validated, key) for key in updates}
+def _make_headless_risk_gate(
+    tool_risk_levels: dict[str, int],
+    *,
+    guardrails: GuardrailsConfig,
+    notifier: NotificationRouter | None,
+    agent_threshold: int | None = None,
+):
+    """Build a headless before_tool_callback bound to the given guardrails/notifier."""
+    return create_risk_gate(
+        tool_risk_levels=tool_risk_levels,
+        risk_overrides=dict(guardrails.tools_risk_overrides),
+        default_threshold=agent_threshold,
+        headless=True,
+        notifier=notifier,
+    )
 
-    risk_tolerance: int | None = None
-    if "risk_tolerance" in payload:
-        risk_tolerance = int(payload["risk_tolerance"])
-        if not 1 <= risk_tolerance <= 5:
-            raise ValueError("risk_tolerance must be between 1 and 5")
-    return updates, risk_tolerance
+
+def _rewire_risk_gates(
+    agent,
+    *,
+    app_config: AppConfig,
+    guardrails: GuardrailsConfig,
+    notifier: NotificationRouter | None,
+) -> None:
+    """Replace ``before_tool_callback`` on the agent (and sub-agents) after a config reload."""
+    if app_config.multi_agent:
+        from .tools.groups import ADMIN_RISK_LEVELS, CONTAINER_RISK_LEVELS, MONITOR_RISK_LEVELS
+        from .tools.notifications import NOTIFIER_RISK_LEVELS
+
+        tolerances = {
+            "Monitor": guardrails.monitor_tolerance,
+            "Container": guardrails.container_tolerance,
+            "Admin": guardrails.admin_tolerance,
+            "Notifier": guardrails.notifier_tolerance,
+        }
+        risk_maps = {
+            "Monitor": MONITOR_RISK_LEVELS,
+            "Container": CONTAINER_RISK_LEVELS,
+            "Admin": ADMIN_RISK_LEVELS,
+            "Notifier": NOTIFIER_RISK_LEVELS,
+        }
+        for sub in getattr(agent, "sub_agents", None) or []:
+            tol = tolerances.get(sub.name)
+            threshold = RuleGate(threshold=tol).threshold if tol is not None else None
+            sub.before_tool_callback = _make_headless_risk_gate(
+                risk_maps.get(sub.name, TOOL_RISK_LEVELS),
+                guardrails=guardrails,
+                notifier=notifier,
+                agent_threshold=threshold,
+            )
+    else:
+        agent.before_tool_callback = _make_headless_risk_gate(
+            TOOL_RISK_LEVELS,
+            guardrails=guardrails,
+            notifier=notifier,
+        )
+
+
+async def _reload_config_from_db(
+    db: DatabaseService,
+    watch_config: WatchConfig,
+    refs: dict[str, Any],
+    *,
+    session_ref: list | None,
+    session_state_template: dict | None,
+) -> None:
+    """Rebuild every mutable config from DB overrides and swap it into the live loop."""
+    new_watch = WatchConfig()
+    new_guardrails = GuardrailsConfig()
+    new_notif = NotificationsConfig()
+
+    # Update watch_config in place so closures elsewhere pick up new values.
+    for field_name in WatchConfig.model_fields:
+        setattr(watch_config, field_name, getattr(new_watch, field_name))
+
+    # Deep-rewire notifier: close old, install new, re-register with tools.
+    old_notifier = refs.get("notifier")
+    new_webhook = WebhookDispatcher(new_notif)
+    new_email = EmailNotifier(new_notif.email) if new_notif.email and new_notif.email.enabled else None
+    new_notifier = NotificationRouter(webhook=new_webhook, email=new_email, db=db)
+    refs["notifier"] = new_notifier
+    refs["notifications"] = new_notif
+    set_notifier(new_notifier)
+    if old_notifier is not None:
+        try:
+            await old_notifier.close()
+        except Exception:
+            logger.debug("Failed closing old notifier during reload", exc_info=True)
+
+    # Deep-rewire guardrails + risk gates.
+    refs["guardrails"] = new_guardrails
+    app_config = refs.get("app_config")
+    agent = refs.get("agent")
+    block_notifier = new_notifier if new_watch.notify_on_blocked else None
+    if app_config is not None and agent is not None:
+        _rewire_risk_gates(agent, app_config=app_config, guardrails=new_guardrails, notifier=block_notifier)
+
+    # Push derived state onto the live session so the next cycle sees the update.
+    tol = new_guardrails.watch_tolerance or new_guardrails.risk_tolerance
+    if session_state_template is not None:
+        session_state_template["risk_tolerance"] = tol
+    sess = session_ref[0] if session_ref and session_ref[0] is not None else None
+    if sess is not None:
+        sess.state["risk_tolerance"] = tol
+        sess.state["watch_max_identical_actions_per_cycle"] = new_watch.max_identical_actions_per_cycle
+        sess.state["watch_max_remote_actions_per_cycle"] = new_watch.max_remote_actions_per_cycle
+
+    await db.set_watch_state("interval_minutes", str(new_watch.interval_minutes))
+    await db.set_watch_state("risk_tolerance", str(tol))
+    logger.info("Reloaded watch config from DB overrides")
 
 
 async def _poll_commands(
@@ -253,6 +330,7 @@ async def _poll_commands(
     *,
     session_ref: list | None = None,
     session_state_template: dict | None = None,
+    refs: dict[str, Any] | None = None,
 ) -> None:
     """Process any pending watch commands from the database."""
     commands = await db.get_pending_watch_commands()
@@ -263,25 +341,15 @@ async def _poll_commands(
             if command == "stop":
                 shutdown.set()
                 await db.update_watch_command_status(cmd_id, "completed")
-            elif command == "update_config" and watch_config is not None:
-                payload = json.loads(cmd["payload"] or "{}")
-                updates, risk_tolerance = _validated_live_watch_updates(payload, watch_config)
-
-                for key, value in updates.items():
-                    setattr(watch_config, key, value)
-                if "interval_minutes" in updates:
-                    await db.set_watch_state("interval_minutes", str(updates["interval_minutes"]))
-
-                if risk_tolerance is not None:
-                    threshold = risk_tolerance
-                    if session_state_template is not None:
-                        session_state_template["risk_tolerance"] = threshold
-                    sess = session_ref[0] if session_ref and session_ref[0] is not None else None
-                    if sess is not None:
-                        sess.state["risk_tolerance"] = threshold
-                    await db.set_watch_state("risk_tolerance", str(threshold))
+            elif command == "reload_config" and watch_config is not None and refs is not None:
+                await _reload_config_from_db(
+                    db,
+                    watch_config,
+                    refs,
+                    session_ref=session_ref,
+                    session_state_template=session_state_template,
+                )
                 await db.update_watch_command_status(cmd_id, "completed")
-                logger.info("Applied config update: %s", payload)
             elif command == "start":
                 await db.update_watch_command_status(cmd_id, "completed")
             else:
@@ -293,18 +361,24 @@ async def _poll_commands(
 async def _interruptible_sleep(
     db: DatabaseService,
     shutdown: asyncio.Event,
-    interval_seconds: float,
+    interval_getter: Callable[[], float],
     poll_seconds: float = 5.0,
     watch_config: WatchConfig | None = None,
     *,
     session_ref: list | None = None,
     session_state_template: dict | None = None,
+    refs: dict[str, Any] | None = None,
 ) -> None:
-    """Sleep in short increments, polling for commands between sleeps."""
+    """Sleep in short increments, polling for commands between sleeps.
+
+    ``interval_getter`` is re-read each loop so that a mid-sleep ``reload_config``
+    that shortens ``watch_config.interval_minutes`` takes effect immediately.
+    """
     elapsed = 0.0
-    while elapsed < interval_seconds and not shutdown.is_set():
+    while elapsed < interval_getter() and not shutdown.is_set():
+        remaining = interval_getter() - elapsed
         try:
-            await asyncio.wait_for(shutdown.wait(), timeout=min(poll_seconds, interval_seconds - elapsed))
+            await asyncio.wait_for(shutdown.wait(), timeout=min(poll_seconds, remaining))
         except TimeoutError:
             pass
         elapsed += poll_seconds
@@ -315,6 +389,7 @@ async def _interruptible_sleep(
                 watch_config,
                 session_ref=session_ref,
                 session_state_template=session_state_template,
+                refs=refs,
             )
 
 
@@ -381,15 +456,6 @@ async def start_watch() -> None:
     # Build the agent with headless risk gate
     block_notifier = notifier if watch_config.notify_on_blocked else None
 
-    def _make_headless_risk_gate(tool_risk_levels: dict[str, int], agent_threshold: int | None = None):
-        return create_risk_gate(
-            tool_risk_levels=tool_risk_levels,
-            risk_overrides=dict(guardrails.tools_risk_overrides),
-            default_threshold=agent_threshold,
-            headless=True,
-            notifier=block_notifier,
-        )
-
     if app_config.multi_agent:
         agent_tolerances = {
             "Monitor": guardrails.monitor_tolerance,
@@ -403,7 +469,12 @@ async def start_watch() -> None:
             threshold = RuleGate(threshold=tol).threshold if tol is not None else None
 
             def factory(tool_risk_levels: dict[str, int]):
-                return _make_headless_risk_gate(tool_risk_levels, agent_threshold=threshold)
+                return _make_headless_risk_gate(
+                    tool_risk_levels,
+                    guardrails=guardrails,
+                    notifier=block_notifier,
+                    agent_threshold=threshold,
+                )
 
             return factory
 
@@ -416,8 +487,20 @@ async def start_watch() -> None:
         agent = create_squire_agent(
             app_config=app_config,
             llm_config=llm_config,
-            before_tool_callback=_make_headless_risk_gate(TOOL_RISK_LEVELS),
+            before_tool_callback=_make_headless_risk_gate(
+                TOOL_RISK_LEVELS,
+                guardrails=guardrails,
+                notifier=block_notifier,
+            ),
         )
+
+    refs: dict[str, Any] = {
+        "app_config": app_config,
+        "agent": agent,
+        "guardrails": guardrails,
+        "notifier": notifier,
+        "notifications": notif_config,
+    }
 
     # Create ADK runner
     adk_runtime = AdkRuntime(app_name=app_config.app_name, db_path=db_config.path)
@@ -518,6 +601,7 @@ async def start_watch() -> None:
         watch_config,
         session_ref=session_ref,
         session_state_template=session_state,
+        refs=refs,
     )
 
     cycle_count = 0
@@ -554,6 +638,7 @@ async def start_watch() -> None:
                 watch_config,
                 session_ref=session_ref,
                 session_state_template=session_state,
+                refs=refs,
             )
             if shutdown.is_set():
                 if active_cycle_id and active_cycle_started_at:
@@ -994,14 +1079,16 @@ async def start_watch() -> None:
             if cycle_count % 10 == 0:
                 await db.cleanup_watch_data()
 
-            # Sleep until next cycle (interruptible by shutdown signal or commands)
+            # Sleep until next cycle (interruptible by shutdown signal or commands).
+            # Getter is re-read each loop so a mid-sleep reload picks up new intervals.
             await _interruptible_sleep(
                 db,
                 shutdown,
-                watch_config.interval_minutes * 60,
+                lambda: watch_config.interval_minutes * 60,
                 watch_config=watch_config,
                 session_ref=session_ref,
                 session_state_template=session_state,
+                refs=refs,
             )
 
     finally:

--- a/tests/test_api_watch.py
+++ b/tests/test_api_watch.py
@@ -112,22 +112,6 @@ async def test_watch_status_stale_process_finalizes_watch_artifacts(db, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_watch_config_update(db):
-    from squire.api.routers.watch import watch_config_update
-    from squire.api.schemas import WatchConfigUpdate
-
-    update = WatchConfigUpdate(interval_minutes=1, checkin_prompt="Custom prompt")
-    result = await watch_config_update(update=update, db=db)
-    assert result.status == "ok"
-
-    pending = await db.get_pending_watch_commands()
-    assert len(pending) == 1
-    payload = json.loads(pending[0]["payload"])
-    assert payload["interval_minutes"] == 1
-    assert payload["checkin_prompt"] == "Custom prompt"
-
-
-@pytest.mark.asyncio
 async def test_watch_cycles(db):
     from squire.api.routers.watch import watch_cycles
 

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -1,11 +1,13 @@
-"""Tests for configuration API endpoints (GET detail + PATCH)."""
+"""Tests for configuration API endpoints (GET detail + PATCH + DELETE)."""
 
 import pytest
+import pytest_asyncio
 
 import squire.api.dependencies as deps
 import squire.config.loader as loader_mod
 from squire.config import AppConfig, GuardrailsConfig, LLMConfig, NotificationsConfig, WatchConfig
 from squire.config.notifications import WebhookConfig
+from squire.database.service import DatabaseService
 
 
 @pytest.fixture(autouse=True)
@@ -14,9 +16,9 @@ def _empty_toml(monkeypatch):
     monkeypatch.setattr(loader_mod, "_cached", {})
 
 
-@pytest.fixture
-def _setup_deps(monkeypatch):
-    """Populate deps singletons with default configs."""
+@pytest_asyncio.fixture
+async def _setup_deps(monkeypatch, tmp_path):
+    """Populate deps singletons with default configs and a scratch DB."""
     from squire.config.skills import SkillsConfig
     from squire.skills import SkillService
 
@@ -30,6 +32,14 @@ def _setup_deps(monkeypatch):
     monkeypatch.setattr(deps, "db_config", None)
     monkeypatch.setattr(deps, "host_store", None)
     monkeypatch.setattr(deps, "notifier", None)
+
+    db = DatabaseService(tmp_path / "test.db")
+    monkeypatch.setattr(deps, "db", db)
+    try:
+        yield db
+    finally:
+        await db.close()
+        monkeypatch.setattr(deps, "db", None)
 
 
 # --- GET /api/config ---
@@ -45,6 +55,7 @@ class TestGetConfig:
 
         result = await get_config(app_config=deps.app_config, llm_config=deps.llm_config)
         assert "risk_tolerance" in result.guardrails.env_overrides
+        assert result.guardrails.sources["risk_tolerance"] == "env"
 
     async def test_returns_section_values(self):
         from squire.api.routers.config import get_config
@@ -53,6 +64,7 @@ class TestGetConfig:
         assert result.app.values["app_name"] == "Squire"
         assert "model" in result.llm.values
         assert "path" in result.skills.values
+        assert result.llm.sources["model"] == "default"
 
     async def test_returns_toml_path(self, tmp_path, monkeypatch):
         from squire.api.routers.config import get_config
@@ -115,47 +127,65 @@ class TestPatchConfig:
     async def test_patch_guardrails_risk_tolerance(self):
         from squire.api.routers.config import patch_config
 
-        result = await patch_config("guardrails", {"risk_tolerance": "full-trust"}, persist=False)
-        assert result["values"]["risk_tolerance"] == "full-trust"
+        result = await patch_config("guardrails", {"risk_tolerance": "full-trust"})
+        assert result.values["risk_tolerance"] == "full-trust"
+        assert result.sources["risk_tolerance"] == "db"
         assert deps.guardrails.risk_tolerance == "full-trust"
+
+    async def test_patch_writes_to_config_overrides(self, _setup_deps):
+        from squire.api.routers.config import patch_config
+
+        await patch_config("watch", {"interval_minutes": 7})
+        stored = await _setup_deps.get_config_overrides("watch")
+        assert stored["interval_minutes"] == 7
+
+    async def test_patch_enqueues_reload_config_command(self, _setup_deps):
+        from squire.api.routers.config import patch_config
+
+        await patch_config("watch", {"interval_minutes": 8})
+        pending = await _setup_deps.get_pending_watch_commands()
+        assert any(cmd["command"] == "reload_config" for cmd in pending)
 
     async def test_patch_llm_updates_in_memory(self):
         from squire.api.routers.config import patch_config
 
-        result = await patch_config("llm", {"temperature": 0.8}, persist=False)
+        result = await patch_config("llm", {"temperature": 0.8})
         assert deps.llm_config.temperature == 0.8
         # api_base should be redacted in response
-        assert result["values"].get("api_base") != deps.llm_config.api_base or deps.llm_config.api_base is None
+        assert result.values.get("api_base") != deps.llm_config.api_base or deps.llm_config.api_base is None
 
     async def test_patch_watch_updates_in_memory(self):
         from squire.api.routers.config import patch_config
 
-        await patch_config("watch", {"interval_minutes": 10, "notify_on_action": False}, persist=False)
+        await patch_config("watch", {"interval_minutes": 10, "notify_on_action": False})
         assert deps.watch_config.interval_minutes == 10
         assert deps.watch_config.notify_on_action is False
 
     async def test_patch_guardrails_updates_in_memory(self):
         from squire.api.routers.config import patch_config
 
-        await patch_config("guardrails", {"tools_deny": ["run_command"]}, persist=False)
+        await patch_config("guardrails", {"tools_deny": ["run_command"]})
         assert deps.guardrails.tools_deny == ["run_command"]
 
-    async def test_rejects_env_locked_field(self, monkeypatch):
+    async def test_rejects_env_locked_field(self, _setup_deps, monkeypatch):
         from fastapi import HTTPException
 
         from squire.api.routers.config import patch_config
 
         monkeypatch.setenv("SQUIRE_GUARDRAILS_RISK_TOLERANCE", "read-only")
         with pytest.raises(HTTPException) as exc_info:
-            await patch_config("guardrails", {"risk_tolerance": "full-trust"}, persist=False)
+            await patch_config("guardrails", {"risk_tolerance": "full-trust"})
         assert exc_info.value.status_code == 409
         assert "SQUIRE_GUARDRAILS_RISK_TOLERANCE" in exc_info.value.detail
+        # Env lock path must NOT write to DB.
+        stored = await _setup_deps.get_config_overrides("guardrails")
+        assert "risk_tolerance" not in stored
 
     async def test_strips_redacted_sentinel(self):
         from squire.api.routers.config import patch_config
 
         original_temp = deps.llm_config.temperature
-        await patch_config("llm", {"model": "new-model", "temperature": "••••••"}, persist=False)
+        await patch_config("llm", {"model": "new-model", "temperature": "••••••"})
         assert deps.llm_config.model == "new-model"
         assert deps.llm_config.temperature == original_temp
 
@@ -165,7 +195,7 @@ class TestPatchConfig:
         from squire.api.routers.config import patch_config
 
         with pytest.raises(HTTPException) as exc_info:
-            await patch_config("bogus", {"key": "val"}, persist=False)
+            await patch_config("bogus", {"key": "val"})
         assert exc_info.value.status_code == 404
 
     async def test_immutable_section_404(self):
@@ -174,7 +204,7 @@ class TestPatchConfig:
         from squire.api.routers.config import patch_config
 
         with pytest.raises(HTTPException) as exc_info:
-            await patch_config("database", {"path": "/tmp/db"}, persist=False)
+            await patch_config("database", {"path": "/tmp/db"})
         assert exc_info.value.status_code == 404
 
     async def test_patch_skills_updates_service(self, monkeypatch, tmp_path):
@@ -182,7 +212,7 @@ class TestPatchConfig:
 
         new_dir = tmp_path / "skills2"
         new_dir.mkdir()
-        await patch_config("skills", {"path": str(new_dir)}, persist=False)
+        await patch_config("skills", {"path": str(new_dir)})
         assert deps.skills_config.path == new_dir
         assert deps.skills_service._dir == new_dir
 
@@ -192,7 +222,7 @@ class TestPatchConfig:
         from squire.api.routers.config import patch_config
 
         with pytest.raises(HTTPException) as exc_info:
-            await patch_config("app", {}, persist=False)
+            await patch_config("app", {})
         assert exc_info.value.status_code == 400
 
     async def test_all_redacted_body_400(self):
@@ -201,7 +231,7 @@ class TestPatchConfig:
         from squire.api.routers.config import patch_config
 
         with pytest.raises(HTTPException) as exc_info:
-            await patch_config("llm", {"model": "••••••"}, persist=False)
+            await patch_config("llm", {"model": "••••••"})
         assert exc_info.value.status_code == 400
 
 
@@ -223,7 +253,6 @@ class TestNotificationsWebhookMerge:
         await patch_config(
             "notifications",
             {"webhooks": [{"name": "discord", "url": "••••••", "events": ["error"]}]},
-            persist=False,
         )
         assert deps.notif_config.webhooks[0].url == "https://real-url.com"
         assert deps.notif_config.webhooks[0].events == ["error"]
@@ -242,7 +271,6 @@ class TestNotificationsWebhookMerge:
         await patch_config(
             "notifications",
             {"webhooks": [{"name": "ntfy", "url": "••••••", "headers": {"Authorization": "••••••"}}]},
-            persist=False,
         )
         assert deps.notif_config.webhooks[0].headers["Authorization"] == "Bearer secret"
 
@@ -275,45 +303,52 @@ class TestNotificationsWebhookMerge:
                     "tls": True,
                 }
             },
-            persist=False,
         )
         assert deps.notif_config.email is not None
         assert deps.notif_config.email.smtp_password == "secret-pass"
         assert deps.notif_config.email.use_tls is True
 
 
-# --- Persist to TOML ---
+# --- DELETE overrides ---
 
 
 @pytest.mark.usefixtures("_setup_deps")
-class TestPersist:
-    async def test_persist_writes_toml(self, tmp_path, monkeypatch):
-        import tomlkit
+class TestDeleteOverrides:
+    async def test_delete_field_clears_override(self, _setup_deps):
+        from squire.api.routers.config import patch_config, reset_field
 
-        from squire.api.routers.config import patch_config
+        await patch_config("watch", {"interval_minutes": 9})
+        assert (await _setup_deps.get_config_overrides("watch"))["interval_minutes"] == 9
 
-        toml_file = tmp_path / "squire.toml"
-        toml_file.write_text("")
-        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+        result = await reset_field("watch", "interval_minutes")
+        stored = await _setup_deps.get_config_overrides("watch")
+        assert "interval_minutes" not in stored
+        assert result.sources["interval_minutes"] == "default"
 
-        result = await patch_config("llm", {"temperature": 0.9}, persist=True)
-        assert result["persisted"] is not None
+    async def test_delete_section_clears_all_overrides(self, _setup_deps):
+        from squire.api.routers.config import patch_config, reset_section
 
-        with open(toml_file) as f:
-            doc = tomlkit.load(f)
-        assert doc["llm"]["temperature"] == 0.9
+        await patch_config("watch", {"interval_minutes": 4, "max_tool_calls_per_cycle": 25})
+        assert await _setup_deps.get_config_overrides("watch")
 
-    async def test_persist_top_level(self, tmp_path, monkeypatch):
-        import tomlkit
+        await reset_section("watch")
+        stored = await _setup_deps.get_config_overrides("watch")
+        assert stored == {}
 
-        from squire.api.routers.config import patch_config
+    async def test_delete_unknown_section_404(self):
+        from fastapi import HTTPException
 
-        toml_file = tmp_path / "squire.toml"
-        toml_file.write_text("")
-        monkeypatch.setattr(loader_mod, "_SEARCH_PATHS", [toml_file])
+        from squire.api.routers.config import reset_section
 
-        await patch_config("app", {"history_limit": 100}, persist=True)
+        with pytest.raises(HTTPException) as exc_info:
+            await reset_section("bogus")
+        assert exc_info.value.status_code == 404
 
-        with open(toml_file) as f:
-            doc = tomlkit.load(f)
-        assert doc["history_limit"] == 100
+    async def test_delete_unknown_field_404(self):
+        from fastapi import HTTPException
+
+        from squire.api.routers.config import reset_field
+
+        with pytest.raises(HTTPException) as exc_info:
+            await reset_field("watch", "no_such_field")
+        assert exc_info.value.status_code == 404

--- a/tests/test_config_db_source.py
+++ b/tests/test_config_db_source.py
@@ -1,0 +1,80 @@
+"""Tests for DatabaseOverrideSource — pydantic-settings source backed by SQLite."""
+
+import json
+
+import pytest
+
+import squire.config.loader as loader_mod
+from squire.config import GuardrailsConfig, WatchConfig
+from squire.config.db_source import DatabaseOverrideSource
+
+
+@pytest.fixture(autouse=True)
+def _empty_toml(monkeypatch):
+    monkeypatch.setattr(loader_mod, "_cached", {})
+
+
+@pytest.mark.asyncio
+async def test_db_overrides_apply_to_watch_config(db, monkeypatch):
+    monkeypatch.setenv("SQUIRE_DB_PATH", str(db._db_path))
+    await db.set_config_section_overrides("watch", {"interval_minutes": 42})
+
+    config = WatchConfig()
+    assert config.interval_minutes == 42
+
+
+@pytest.mark.asyncio
+async def test_env_precedence_over_db(db, monkeypatch):
+    monkeypatch.setenv("SQUIRE_DB_PATH", str(db._db_path))
+    monkeypatch.setenv("SQUIRE_WATCH_INTERVAL_MINUTES", "11")
+    await db.set_config_section_overrides("watch", {"interval_minutes": 99})
+
+    config = WatchConfig()
+    assert config.interval_minutes == 11  # env wins
+
+
+@pytest.mark.asyncio
+async def test_missing_db_returns_defaults(tmp_path, monkeypatch):
+    # Point at a non-existent DB path.
+    monkeypatch.setenv("SQUIRE_DB_PATH", str(tmp_path / "does-not-exist.db"))
+    config = WatchConfig()
+    assert config.interval_minutes == 5  # code default
+
+
+@pytest.mark.asyncio
+async def test_pre_schema_db_returns_defaults(tmp_path, monkeypatch):
+    # Create an empty SQLite file with no schema.
+    import sqlite3
+
+    db_path = tmp_path / "empty.db"
+    conn = sqlite3.connect(db_path)
+    conn.close()
+    monkeypatch.setenv("SQUIRE_DB_PATH", str(db_path))
+
+    config = WatchConfig()
+    assert config.interval_minutes == 5
+
+
+@pytest.mark.asyncio
+async def test_override_source_returns_empty_for_other_sections(db, monkeypatch):
+    monkeypatch.setenv("SQUIRE_DB_PATH", str(db._db_path))
+    await db.set_config_section_overrides("watch", {"interval_minutes": 2})
+
+    # A different section's source must NOT pick up watch's overrides.
+    source = DatabaseOverrideSource(GuardrailsConfig, "guardrails")
+    assert source() == {}
+
+
+@pytest.mark.asyncio
+async def test_override_source_filters_unknown_fields(db, monkeypatch):
+    monkeypatch.setenv("SQUIRE_DB_PATH", str(db._db_path))
+    # Write a row for a field WatchConfig does not define — should be ignored.
+    conn = await db._get_conn()
+    await conn.execute(
+        "INSERT INTO config_overrides (section, field, value_json, updated_at) VALUES (?, ?, ?, ?)",
+        ("watch", "not_a_field", json.dumps("ignored"), "now"),
+    )
+    await conn.commit()
+
+    source = DatabaseOverrideSource(WatchConfig, "watch")
+    assert "not_a_field" not in source()

--- a/tests/test_config_overrides_db.py
+++ b/tests/test_config_overrides_db.py
@@ -1,0 +1,64 @@
+"""Tests for DatabaseService config_overrides accessors."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_single_override(db):
+    await db.set_config_override("watch", "interval_minutes", 7)
+    stored = await db.get_config_overrides("watch")
+    assert stored == {"interval_minutes": 7}
+
+
+@pytest.mark.asyncio
+async def test_set_section_overrides_upserts(db):
+    await db.set_config_section_overrides("watch", {"interval_minutes": 3, "notify_on_action": False})
+    await db.set_config_section_overrides("watch", {"interval_minutes": 12})  # upsert
+    stored = await db.get_config_overrides("watch")
+    assert stored == {"interval_minutes": 12, "notify_on_action": False}
+
+
+@pytest.mark.asyncio
+async def test_delete_single_field(db):
+    await db.set_config_section_overrides("watch", {"interval_minutes": 2, "notify_on_action": True})
+    removed = await db.delete_config_override("watch", "interval_minutes")
+    assert removed is True
+    stored = await db.get_config_overrides("watch")
+    assert stored == {"notify_on_action": True}
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_field_returns_false(db):
+    result = await db.delete_config_override("watch", "nothing")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_clear_section(db):
+    await db.set_config_section_overrides("watch", {"interval_minutes": 5, "notify_on_action": False})
+    await db.set_config_section_overrides("llm", {"temperature": 0.3})
+
+    count = await db.clear_config_section("watch")
+    assert count == 2
+    assert await db.get_config_overrides("watch") == {}
+    # Other section untouched.
+    assert await db.get_config_overrides("llm") == {"temperature": 0.3}
+
+
+@pytest.mark.asyncio
+async def test_get_all_returns_grouped(db):
+    await db.set_config_section_overrides("watch", {"interval_minutes": 9})
+    await db.set_config_section_overrides("llm", {"temperature": 0.9})
+    grouped = await db.get_all_config_overrides()
+    assert grouped == {"watch": {"interval_minutes": 9}, "llm": {"temperature": 0.9}}
+
+
+@pytest.mark.asyncio
+async def test_complex_values_roundtrip(db):
+    payload = {
+        "webhooks": [{"name": "discord", "url": "https://example.invalid", "events": ["*"]}],
+        "enabled": True,
+    }
+    await db.set_config_section_overrides("notifications", payload)
+    stored = await db.get_config_overrides("notifications")
+    assert stored == payload

--- a/tests/test_watch_loop.py
+++ b/tests/test_watch_loop.py
@@ -1,7 +1,6 @@
 """Tests for watch loop helpers: command polling and interruptible sleep."""
 
 import asyncio
-import json
 from types import SimpleNamespace
 
 import pytest
@@ -23,13 +22,29 @@ async def test_poll_commands_stop(db):
 
 
 @pytest.mark.asyncio
-async def test_poll_commands_update_config(db):
-    """An 'update_config' command should apply overrides."""
-    from squire.config import WatchConfig
+async def test_poll_commands_reload_config_rebuilds_from_db(db, monkeypatch):
+    """A 'reload_config' command should rebuild WatchConfig from DB overrides."""
+    from squire.config import AppConfig, GuardrailsConfig, NotificationsConfig, WatchConfig
+    from squire.notifications.router import NotificationRouter
+    from squire.notifications.webhook import WebhookDispatcher
     from squire.watch import _poll_commands
 
+    # DatabaseOverrideSource resolves the DB path via SQUIRE_DB_PATH env first.
+    monkeypatch.setenv("SQUIRE_DB_PATH", str(db._db_path))
+
     shutdown = asyncio.Event()
-    config = WatchConfig()
+    # Ensure schema is initialized before WatchConfig() reads it sync.
+    await db.get_pending_watch_commands()
+
+    config = WatchConfig()  # defaults — no overrides yet
+    assert config.interval_minutes == 5
+
+    # Write overrides AFTER config is built so the reload is the only thing that applies them.
+    await db.set_config_section_overrides(
+        "watch",
+        {"interval_minutes": 1, "cycle_timeout_seconds": 120, "notify_on_action": False},
+    )
+
     session_state = {"risk_tolerance": 2}
 
     class _FakeSession:
@@ -38,61 +53,42 @@ async def test_poll_commands_update_config(db):
 
     session_ref = [_FakeSession()]
 
-    await db.insert_watch_command(
-        "update_config",
-        payload=json.dumps(
-            {
-                "interval_minutes": 1,
-                "cycle_timeout_seconds": 120,
-                "notify_on_action": False,
-                "risk_tolerance": 5,
-            }
-        ),
-    )
+    notifier = NotificationRouter(webhook=WebhookDispatcher(NotificationsConfig()), email=None, db=db)
+
+    class _DummyAgent:
+        before_tool_callback = None
+        sub_agents: list = []
+
+    agent = _DummyAgent()
+    refs = {
+        "app_config": AppConfig(),
+        "agent": agent,
+        "guardrails": GuardrailsConfig(),
+        "notifier": notifier,
+        "notifications": NotificationsConfig(),
+    }
+
+    await db.insert_watch_command("reload_config")
     await _poll_commands(
         db,
         shutdown,
         watch_config=config,
         session_ref=session_ref,
         session_state_template=session_state,
+        refs=refs,
     )
 
     assert config.interval_minutes == 1
     assert config.cycle_timeout_seconds == 120
     assert config.notify_on_action is False
-    assert session_ref[0].state["risk_tolerance"] == 5
-    assert session_state["risk_tolerance"] == 5
     assert not shutdown.is_set()
 
     pending = await db.get_pending_watch_commands()
     assert len(pending) == 0
 
-
-@pytest.mark.asyncio
-async def test_poll_commands_update_config_rejects_invalid_safety_values(db):
-    """Invalid live safety updates should fail and keep existing values."""
-    from squire.config import WatchConfig
-    from squire.watch import _poll_commands
-
-    shutdown = asyncio.Event()
-    config = WatchConfig()
-    initial_identical_limit = config.max_identical_actions_per_cycle
-
-    cmd_id = await db.insert_watch_command(
-        "update_config",
-        payload=json.dumps({"max_identical_actions_per_cycle": 0}),
-    )
-    await _poll_commands(db, shutdown, watch_config=config)
-
-    assert config.max_identical_actions_per_cycle == initial_identical_limit
-    pending = await db.get_pending_watch_commands()
-    assert len(pending) == 0
-
-    conn = await db._get_conn()  # noqa: SLF001 - test verifies command status persistence
-    cursor = await conn.execute("SELECT status, error FROM watch_commands WHERE id = ?", (cmd_id,))
-    row = await cursor.fetchone()
-    assert row["status"] == "failed"
-    assert "max_identical_actions_per_cycle" in (row["error"] or "")
+    # The new notifier must have replaced the old one, and risk gates rewired.
+    assert refs["notifier"] is not notifier
+    assert agent.before_tool_callback is not None
 
 
 @pytest.mark.asyncio
@@ -126,8 +122,29 @@ async def test_interruptible_sleep_responds_to_commands(db):
         await db.insert_watch_command("stop")
 
     asyncio.create_task(insert_stop())
-    await _interruptible_sleep(db, shutdown, interval_seconds=60, poll_seconds=0.1, watch_config=None)
+    await _interruptible_sleep(db, shutdown, lambda: 60, poll_seconds=0.1, watch_config=None)
     assert shutdown.is_set()
+
+
+@pytest.mark.asyncio
+async def test_interruptible_sleep_honors_live_interval_change(db):
+    """Shortening the interval mid-sleep via the getter should wake the sleep early."""
+    from squire.watch import _interruptible_sleep
+
+    shutdown = asyncio.Event()
+    interval_holder = [5.0]  # starts at 5 seconds
+
+    async def shrink():
+        await asyncio.sleep(0.15)
+        interval_holder[0] = 0.2  # below current elapsed; loop should exit
+
+    await db.get_pending_watch_commands()  # initialize schema
+    asyncio.create_task(shrink())
+
+    start = asyncio.get_event_loop().time()
+    await _interruptible_sleep(db, shutdown, lambda: interval_holder[0], poll_seconds=0.1, watch_config=None)
+    elapsed = asyncio.get_event_loop().time() - start
+    assert elapsed < 1.0, f"sleep did not honor shortened interval, took {elapsed:.2f}s"
 
 
 @pytest.mark.asyncio

--- a/web/src/components/config/app-config-form.tsx
+++ b/web/src/components/config/app-config-form.tsx
@@ -14,11 +14,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ConfigSource } from "@/lib/types";
 import { ConfigHint, ConfigIntro } from "./config-help";
+import { SectionResetButton, SourceBadge } from "./provenance";
 
 interface AppConfigFormProps {
   values: Record<string, unknown>;
   envOverrides: string[];
+  sources: Record<string, ConfigSource>;
   tomlPath: string | null;
   onSaved: () => void;
 }
@@ -38,13 +41,12 @@ function EnvLock({ field, prefix }: { field: string; prefix: string }) {
   );
 }
 
-export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppConfigFormProps) {
+export function AppConfigForm({ values, envOverrides, sources, onSaved }: AppConfigFormProps) {
   const [appName, setAppName] = useState(String(values.app_name ?? "Squire"));
   const [userId, setUserId] = useState(String(values.user_id ?? "squire-user"));
   const [historyLimit, setHistoryLimit] = useState(Number(values.history_limit ?? 50));
   const [maxToolRounds, setMaxToolRounds] = useState(Number(values.max_tool_rounds ?? 10));
   const [multiAgent, setMultiAgent] = useState(Boolean(values.multi_agent));
-  const [persist, setPersist] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -77,8 +79,7 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
       if (maxToolRounds !== Number(values.max_tool_rounds ?? 10)) changed.max_tool_rounds = maxToolRounds;
       if (multiAgent !== Boolean(values.multi_agent)) changed.multi_agent = multiAgent;
 
-      const url = persist ? "/api/config/app?persist=true" : "/api/config/app";
-      await apiPatch(url, changed);
+      await apiPatch("/api/config/app", changed);
       onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
@@ -89,23 +90,27 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="text-base">App</CardTitle>
-        <CardDescription>
-          Identity and session behavior. Affects new and ongoing chat sessions.
-        </CardDescription>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <div>
+          <CardTitle className="text-base">App</CardTitle>
+          <CardDescription>
+            Identity and session behavior. Affects new and ongoing chat sessions.
+          </CardDescription>
+        </div>
+        <SectionResetButton section="app" sources={sources} onReset={onSaved} />
       </CardHeader>
       <CardContent className="space-y-4">
         <ConfigIntro title="When changes apply">
           <p>
-            Saving updates the running API server immediately for new and ongoing chat sessions. Check{" "}
-            <strong>Save to disk</strong> below to write values into <code>squire.toml</code> when a file is found.
+            Saving updates the running API server immediately for new and ongoing chat sessions. UI edits are stored in
+            the database and override <code>squire.toml</code>; use &ldquo;Reset&rdquo; to revert to file defaults.
           </p>
         </ConfigIntro>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>App name</Label>
             {isLocked("app_name") && <EnvLock field="app_name" prefix="SQUIRE_" />}
+            <SourceBadge section="app" field="app_name" sources={sources} onReset={onSaved} />
           </div>
           <Input
             value={appName}
@@ -119,6 +124,7 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
           <div className="flex items-center gap-1.5">
             <Label>User ID</Label>
             {isLocked("user_id") && <EnvLock field="user_id" prefix="SQUIRE_" />}
+            <SourceBadge section="app" field="user_id" sources={sources} onReset={onSaved} />
           </div>
           <Input
             value={userId}
@@ -135,6 +141,7 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
           <div className="flex items-center gap-1.5">
             <Label>History Limit</Label>
             {isLocked("history_limit") && <EnvLock field="history_limit" prefix="SQUIRE_" />}
+            <SourceBadge section="app" field="history_limit" sources={sources} onReset={onSaved} />
           </div>
           <Input
             type="number"
@@ -153,6 +160,7 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
           <div className="flex items-center gap-1.5">
             <Label>Max Tool Rounds</Label>
             {isLocked("max_tool_rounds") && <EnvLock field="max_tool_rounds" prefix="SQUIRE_" />}
+            <SourceBadge section="app" field="max_tool_rounds" sources={sources} onReset={onSaved} />
           </div>
           <Input
             type="number"
@@ -172,6 +180,7 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
             <div className="flex items-center gap-1.5">
               <Label>Multi-Agent</Label>
               {isLocked("multi_agent") && <EnvLock field="multi_agent" prefix="SQUIRE_" />}
+              <SourceBadge section="app" field="multi_agent" sources={sources} onReset={onSaved} />
             </div>
             <Switch
               checked={multiAgent}
@@ -187,20 +196,7 @@ export function AppConfigForm({ values, envOverrides, tomlPath, onSaved }: AppCo
 
         {error && <p className="text-sm text-destructive">{error}</p>}
 
-        <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
-            <input
-              type="checkbox"
-              checked={persist}
-              onChange={(e) => setPersist(e.target.checked)}
-              disabled={!tomlPath}
-              className="rounded"
-            />
-            <span>
-              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — also writes{" "}
-              <code className="font-mono text-[11px]">squire.toml</code> so values survive restart.
-            </span>
-          </label>
+        <div className="flex items-center justify-end pt-2 border-t">
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
               <RotateCcw className="h-3.5 w-3.5 mr-1" />

--- a/web/src/components/config/config-editor.tsx
+++ b/web/src/components/config/config-editor.tsx
@@ -113,6 +113,7 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
         <AppConfigForm
           values={config.app.values}
           envOverrides={config.app.env_overrides}
+          sources={config.app.sources}
           tomlPath={config.toml_path}
           onSaved={onSaved}
         />
@@ -122,6 +123,7 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
         <LLMConfigForm
           values={config.llm.values}
           envOverrides={config.llm.env_overrides}
+          sources={config.llm.sources}
           tomlPath={config.toml_path}
           onSaved={onSaved}
         />
@@ -160,6 +162,7 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
         <GuardrailsConfigForm
           values={config.guardrails.values}
           envOverrides={config.guardrails.env_overrides}
+          sources={config.guardrails.sources}
           tomlPath={config.toml_path}
           onSaved={onSaved}
         />
@@ -169,7 +172,7 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
         <WatchConfigForm
           values={config.watch.values}
           envOverrides={config.watch.env_overrides}
-          tomlPath={config.toml_path}
+          sources={config.watch.sources}
           onSaved={onSaved}
         />
       </TabsContent>
@@ -178,6 +181,7 @@ export function ConfigEditor({ config, onSaved }: ConfigEditorProps) {
         <SkillsConfigForm
           values={config.skills.values}
           envOverrides={config.skills.env_overrides}
+          sources={config.skills.sources}
           tomlPath={config.toml_path}
           onSaved={onSaved}
         />

--- a/web/src/components/config/guardrails-config-form.tsx
+++ b/web/src/components/config/guardrails-config-form.tsx
@@ -23,11 +23,14 @@ import {
 } from "@/components/ui/tooltip";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ConfigSource } from "@/lib/types";
 import { ConfigHint, ConfigIntro } from "./config-help";
+import { SectionResetButton, SourceBadge } from "./provenance";
 
 interface GuardrailsConfigFormProps {
   values: Record<string, unknown>;
   envOverrides: string[];
+  sources: Record<string, ConfigSource>;
   tomlPath: string | null;
   onSaved: () => void;
 }
@@ -123,7 +126,7 @@ function arraysEqual(a: unknown, b: string[]): boolean {
   return arr.length === b.length && arr.every((v, i) => v === b[i]);
 }
 
-export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }: GuardrailsConfigFormProps) {
+export function GuardrailsConfigForm({ values, envOverrides, sources, onSaved }: GuardrailsConfigFormProps) {
   const toArr = (v: unknown): string[] => (Array.isArray(v) ? (v as string[]) : []);
   const toStr = (v: unknown): string => (v != null ? String(v) : "");
 
@@ -150,7 +153,6 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
     2
   );
   const [toolsRiskJson, setToolsRiskJson] = useState(riskOrigJson);
-  const [persist, setPersist] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -264,8 +266,7 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
       if (!arraysEqual(values.config_paths, configPaths)) changed.config_paths = configPaths;
       if (parsedOverrides !== undefined) changed.tools_risk_overrides = parsedOverrides;
 
-      const url = persist ? "/api/config/guardrails?persist=true" : "/api/config/guardrails";
-      await apiPatch(url, changed);
+      await apiPatch("/api/config/guardrails", changed);
       onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
@@ -276,18 +277,21 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Guardrails</CardTitle>
-        <CardDescription>
-          Global risk policy, tool lists, per-agent overrides, watch-specific policy, and command/path restrictions.
-        </CardDescription>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <div>
+          <CardTitle className="text-base">Guardrails</CardTitle>
+          <CardDescription>
+            Global risk policy, tool lists, per-agent overrides, watch-specific policy, and command/path restrictions.
+          </CardDescription>
+        </div>
+        <SectionResetButton section="guardrails" sources={sources} onReset={onSaved} />
       </CardHeader>
       <CardContent className="space-y-4">
         <ConfigIntro title="How this interacts with chat and watch">
           <p>
             All settings here—including risk tolerance, tool lists, and command allowlists—take effect immediately for
-            new chat sessions and tool calls as soon as you save. The separate <strong>watch</strong> process loads
-            guardrails at startup; restart watch for changes to take effect there.
+            new chat sessions and tool calls as soon as you save. A running <strong>watch</strong> process reloads
+            within seconds; UI edits override <code>squire.toml</code>.
           </p>
         </ConfigIntro>
 
@@ -295,6 +299,7 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
           <div className="flex items-center gap-1.5">
             <Label>Risk Tolerance</Label>
             {isLocked("risk_tolerance") && <EnvLock field="risk_tolerance" prefix="SQUIRE_GUARDRAILS_" />}
+            <SourceBadge section="guardrails" field="risk_tolerance" sources={sources} onReset={onSaved} />
           </div>
           <Select
             value={riskTolerance}
@@ -521,20 +526,7 @@ export function GuardrailsConfigForm({ values, envOverrides, tomlPath, onSaved }
 
         {error && <p className="text-sm text-destructive">{error}</p>}
 
-        <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
-            <input
-              type="checkbox"
-              checked={persist}
-              onChange={(e) => setPersist(e.target.checked)}
-              disabled={!tomlPath}
-              className="rounded"
-            />
-            <span>
-              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — writes the{" "}
-              <code className="font-mono text-[11px]">[guardrails]</code> section.
-            </span>
-          </label>
+        <div className="flex items-center justify-end pt-2 border-t">
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
               <RotateCcw className="h-3.5 w-3.5 mr-1" />

--- a/web/src/components/config/llm-config-form.tsx
+++ b/web/src/components/config/llm-config-form.tsx
@@ -14,12 +14,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import type { LLMModelsResponse } from "@/lib/types";
+import type { ConfigSource, LLMModelsResponse } from "@/lib/types";
 import { ConfigHint, ConfigIntro } from "./config-help";
+import { SectionResetButton, SourceBadge } from "./provenance";
 
 interface LLMConfigFormProps {
   values: Record<string, unknown>;
   envOverrides: string[];
+  sources: Record<string, ConfigSource>;
   tomlPath: string | null;
   onSaved: () => void;
 }
@@ -47,7 +49,7 @@ function apiBaseFromValues(v: unknown): string {
   return s === REDACTED ? "" : s;
 }
 
-export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMConfigFormProps) {
+export function LLMConfigForm({ values, envOverrides, sources, onSaved }: LLMConfigFormProps) {
   const [model, setModel] = useState(String(values.model ?? ""));
   const [modelOptions, setModelOptions] = useState<string[]>([]);
   const [modelProvider, setModelProvider] = useState<string>("");
@@ -56,7 +58,6 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
   const [temperature, setTemperature] = useState(Number(values.temperature ?? 0.2));
   const [maxTokens, setMaxTokens] = useState(Number(values.max_tokens ?? 4096));
   const [apiBase, setApiBase] = useState(() => apiBaseFromValues(values.api_base));
-  const [persist, setPersist] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -122,8 +123,7 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
       if (maxTokens !== Number(values.max_tokens ?? 4096)) changed.max_tokens = maxTokens;
       if (apiBase !== origApiBase) changed.api_base = apiBase.trim() === "" ? null : apiBase.trim();
 
-      const url = persist ? "/api/config/llm?persist=true" : "/api/config/llm";
-      await apiPatch(url, changed);
+      await apiPatch("/api/config/llm", changed);
       onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
@@ -134,12 +134,15 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="text-base">LLM</CardTitle>
-        <CardDescription>
-          LiteLLM model id and generation parameters for chat (and the web-driven agent). Takes effect on the next
-          request that builds the model client.
-        </CardDescription>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <div>
+          <CardTitle className="text-base">LLM</CardTitle>
+          <CardDescription>
+            LiteLLM model id and generation parameters for chat and the web-driven agent. Takes effect on the next
+            request that builds the model client.
+          </CardDescription>
+        </div>
+        <SectionResetButton section="llm" sources={sources} onReset={onSaved} />
       </CardHeader>
       <CardContent className="space-y-4">
         <ConfigIntro title="Provider keys">
@@ -152,6 +155,7 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
           <div className="flex items-center gap-1.5">
             <Label>Model{modelProvider ? ` (${modelProvider})` : ""}</Label>
             {isLocked("model") && <EnvLock field="model" prefix="SQUIRE_LLM_" />}
+            <SourceBadge section="llm" field="model" sources={sources} onReset={onSaved} />
           </div>
           {modelsLoading ? (
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -183,6 +187,7 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
           <div className="flex items-center gap-1.5">
             <Label>Temperature</Label>
             {isLocked("temperature") && <EnvLock field="temperature" prefix="SQUIRE_LLM_" />}
+            <SourceBadge section="llm" field="temperature" sources={sources} onReset={onSaved} />
           </div>
           <Input
             type="number"
@@ -203,6 +208,7 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
           <div className="flex items-center gap-1.5">
             <Label>Max Tokens</Label>
             {isLocked("max_tokens") && <EnvLock field="max_tokens" prefix="SQUIRE_LLM_" />}
+            <SourceBadge section="llm" field="max_tokens" sources={sources} onReset={onSaved} />
           </div>
           <Input
             type="number"
@@ -218,6 +224,7 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
           <div className="flex items-center gap-1.5">
             <Label>API Base URL</Label>
             {isLocked("api_base") && <EnvLock field="api_base" prefix="SQUIRE_LLM_" />}
+            <SourceBadge section="llm" field="api_base" sources={sources} onReset={onSaved} />
           </div>
           <Input
             value={apiBase}
@@ -234,20 +241,7 @@ export function LLMConfigForm({ values, envOverrides, tomlPath, onSaved }: LLMCo
 
         {error && <p className="text-sm text-destructive">{error}</p>}
 
-        <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
-            <input
-              type="checkbox"
-              checked={persist}
-              onChange={(e) => setPersist(e.target.checked)}
-              disabled={!tomlPath}
-              className="rounded"
-            />
-            <span>
-              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — persists the{" "}
-              <code className="font-mono text-[11px]">[llm]</code> section.
-            </span>
-          </label>
+        <div className="flex items-center justify-end pt-2 border-t">
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
               <RotateCcw className="h-3.5 w-3.5 mr-1" />

--- a/web/src/components/config/provenance.tsx
+++ b/web/src/components/config/provenance.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { Database, RotateCcw } from "lucide-react";
+import { apiDelete } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ConfigSource } from "@/lib/types";
+
+interface SourceBadgeProps {
+  section: string;
+  field: string;
+  sources: Record<string, ConfigSource>;
+  onReset?: () => void;
+}
+
+/**
+ * Small provenance pip shown next to a config field.
+ *
+ * Only renders for fields whose current value came from a UI-driven DB override.
+ * Clicking the pip clears the override and reverts to TOML/defaults.
+ */
+export function SourceBadge({ section, field, sources, onReset }: SourceBadgeProps) {
+  const source = sources[field];
+  if (source !== "db") return null;
+
+  const handleReset = async () => {
+    await apiDelete(`/api/config/${section}/${encodeURIComponent(field)}`);
+    onReset?.();
+  };
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger
+          onClick={handleReset}
+          aria-label={`Reset ${field}`}
+          className="inline-flex h-4 w-4 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <Database className="h-3 w-3" />
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Overridden via UI (stored in DB). Click to revert.</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+interface SectionResetButtonProps {
+  section: string;
+  sources: Record<string, ConfigSource>;
+  onReset?: () => void;
+}
+
+/**
+ * "Reset to file defaults" button for a whole config section.
+ *
+ * Disabled when no field is currently DB-overridden. Uses a plain confirm()
+ * rather than an AlertDialog to avoid pulling more components into the tree;
+ * swap in shadcn's AlertDialog if we grow more surfaces needing this.
+ */
+export function SectionResetButton({ section, sources, onReset }: SectionResetButtonProps) {
+  const [busy, setBusy] = useState(false);
+  const hasOverrides = Object.values(sources).some((s) => s === "db");
+
+  const handleClick = async () => {
+    if (!hasOverrides) return;
+    if (!window.confirm(`Reset all ${section} overrides to the values in squire.toml / code defaults?`)) return;
+    setBusy(true);
+    try {
+      await apiDelete(`/api/config/${section}`);
+      onReset?.();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      disabled={!hasOverrides || busy}
+      onClick={handleClick}
+      title={hasOverrides ? "Reset DB overrides for this section" : "No DB overrides in this section"}
+    >
+      <RotateCcw className="mr-1 h-3.5 w-3.5" />
+      Reset
+    </Button>
+  );
+}

--- a/web/src/components/config/skills-config-form.tsx
+++ b/web/src/components/config/skills-config-form.tsx
@@ -13,11 +13,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ConfigSource } from "@/lib/types";
 import { ConfigHint, ConfigIntro } from "./config-help";
+import { SectionResetButton, SourceBadge } from "./provenance";
 
 interface SkillsConfigFormProps {
   values: Record<string, unknown>;
   envOverrides: string[];
+  sources: Record<string, ConfigSource>;
   tomlPath: string | null;
   onSaved: () => void;
 }
@@ -40,9 +43,8 @@ function EnvLock({ field, prefix }: { field: string; prefix: string }) {
   );
 }
 
-export function SkillsConfigForm({ values, envOverrides, tomlPath, onSaved }: SkillsConfigFormProps) {
+export function SkillsConfigForm({ values, envOverrides, sources, onSaved }: SkillsConfigFormProps) {
   const [path, setPath] = useState(String(values.path ?? ""));
-  const [persist, setPersist] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -58,8 +60,7 @@ export function SkillsConfigForm({ values, envOverrides, tomlPath, onSaved }: Sk
     setSaving(true);
     setError(null);
     try {
-      const url = persist ? "/api/config/skills?persist=true" : "/api/config/skills";
-      await apiPatch(url, { path });
+      await apiPatch("/api/config/skills", { path });
       onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
@@ -70,11 +71,14 @@ export function SkillsConfigForm({ values, envOverrides, tomlPath, onSaved }: Sk
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Skills</CardTitle>
-        <CardDescription>
-          Filesystem root for Open Agent Skills—optional instructions the model can load for chat and watch.
-        </CardDescription>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <div>
+          <CardTitle className="text-base">Skills</CardTitle>
+          <CardDescription>
+            Filesystem root for Open Agent Skills—optional instructions the model can load for chat and watch.
+          </CardDescription>
+        </div>
+        <SectionResetButton section="skills" sources={sources} onReset={onSaved} />
       </CardHeader>
       <CardContent className="space-y-4">
         <ConfigIntro title="Layout and effect">
@@ -87,6 +91,7 @@ export function SkillsConfigForm({ values, envOverrides, tomlPath, onSaved }: Sk
           <div className="flex items-center gap-1.5">
             <Label>Skills directory</Label>
             {isLocked("path") && <EnvLock field="path" prefix="SQUIRE_SKILLS_" />}
+            <SourceBadge section="skills" field="path" sources={sources} onReset={onSaved} />
           </div>
           <Input
             value={path}
@@ -100,19 +105,7 @@ export function SkillsConfigForm({ values, envOverrides, tomlPath, onSaved }: Sk
           </ConfigHint>
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
-        <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
-            <input
-              type="checkbox"
-              checked={persist}
-              onChange={(e) => setPersist(e.target.checked)}
-              disabled={!tomlPath}
-              className="rounded"
-            />
-            <span>
-              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — writes <code>[skills].path</code>.
-            </span>
-          </label>
+        <div className="flex items-center justify-end pt-2 border-t">
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
               <RotateCcw className="h-3.5 w-3.5 mr-1" />

--- a/web/src/components/config/watch-config-form.tsx
+++ b/web/src/components/config/watch-config-form.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from "react";
 import { Lock, Loader2, RotateCcw, Save } from "lucide-react";
-import type { WatchStatus } from "@/lib/types";
-import { apiGet, apiPatch, apiPut } from "@/lib/api";
+import { apiPatch } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -16,12 +15,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ConfigSource } from "@/lib/types";
 import { ConfigHint, ConfigIntro } from "./config-help";
+import { SectionResetButton, SourceBadge } from "./provenance";
 
 interface WatchConfigFormProps {
   values: Record<string, unknown>;
   envOverrides: string[];
-  tomlPath: string | null;
+  sources: Record<string, ConfigSource>;
   onSaved: () => void;
 }
 
@@ -40,7 +41,7 @@ function EnvLock({ field, prefix }: { field: string; prefix: string }) {
   );
 }
 
-export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: WatchConfigFormProps) {
+export function WatchConfigForm({ values, envOverrides, sources, onSaved }: WatchConfigFormProps) {
   const [intervalMinutes, setIntervalMinutes] = useState(Number(values.interval_minutes ?? 5));
   const [cycleTimeout, setCycleTimeout] = useState(Number(values.cycle_timeout_seconds ?? 300));
   const [checkinPrompt, setCheckinPrompt] = useState(String(values.checkin_prompt ?? ""));
@@ -51,7 +52,6 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
   );
   const [cyclesPerSession, setCyclesPerSession] = useState(Number(values.cycles_per_session ?? 12));
   const [maxContextEvents, setMaxContextEvents] = useState(Number(values.max_context_events ?? 40));
-  const [persist, setPersist] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -99,18 +99,7 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
         changed.max_context_events = maxContextEvents;
       }
 
-      const url = persist ? "/api/config/watch?persist=true" : "/api/config/watch";
-      await apiPatch(url, changed);
-
-      try {
-        const status = await apiGet<WatchStatus>("/api/watch/status");
-        if (status.status === "running" && Object.keys(changed).length > 0) {
-          await apiPut("/api/watch/config", changed);
-        }
-      } catch {
-        /* watch API unavailable — server-side config still updated */
-      }
-
+      await apiPatch("/api/config/watch", changed);
       onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to save");
@@ -121,29 +110,28 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Watch</CardTitle>
-        <CardDescription>
-          Autonomous <code>squire watch</code> loop: timing, prompts, limits, and notifications. Separate from web chat,
-          but many fields sync to a running watch when you save.
-        </CardDescription>
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+        <div>
+          <CardTitle className="text-base">Watch</CardTitle>
+          <CardDescription>
+            Autonomous <code>squire watch</code> loop: timing, prompts, limits, and notifications.
+          </CardDescription>
+        </div>
+        <SectionResetButton section="watch" sources={sources} onReset={onSaved} />
       </CardHeader>
       <CardContent className="space-y-4">
-        <ConfigIntro title="Live vs restart">
+        <ConfigIntro title="How saves work">
           <p>
-            Saving updates the web API’s copy of watch settings immediately. If watch status is <strong>running</strong>,
-            the same changes are queued for the watch process (usually within a few seconds).
-          </p>
-          <p>
-            Effective <strong>risk threshold</strong> during a watch cycle can be changed from the Watch page drawer or
-            live queue; changing <strong>Guardrails → Watch tolerance</strong> requires restarting watch to reload from
-            config files.
+            UI edits land in the database as overrides and take effect immediately; any running watch process reloads
+            within a few seconds. <code>squire.toml</code> is read-only from the app — use &ldquo;Reset&rdquo; to revert a
+            field to the value in <code>squire.toml</code> or the code default.
           </p>
         </ConfigIntro>
         <div className="space-y-2">
           <div className="flex items-center gap-1.5">
             <Label>Interval (minutes)</Label>
             {isLocked("interval_minutes") && <EnvLock field="interval_minutes" prefix="SQUIRE_WATCH_" />}
+            <SourceBadge section="watch" field="interval_minutes" sources={sources} onReset={onSaved} />
           </div>
           <Input
             type="number"
@@ -273,20 +261,7 @@ export function WatchConfigForm({ values, envOverrides, tomlPath, onSaved }: Wat
 
         {error && <p className="text-sm text-destructive">{error}</p>}
 
-        <div className="flex items-center justify-between pt-2 border-t">
-          <label className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:items-center">
-            <input
-              type="checkbox"
-              checked={persist}
-              onChange={(e) => setPersist(e.target.checked)}
-              disabled={!tomlPath}
-              className="rounded"
-            />
-            <span>
-              Save to disk{tomlPath ? "" : " (no squire.toml found)"} — writes the{" "}
-              <code className="font-mono text-[11px]">[watch]</code> section.
-            </span>
-          </label>
+        <div className="flex items-center justify-end pt-2 border-t">
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={revert} disabled={!isDirty}>
               <RotateCcw className="h-3.5 w-3.5 mr-1" />

--- a/web/src/components/watch/watch-config-drawer.tsx
+++ b/web/src/components/watch/watch-config-drawer.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import useSWR from "swr";
-import { apiGet, apiPut } from "@/lib/api";
+import useSWR, { mutate } from "swr";
+import { apiGet, apiPatch } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -30,6 +30,14 @@ const riskLevels = [
   { value: 5, label: "Full" },
 ];
 
+const riskLevelToTolerance: Record<number, string> = {
+  1: "read-only",
+  2: "cautious",
+  3: "standard",
+  4: "standard",
+  5: "full-trust",
+};
+
 export function WatchConfigDrawer({ open, onOpenChange }: WatchConfigDrawerProps) {
   const { data: config } = useSWR(
     open ? "/api/watch/config" : null,
@@ -55,14 +63,20 @@ export function WatchConfigDrawer({ open, onOpenChange }: WatchConfigDrawerProps
   }
 
   const handleApply = async () => {
-    await apiPut("/api/watch/config", {
+    await apiPatch("/api/config/watch", {
       interval_minutes: interval,
-      risk_tolerance: risk,
       checkin_prompt: prompt,
       max_identical_actions_per_cycle: maxIdenticalActions,
       blocked_action_cooldown_cycles: blockedCooldown,
       max_remote_actions_per_cycle: maxRemoteActions,
     });
+    await apiPatch("/api/config/guardrails", {
+      watch_tolerance: riskLevelToTolerance[risk],
+    });
+    await Promise.all([
+      mutate("/api/config"),
+      mutate("/api/watch/config"),
+    ]);
     onOpenChange(false);
   };
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -299,22 +299,6 @@ export interface WatchConfigResponse {
   risk_tolerance: number | null;
 }
 
-// Watch config update payload
-export interface WatchConfigUpdate {
-  interval_minutes?: number;
-  max_tool_calls_per_cycle?: number;
-  cycle_timeout_seconds?: number;
-  checkin_prompt?: string;
-  notify_on_action?: boolean;
-  notify_on_blocked?: boolean;
-  cycles_per_session?: number;
-  max_context_events?: number;
-  max_identical_actions_per_cycle?: number;
-  blocked_action_cooldown_cycles?: number;
-  max_remote_actions_per_cycle?: number;
-  risk_tolerance?: number;
-}
-
 // --- Tools ---
 
 export interface ToolParameter {
@@ -354,9 +338,12 @@ export interface ConfigResponse {
   hosts: Record<string, unknown>[];
 }
 
+export type ConfigSource = "env" | "db" | "toml" | "default";
+
 export interface ConfigSectionMeta {
   values: Record<string, unknown>;
   env_overrides: string[];
+  sources: Record<string, ConfigSource>;
 }
 
 export interface ConfigDetailResponse {


### PR DESCRIPTION
## Problem

Watch-mode settings changed via the Watch page drawer or the Configuration page in v0.18.0 were not being applied in production. Two concrete failure modes:

1. **Stale-GET mirage.** `PUT /api/watch/config` queued a command for the subprocess but never updated the API's in-memory `deps.watch_config` singleton. `GET /api/watch/config` read that singleton, so reopening the drawer showed old values — making it look like nothing applied, even though the running loop had received the update.
2. **Restart wipes changes.** Neither the drawer's PUT nor the Config page's PATCH (with `persist=false`, the default) wrote to `squire.toml`. The `squire watch` subprocess rebuilt `WatchConfig()` fresh at startup from env + TOML, so any in-memory-only change was lost on restart.

## Context

The user asked for the pattern used by similar self-hosted apps (Home Assistant, Grafana): **TOML stays user-owned and read-only; UI edits land in the DB and override TOML at load time.** Plan reviewed with the user covered scope (provenance badges, per-section / per-field reset, watch subprocess deep reload) and confirmed as a clean break — no backward-compat shims, no "persist" checkbox, no dual write paths.

Plan: [that-sounds-good-let-s-binary-puddle.md](https://github.com/willdah/squire/tree/main/.claude/plans) (local planning artifact).

## Solution

**Precedence becomes: env vars > DB overrides > `squire.toml` > code defaults**, for every mutable section (`app`, `llm`, `watch`, `guardrails`, `notifications`, `skills`).

- **New `config_overrides` SQLite table** keyed by `(section, field)`, with `value_json` storing arbitrary nested values. DDL runs inside the existing `_ensure_schema` path so it is created automatically on first boot — no manual migration.
- **New `DatabaseOverrideSource`** ([src/squire/config/db_source.py](src/squire/config/db_source.py)) implements `PydanticBaseSettingsSource` and is inserted between `env_settings` and `TomlSectionSource` in every mutable `BaseSettings`. It uses sync `sqlite3` (Pydantic sources are sync), resolves the DB path via `SQUIRE_DB_PATH` → TOML → default to avoid circular config, and silently returns `{}` on pre-schema / missing-DB. `DatabaseConfig` deliberately opts out — it's documented inline.
- **`PATCH /api/config/{section}`** now writes to DB (via `set_config_section_overrides`), replaces the `deps.*` singleton, rewires notifier/guardrails/skills, and enqueues a `reload_config` watch command. Env-locked fields still 409 without touching DB. Webhook URL / SMTP password redaction roundtrip preserved.
- **New `DELETE /api/config/{section}`** and **`DELETE /api/config/{section}/{field}`** clear DB overrides and rebuild the singleton from TOML/defaults.
- **`ConfigSectionMeta.sources`** (new field) maps every field to `env` / `db` / `toml` / `default` so the UI can render provenance.
- **Watch subprocess deep reload.** `_poll_commands` drops `update_config` and handles `reload_config`: rebuild `WatchConfig`/`GuardrailsConfig`/`NotificationsConfig`, close old notifier, install new `NotificationRouter` via a `refs` dict, and re-attach `before_tool_callback`s via a new `_rewire_risk_gates` helper that handles both single-agent and multi-agent modes. `_interruptible_sleep` takes an `interval_getter: Callable[[], float]` so a mid-sleep reload that shortens `interval_minutes` takes effect immediately.
- **Removed:** `PUT /api/watch/config`, `WatchConfigUpdate` schema, `persist=` query param, `write_toml_section` call site, "Save to disk" checkbox on every config form, and the old `update_config` watch command.
- **UI provenance.** New `SourceBadge` shows a small database pip next to any DB-overridden field; clicking the pip deletes that one override. New `SectionResetButton` in each form header clears every DB override for the section. The Watch drawer now splits into `PATCH /api/config/watch` + `PATCH /api/config/guardrails` and revalidates SWR caches so reopening shows fresh values.

## Testing

### Unit tests

- [tests/test_config_overrides_db.py](tests/test_config_overrides_db.py) — CRUD for `set_config_override`, `set_config_section_overrides` (upsert), `delete_config_override`, `clear_config_section`, `get_all_config_overrides`, and complex-value roundtrip.
- [tests/test_config_db_source.py](tests/test_config_db_source.py) — DB override applies to `WatchConfig`, env beats DB, missing DB / pre-schema DB returns defaults, cross-section isolation, unknown-field filtering.
- [tests/test_config_api.py](tests/test_config_api.py) — PATCH writes to `config_overrides`, enqueues `reload_config`, env-lock still 409s without touching DB, `sources` provenance populated, DELETE field and DELETE section revert correctly. Dropped all `persist=true` cases. All webhook/email redaction merge tests kept.
- [tests/test_watch_loop.py](tests/test_watch_loop.py) — New `test_poll_commands_reload_config_rebuilds_from_db` and `test_interruptible_sleep_honors_live_interval_change`. Dropped obsolete `update_config` tests.
- [tests/test_api_watch.py](tests/test_api_watch.py) — Removed `test_watch_config_update`.

### Integration tests

Manual web build + typecheck only; no browser-level E2E tests exist in this repo. Ran `npm run build` + `npm run lint` — both clean.

### Test results

```
uv run pytest
======================= 524 passed, 4 warnings in 4.47s ========================

uv run ruff check src/ tests/   → All checks passed!
uv run ruff format --check src/ tests/   → 169 files already formatted

web/ npm run lint   → clean
web/ npm run build  → 15 static routes generated successfully
```

## Reviewer Validation

1. `make ci` — should pass lint + format + 524 tests + eslint + Next.js build.
2. Inspect [src/squire/config/db_source.py](src/squire/config/db_source.py) and the `settings_customise_sources` additions in [src/squire/config/app.py](src/squire/config/app.py), [llm.py](src/squire/config/llm.py), [watch.py](src/squire/config/watch.py), [guardrails.py](src/squire/config/guardrails.py), [notifications.py](src/squire/config/notifications.py), [skills.py](src/squire/config/skills.py). Confirm [database.py](src/squire/config/database.py) does **not** wire the DB source (inline comment explains).
3. Smoke in a dev server: `make web-dev`, open Configuration → Watch, change interval, Save. No "Save to disk" checkbox present. `sqlite3 ~/.local/share/squire/squire.db "SELECT * FROM config_overrides;"` should show the new row. `ls -la squire.toml` mtime unchanged.
4. Click the small database pip next to the changed field or the section Reset button — verify DB rows disappear and the field reverts to its TOML / default value.
5. Start watch in the UI, change `interval_minutes` from 5 to 1. Watch logs should print `Reloaded watch config from DB overrides` and the next cycle fires after ~1 min, not 5.
6. Env-lock check: `SQUIRE_WATCH_INTERVAL_MINUTES=15 make web`, attempt to PATCH `interval_minutes` via the UI → expect 409 and no DB row written.

## TODOs / Follow-Ups

- Secrets in the DB (webhook URLs, SMTP password) land in `config_overrides.value_json` plaintext. Documented as equivalent sensitivity to `squire.toml`; no encryption added here.
- No concurrency lock around the notifier swap in `_reload_config_from_db`. The old notifier is closed before the new one is installed; in-flight dispatches have try/except at call sites. If this proves flaky under load, a module-level `asyncio.Lock` is a small follow-up.
- Per-field reset currently uses a plain database pip icon; a dedicated shadcn AlertDialog confirm for the section-level Reset (instead of `window.confirm`) is a nice-to-have that was skipped to keep component surface area stable.
- The stale `_cached` TOML dict in [loader.py](src/squire/config/loader.py) still requires app restart when the user hand-edits `squire.toml`. Unchanged from today — noted in [docs/configuration.md](docs/configuration.md).
- E2E / Playwright tests for the drawer + Reset button flows don't exist; verification relies on the manual steps above.

Generated with [Claude Code](https://claude.com/claude-code)